### PR TITLE
fix Overlay top and bottom padding

### DIFF
--- a/urwid/container.py
+++ b/urwid/container.py
@@ -688,14 +688,14 @@ class Overlay(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
             height = self.top_w.rows((maxcol,),focus=focus)
             top, bottom =  calculate_top_bottom_filler(maxrow,
                 self.valign_type, self.valign_amount,
-                GIVEN, height, None, self.left, self.right)
+                GIVEN, height, None, self.top, self.bottom)
             if height > maxrow: # flow widget rendered too large
                 bottom = maxrow - height
         else:
             top, bottom = calculate_top_bottom_filler(maxrow,
                 self.valign_type, self.valign_amount,
                 self.height_type, self.height_amount,
-                self.min_height, self.left, self.right)
+                self.min_height, self.top, self.bottom)
         return left, right, top, bottom
 
     def top_w_size(self, size, left, right, top, bottom):


### PR DESCRIPTION
Due to a copy-paste error, the Overlay widget would apply the left and
right padding to the top and bottom as well as to the left and right.
