### PR TITLE
GLibEventLoop works with python3 and gobject introspection

### DIFF
--- a/urwid/main_loop.py
+++ b/urwid/main_loop.py
@@ -375,12 +375,12 @@ class MainLoop(object):
         self._input_timeout = None
 
         max_wait, keys, raw = self.screen.get_input_nonblocking()
-        
+
         if max_wait is not None:
             # if get_input_nonblocking wants to be called back
             # make sure it happens with an alarm
-            self._input_timeout = self.event_loop.alarm(max_wait, 
-                lambda: self._update(timeout=True)) 
+            self._input_timeout = self.event_loop.alarm(max_wait,
+                lambda: self._update(timeout=True))
 
         keys = self.input_filter(keys, raw)
 
@@ -413,7 +413,7 @@ class MainLoop(object):
                 else:
                     self.screen.set_input_timeouts(None)
                 keys, raw = self.screen.get_input(True)
-                if not keys and next_alarm: 
+                if not keys and next_alarm:
                     sec = next_alarm[0] - time.time()
                     if sec <= 0:
                         break
@@ -706,7 +706,7 @@ class SelectEventLoop(object):
             while True:
                 try:
                     self._loop()
-                except select.error, e:
+                except select.error as e:
                     if e.args[0] != 4:
                         # not just something we need to retry
                         raise
@@ -764,7 +764,7 @@ class SelectEventLoop(object):
             if self._alarms:
                 tm = self._alarms[0][0]
                 timeout = max(0, tm - time.time())
-            if self._did_something and (not self._alarms or 
+            if self._did_something and (not self._alarms or
                     (self._alarms and timeout > 0)):
                 timeout = 0
                 tm = 'idle'
@@ -788,245 +788,254 @@ class SelectEventLoop(object):
             self._did_something = True
 
 
-if not PYTHON3:
-    class GLibEventLoop(object):
+class GLibEventLoop(object):
+    """
+    Event loop based on gobject.MainLoop
+    """
+
+    def __init__(self):
+        from gi.repository import GLib
+        self.GLib = GLib
+        #import gobject
+        #self.gobject = gobject
+        self._alarms = []
+        self._watch_files = {}
+        self._idle_handle = 0
+        self._glib_idle_enabled = False # have we called glib.idle_add?
+        self._idle_callbacks = {}
+        #self._loop = self.gobject.MainLoop()
+        self._loop = GLib.MainLoop()
+        self._exc_info = None
+        self._enable_glib_idle()
+
+    def _test_event_loop(self):
         """
-        Event loop based on gobject.MainLoop
+        >>> import os
+        >>> rd, wr = os.pipe()
+        >>> evl = GLibEventLoop()
+        >>> def step1():
+        ...     print "writing"
+        ...     os.write(wr, "hi")
+        >>> def step2():
+        ...     print os.read(rd, 2)
+        ...     raise ExitMainLoop
+        >>> handle = evl.alarm(0, step1)
+        >>> handle = evl.watch_file(rd, step2)
+        >>> evl.run()
+        writing
+        hi
         """
 
-        def __init__(self):
-            import gobject
-            self.gobject = gobject
-            self._alarms = []
-            self._watch_files = {}
-            self._idle_handle = 0
-            self._glib_idle_enabled = False # have we called glib.idle_add?
-            self._idle_callbacks = {}
-            self._loop = self.gobject.MainLoop()
-            self._exc_info = None
+    def alarm(self, seconds, callback):
+        """
+        Call callback() given time from from now.  No parameters are
+        passed to callback.
+
+        Returns a handle that may be passed to remove_alarm()
+
+        seconds -- floating point time to wait before calling callback
+        callback -- function to call from event loop
+        """
+        @self.handle_exit
+        def ret_false():
+            callback()
             self._enable_glib_idle()
+            return False
+        #fd = self.gobject.timeout_add(int(seconds*1000), ret_false)
+        fd = self.GLib.timeout_add(int(seconds*1000), ret_false)
+        self._alarms.append(fd)
+        return (fd, callback)
 
-        def _test_event_loop(self):
-            """
-            >>> import os
-            >>> rd, wr = os.pipe()
-            >>> evl = GLibEventLoop()
-            >>> def step1():
-            ...     print "writing"
-            ...     os.write(wr, "hi")
-            >>> def step2():
-            ...     print os.read(rd, 2)
-            ...     raise ExitMainLoop
-            >>> handle = evl.alarm(0, step1)
-            >>> handle = evl.watch_file(rd, step2)
-            >>> evl.run()
-            writing
-            hi
-            """
+    def remove_alarm(self, handle):
+        """
+        Remove an alarm.
 
-        def alarm(self, seconds, callback):
-            """
-            Call callback() given time from from now.  No parameters are
-            passed to callback.
-
-            Returns a handle that may be passed to remove_alarm()
-
-            seconds -- floating point time to wait before calling callback
-            callback -- function to call from event loop
-            """
-            @self.handle_exit
-            def ret_false():
-                callback()
-                self._enable_glib_idle()
-                return False
-            fd = self.gobject.timeout_add(int(seconds*1000), ret_false)
-            self._alarms.append(fd)
-            return (fd, callback)
-
-        def remove_alarm(self, handle):
-            """
-            Remove an alarm.
-
-            Returns True if the alarm exists, False otherwise
-            """
-            try:
-                self._alarms.remove(handle[0])
-                self.gobject.source_remove(handle[0])
-                return True
-            except ValueError:
-                return False
-
-        def _test_remove_alarm(self):
-            """
-            >>> evl = GLibEventLoop()
-            >>> handle = evl.alarm(50, lambda: None)
-            >>> evl.remove_alarm(handle)
-            True
-            >>> evl.remove_alarm(handle)
-            False
-            """
-
-        def watch_file(self, fd, callback):
-            """
-            Call callback() when fd has some data to read.  No parameters
-            are passed to callback.
-
-            Returns a handle that may be passed to remove_watch_file()
-
-            fd -- file descriptor to watch for input
-            callback -- function to call when input is available
-            """
-            @self.handle_exit
-            def io_callback(source, cb_condition):
-                callback()
-                self._enable_glib_idle()
-                return True
-            self._watch_files[fd] = \
-                 self.gobject.io_add_watch(fd,self.gobject.IO_IN,io_callback)
-            return fd
-
-        def remove_watch_file(self, handle):
-            """
-            Remove an input file.
-
-            Returns True if the input file exists, False otherwise
-            """
-            if handle in self._watch_files:
-                self.gobject.source_remove(self._watch_files[handle])
-                del self._watch_files[handle]
-                return True
+        Returns True if the alarm exists, False otherwise
+        """
+        try:
+            self._alarms.remove(handle[0])
+            #self.gobject.source_remove(handle[0])
+            self.GLib.source_remove(handle[0])
+            return True
+        except ValueError:
             return False
 
-        def _test_remove_watch_file(self):
-            """
-            >>> evl = GLibEventLoop()
-            >>> handle = evl.watch_file(1, lambda: None)
-            >>> evl.remove_watch_file(handle)
-            True
-            >>> evl.remove_watch_file(handle)
-            False
-            """
+    def _test_remove_alarm(self):
+        """
+        >>> evl = GLibEventLoop()
+        >>> handle = evl.alarm(50, lambda: None)
+        >>> evl.remove_alarm(handle)
+        True
+        >>> evl.remove_alarm(handle)
+        False
+        """
 
-        def enter_idle(self, callback):
-            """
-            Add a callback for entering idle.
+    def watch_file(self, fd, callback):
+        """
+        Call callback() when fd has some data to read.  No parameters
+        are passed to callback.
 
-            Returns a handle that may be passed to remove_enter_idle()
-            """
-            self._idle_handle += 1
-            self._idle_callbacks[self._idle_handle] = callback
-            return self._idle_handle
+        Returns a handle that may be passed to remove_watch_file()
 
-        def _enable_glib_idle(self):
-            if self._glib_idle_enabled:
-                return
-            self.gobject.idle_add(self._glib_idle_callback)
-            self._glib_idle_enabled = True
-
-        def _glib_idle_callback(self):
-            for callback in self._idle_callbacks.values():
-                callback()
-            self._glib_idle_enabled = False
-            return False # ask glib not to call again (or we would be called
-
-        def remove_enter_idle(self, handle):
-            """
-            Remove an idle callback.
-
-            Returns True if the handle was removed.
-            """
-            try:
-                del self._idle_callbacks[handle]
-            except KeyError:
-                return False
+        fd -- file descriptor to watch for input
+        callback -- function to call when input is available
+        """
+        @self.handle_exit
+        def io_callback(source, cb_condition):
+            callback()
+            self._enable_glib_idle()
             return True
+        self._watch_files[fd] = \
+                self.GLib.io_add_watch(fd,self.GLib.IO_IN,io_callback)
+                #self.gobject.io_add_watch(fd,self.gobject.IO_IN,io_callback)
+        return fd
+
+    def remove_watch_file(self, handle):
+        """
+        Remove an input file.
+
+        Returns True if the input file exists, False otherwise
+        """
+        if handle in self._watch_files:
+            #self.gobject.source_remove(self._watch_files[handle])
+            self.GLib.source_remove(self._watch_files[handle])
+            del self._watch_files[handle]
+            return True
+        return False
+
+    def _test_remove_watch_file(self):
+        """
+        >>> evl = GLibEventLoop()
+        >>> handle = evl.watch_file(1, lambda: None)
+        >>> evl.remove_watch_file(handle)
+        True
+        >>> evl.remove_watch_file(handle)
+        False
+        """
+
+    def enter_idle(self, callback):
+        """
+        Add a callback for entering idle.
+
+        Returns a handle that may be passed to remove_enter_idle()
+        """
+        self._idle_handle += 1
+        self._idle_callbacks[self._idle_handle] = callback
+        return self._idle_handle
+
+    def _enable_glib_idle(self):
+        if self._glib_idle_enabled:
+            return
+        #self.gobject.idle_add(self._glib_idle_callback)
+        self.GLib.idle_add(self._glib_idle_callback)
+        self._glib_idle_enabled = True
+
+    def _glib_idle_callback(self):
+        for callback in self._idle_callbacks.values():
+            callback()
+        self._glib_idle_enabled = False
+        return False # ask glib not to call again (or we would be called
+
+    def remove_enter_idle(self, handle):
+        """
+        Remove an idle callback.
+
+        Returns True if the handle was removed.
+        """
+        try:
+            del self._idle_callbacks[handle]
+        except KeyError:
+            return False
+        return True
 
 
-        def run(self):
-            """
-            Start the event loop.  Exit the loop when any callback raises
-            an exception.  If ExitMainLoop is raised, exit cleanly.
-            """
+    def run(self):
+        """
+        Start the event loop.  Exit the loop when any callback raises
+        an exception.  If ExitMainLoop is raised, exit cleanly.
+        """
+        try:
+            self._loop.run()
+        finally:
+            if self._loop.is_running():
+                self._loop.quit()
+        if self._exc_info:
+            # An exception caused us to exit, raise it now
+            exc_info = self._exc_info
+            self._exc_info = None
+            raise exc_info[0], exc_info[1], exc_info[2]
+
+    def _test_run(self):
+        """
+        >>> import os
+        >>> rd, wr = os.pipe()
+        >>> os.write(wr, "data") # something to read from rd
+        4
+        >>> evl = GLibEventLoop()
+        >>> def say_hello():
+        ...     print "hello"
+        >>> def say_waiting():
+        ...     print "waiting"
+        >>> def exit_clean():
+        ...     print "clean exit"
+        ...     raise ExitMainLoop
+        >>> def exit_error():
+        ...     1/0
+        >>> handle = evl.alarm(0.01, exit_clean)
+        >>> handle = evl.alarm(0.005, say_hello)
+        >>> evl.enter_idle(say_waiting)
+        1
+        >>> evl.run()
+        waiting
+        hello
+        waiting
+        clean exit
+        >>> handle = evl.watch_file(rd, exit_clean)
+        >>> evl.run()
+        clean exit
+        >>> evl.remove_watch_file(handle)
+        True
+        >>> handle = evl.alarm(0, exit_error)
+        >>> evl.run()
+        Traceback (most recent call last):
+            ...
+        ZeroDivisionError: integer division or modulo by zero
+        >>> handle = evl.watch_file(rd, exit_error)
+        >>> evl.run()
+        Traceback (most recent call last):
+            ...
+        ZeroDivisionError: integer division or modulo by zero
+        """
+
+    def handle_exit(self,f):
+        """
+        Decorator that cleanly exits the :class:`GLibEventLoop` if
+        :exc:`ExitMainLoop` is thrown inside of the wrapped function. Store the
+        exception info if some other exception occurs, it will be reraised after
+        the loop quits.
+
+        *f* -- function to be wrapped
+        """
+        def wrapper(*args,**kargs):
             try:
-                self._loop.run()
-            finally:
+                return f(*args,**kargs)
+            except ExitMainLoop:
+                self._loop.quit()
+            except:
+                import sys
+                self._exc_info = sys.exc_info()
                 if self._loop.is_running():
                     self._loop.quit()
-            if self._exc_info:
-                # An exception caused us to exit, raise it now
-                exc_info = self._exc_info
-                self._exc_info = None
-                raise exc_info[0], exc_info[1], exc_info[2]
-
-        def _test_run(self):
-            """
-            >>> import os
-            >>> rd, wr = os.pipe()
-            >>> os.write(wr, "data") # something to read from rd
-            4
-            >>> evl = GLibEventLoop()
-            >>> def say_hello():
-            ...     print "hello"
-            >>> def say_waiting():
-            ...     print "waiting"
-            >>> def exit_clean():
-            ...     print "clean exit"
-            ...     raise ExitMainLoop
-            >>> def exit_error():
-            ...     1/0
-            >>> handle = evl.alarm(0.01, exit_clean)
-            >>> handle = evl.alarm(0.005, say_hello)
-            >>> evl.enter_idle(say_waiting)
-            1
-            >>> evl.run()
-            waiting
-            hello
-            waiting
-            clean exit
-            >>> handle = evl.watch_file(rd, exit_clean)
-            >>> evl.run()
-            clean exit
-            >>> evl.remove_watch_file(handle)
-            True
-            >>> handle = evl.alarm(0, exit_error)
-            >>> evl.run()
-            Traceback (most recent call last):
-               ...
-            ZeroDivisionError: integer division or modulo by zero
-            >>> handle = evl.watch_file(rd, exit_error)
-            >>> evl.run()
-            Traceback (most recent call last):
-               ...
-            ZeroDivisionError: integer division or modulo by zero
-            """
-
-        def handle_exit(self,f):
-            """
-            Decorator that cleanly exits the :class:`GLibEventLoop` if
-            :exc:`ExitMainLoop` is thrown inside of the wrapped function. Store the
-            exception info if some other exception occurs, it will be reraised after
-            the loop quits.
-
-            *f* -- function to be wrapped
-            """
-            def wrapper(*args,**kargs):
-                try:
-                    return f(*args,**kargs)
-                except ExitMainLoop:
-                    self._loop.quit()
-                except:
-                    import sys
-                    self._exc_info = sys.exc_info()
-                    if self._loop.is_running():
-                        self._loop.quit()
-                return False
-            return wrapper
+            return False
+        return wrapper
 
 
+if not PYTHON3:
     try:
         from twisted.internet.abstract import FileDescriptor
     except ImportError:
         FileDescriptor = object
+
 
     class TwistedInputDescriptor(FileDescriptor):
         def __init__(self, reactor, fd, cb):

--- a/urwid/util.py
+++ b/urwid/util.py
@@ -43,7 +43,7 @@ def detect_encoding():
         except locale.Error:
             pass
         return locale.getlocale()[1] or ""
-    except ValueError, e:
+    except ValueError as e:
         # with invalid LANG value python will throw ValueError
         if e.args and e.args[0].startswith("unknown locale"):
             return ""
@@ -70,7 +70,7 @@ def set_encoding( encoding ):
 
     if encoding in ( 'utf-8', 'utf8', 'utf' ):
         str_util.set_byte_encoding("utf8")
-            
+
         _use_dec_special = False
     elif encoding in ( 'euc-jp' # JISX 0208 only
             , 'euc-kr', 'euc-cn', 'euc-tw' # CNS 11643 plain 1 only
@@ -78,7 +78,7 @@ def set_encoding( encoding ):
             # these shouldn't happen, should they?
             , 'eucjp', 'euckr', 'euccn', 'euctw', 'cncb' ):
         str_util.set_byte_encoding("wide")
-            
+
         _use_dec_special = True
     else:
         str_util.set_byte_encoding("narrow")
@@ -86,7 +86,7 @@ def set_encoding( encoding ):
 
     # if encoding is valid for conversion from unicode, remember it
     _target_encoding = 'ascii'
-    try:    
+    try:
         if encoding:
             u"".encode(encoding)
             _target_encoding = encoding
@@ -112,10 +112,10 @@ def apply_target_encoding( s ):
             s = s.translate( escape.DEC_SPECIAL_CHARMAP )
         except NotImplementedError:
             # python < 2.4 needs to do this the hard way..
-            for c, alt in zip(escape.DEC_SPECIAL_CHARS, 
+            for c, alt in zip(escape.DEC_SPECIAL_CHARS,
                     escape.ALT_DEC_SPECIAL_CHARS):
                 s = s.replace( c, escape.SO+alt+escape.SI )
-    
+
     if type(s) == unicode:
         s = s.replace( escape.SI+escape.SO, u"" ) # remove redundant shifts
         s = s.encode( _target_encoding )
@@ -134,10 +134,10 @@ def apply_target_encoding( s ):
     if sis0:
         sout.append( sis0 )
         cout.append( (None,len(sis0)) )
-    
+
     if len(sis)==1:
         return sis0, cout
-    
+
     for sn in sis[1:]:
         assert isinstance(sn, bytes)
         assert isinstance(SI, bytes)
@@ -198,7 +198,7 @@ def calc_trim_text( text, start_offs, end_offs, start_col, end_col ):
         spos, sc = calc_text_pos( text, spos, end_offs, start_col )
         if sc < start_col:
             pad_left = 1
-            spos, sc = calc_text_pos( text, start_offs, 
+            spos, sc = calc_text_pos( text, start_offs,
                 end_offs, start_col+1 )
     run = end_col - start_col - pad_left
     pos, sc = calc_text_pos( text, spos, end_offs, run )
@@ -213,7 +213,7 @@ def trim_text_attr_cs( text, attr, cs, start_col, end_col ):
     """
     Return ( trimmed text, trimmed attr, trimmed cs ).
     """
-    spos, epos, pad_left, pad_right = calc_trim_text( 
+    spos, epos, pad_left, pad_right = calc_trim_text(
         text, 0, len(text), start_col, end_col )
     attrtr = rle_subseg( attr, spos, epos )
     cstr = rle_subseg( cs, spos, epos )
@@ -261,7 +261,7 @@ def rle_subseg( rle, start, end ):
             break
         if x+run > end:
             run = end-x
-        x += run    
+        x += run
         l.append( (a, run) )
     return l
 
@@ -271,7 +271,7 @@ def rle_len( rle ):
     Return the number of characters covered by a run length
     encoded attribute list.
     """
-    
+
     run = 0
     for v in rle:
         assert type(v) == tuple, repr(rle)
@@ -279,28 +279,29 @@ def rle_len( rle ):
         run += r
     return run
 
-def rle_append_beginning_modify( rle, (a, r) ):
+def rle_append_beginning_modify( rle, tup ):
     """
-    Append (a, r) to BEGINNING of rle.
+    Append tup = (a, r) to BEGINNING of rle.
     Merge with first run when possible
 
     MODIFIES rle parameter contents. Returns None.
     """
+    a, r = tup
     if not rle:
         rle[:] = [(a, r)]
-    else:    
+    else:
         al, run = rle[0]
         if a == al:
             rle[0] = (a,run+r)
         else:
             rle[0:0] = [(al, r)]
-            
-            
+
+
 def rle_append_modify( rle, (a, r) ):
     """
     Append (a,r) to the rle list rle.
     Merge with last run when possible.
-    
+
     MODIFIES rle parameter contents. Returns None.
     """
     if not rle or rle[-1][0] != a:
@@ -320,7 +321,7 @@ def rle_join_modify( rle, rle2 ):
         return
     rle_append_modify(rle, rle2[0])
     rle += rle2[1:]
-        
+
 def rle_product( rle1, rle2 ):
     """
     Merge the runs of rle1 and rle2 like this:
@@ -335,7 +336,7 @@ def rle_product( rle1, rle2 ):
     if not rle1 or not rle2: return []
     a1, r1 = rle1[0]
     a2, r2 = rle2[0]
-    
+
     l = []
     while r1 and r2:
         r = min(r1, r2)
@@ -348,7 +349,7 @@ def rle_product( rle1, rle2 ):
         if r2 == 0 and i2< len(rle2):
             a2, r2 = rle2[i2]
             i2 += 1
-    return l    
+    return l
 
 
 def rle_factor( rle ):
@@ -379,13 +380,13 @@ def decompose_tagmarkup(tm):
 
 def _tagmarkup_recurse( tm, attr ):
     """Return (text list, attribute list) for tagmarkup passed.
-    
+
     tm -- tagmarkup
     attr -- current attribute or None"""
-    
+
     if type(tm) == list:
         # for lists recurse to process each subelement
-        rtl = [] 
+        rtl = []
         ral = []
         for element in tm:
             tl, al = _tagmarkup_recurse( element, attr )
@@ -399,18 +400,18 @@ def _tagmarkup_recurse( tm, attr ):
             rtl += tl
             ral += al
         return rtl, ral
-        
+
     if type(tm) == tuple:
         # tuples mark a new attribute boundary
-        if len(tm) != 2: 
+        if len(tm) != 2:
             raise TagMarkupException, "Tuples must be in the form (attribute, tagmarkup): %r" % (tm,)
 
         attr, element = tm
         return _tagmarkup_recurse( element, attr )
-    
+
     if not isinstance(tm,(basestring, bytes)):
         raise TagMarkupException, "Invalid markup element: %r" % tm
-    
+
     # text
     return [tm], [(attr, len(tm))]
 
@@ -433,11 +434,11 @@ class MetaSuper(type):
         setattr(cls, "_%s__super" % name, super(cls))
 
 
-    
+
 def int_scale(val, val_range, out_range):
     """
-    Scale val in the range [0, val_range-1] to an integer in the range 
-    [0, out_range-1].  This implementaton uses the "round-half-up" rounding 
+    Scale val in the range [0, val_range-1] to an integer in the range
+    [0, out_range-1].  This implementaton uses the "round-half-up" rounding
     method.
 
     >>> "%x" % int_scale(0x7, 0x10, 0x10000)


### PR DESCRIPTION
I modified GLibEventLoop. It imports GLib's MainLoop from the gobject introspection repository, instead of importing gobject, and added minor changes in order to get it working in python3.
