### PR TITLE
Retry setup without C extension if building it failed.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -105,5 +105,10 @@ if PYTHON3:
     setup_d['use_2to3'] = True
 
 if __name__ == "__main__":
-    setup(**setup_d)
-
+    try:
+        setup(**setup_d)
+    except (IOError, SystemExit) as e:
+        traceback.print_exc()
+        print("Couldn't build the extension module, trying without it...")
+        del setup_d["ext_modules"]
+        setup(**setup_d)


### PR DESCRIPTION
Should help users on Windows building without a compiler to not have to modify setup.py to get it to build without the ext.
