### PR TITLE
Divide by zero in container

### DIFF
--- a/urwid/container.py
+++ b/urwid/container.py
@@ -1490,7 +1490,9 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         for i, (w, (f, height)) in enumerate(self.contents):
             li = l[i]
             if li is None:
-                rows = int(float(remaining) * height / wtotal + 0.5)
+                rows = 0
+                if wtotal != 0:
+                    rows = int(float(remaining) * height / wtotal + 0.5)
                 l[i] = rows
                 remaining -= rows
                 wtotal -= height


### PR DESCRIPTION
When one of the rows in a pile hits zero size you get a divide by zero - simple fix.
