### PR TITLE
string encoding fix for python3

### DIFF
--- a/urwid/raw_display.py
+++ b/urwid/raw_display.py
@@ -108,7 +108,7 @@ class Screen(BaseScreen, RealTerminal):
 
     def _sigwinch_handler(self, signum, frame):
         if not self._resized:
-            os.write(self._resize_pipe_wr, 'R')
+            os.write(self._resize_pipe_wr, 'R'.encode('ascii'))
         self._resized = True
         self.screen_buf = None
       

--- a/urwid/vterm.py
+++ b/urwid/vterm.py
@@ -1438,7 +1438,7 @@ class Terminal(BoxWidget):
 
     def flush_responses(self):
         for string in self.response_buffer:
-            os.write(self.master, string)
+            os.write(self.master, string.encode('ascii'))
         self.response_buffer = []
 
     def set_termsize(self, width, height):

--- a/urwid/web_display.py
+++ b/urwid/web_display.py
@@ -1016,7 +1016,7 @@ def handle_short_request():
         return True
         
     keydata = sys.stdin.read(MAX_READ)
-    os.write(fd,keydata)
+    os.write(fd,keydata.encode('ascii'))
     os.close(fd)
     sys.stdout.write("Content-type: text/plain\r\n\r\n")
     


### PR DESCRIPTION
I added .encode('ascii') to some strings that are used in os.write calls.
Without that urwid breaks in python3 on window-resize with
'TypeError: 'str' does not support the buffer interface'
