### PR TITLE
Allow custom text in ProgressBar.

### DIFF
--- a/urwid/graphics.py
+++ b/urwid/graphics.py
@@ -818,6 +818,13 @@ class ProgressBar( FlowWidget ):
         """
         self.current = current
         self._invalidate()
+
+    def set_finished(self, done):
+        """
+        done -- progress amount at 100%
+        """
+        self.done = done
+        self._invalidate()
     
     def rows(self, size, focus=False):
         """
@@ -825,16 +832,19 @@ class ProgressBar( FlowWidget ):
         """
         return 1
 
+    def get_text(self):
+        """
+        Return the progress bar percentage as a Text widget.
+        """
+        percent = min(100, max(0, int(self.current * 100 / self.done)))
+        return Text(str(percent) + " %", 'center', 'clip' )
+
     def render(self, size, focus=False):
         """
         Render the progress bar.
         """
         (maxcol,) = size
-        percent = int( self.current*100/self.done )
-        if percent < 0: percent = 0
-        if percent > 100: percent = 100
-            
-        txt=Text( str(percent)+" %", 'center', 'clip' )
+        txt = self.get_text()
         c = txt.render((maxcol,))
 
         cf = float( self.current ) * maxcol / self.done


### PR DESCRIPTION
This has been bugging me for awhile.

ProgressBar.render currently generates the Text widget that contains the percentage. Sometimes the user might not want any text, sometimes you might want it aligned left, and sometimes (my case) you might want to render something completely different like time. This patch separates the creation of this text into a new ProgressBar.get_text method, so that it may be cleanly subclassed to display different text.

It also adds a ProgressBar.set_finished method to change the maximum value and invalidate the canvas cache. Since we no longer assume ProgressBar represents a percentage, it makes sense to add an "official" way to change the maximum value, which is is otherwise exposed only in the constructor.
