### PR TITLE
urwid double and triple click functionality

### DIFF
--- a/urwid/curses_display.py
+++ b/urwid/curses_display.py
@@ -85,6 +85,10 @@ class Screen(BaseScreen, RealTerminal):
             | curses.BUTTON2_PRESSED | curses.BUTTON2_RELEASED
             | curses.BUTTON3_PRESSED | curses.BUTTON3_RELEASED
             | curses.BUTTON4_PRESSED | curses.BUTTON4_RELEASED
+            | curses.BUTTON1_DOUBLE_CLICKED | curses.BUTTON1_TRIPLE_CLICKED
+            | curses.BUTTON2_DOUBLE_CLICKED | curses.BUTTON2_TRIPLE_CLICKED
+            | curses.BUTTON3_DOUBLE_CLICKED | curses.BUTTON3_TRIPLE_CLICKED
+            | curses.BUTTON4_DOUBLE_CLICKED | curses.BUTTON4_TRIPLE_CLICKED
             | curses.BUTTON_SHIFT | curses.BUTTON_ALT
             | curses.BUTTON_CTRL)
 
@@ -397,6 +401,24 @@ class Screen(BaseScreen, RealTerminal):
             append_button( 64 + escape.MOUSE_RELEASE_FLAG )
             next &= ~ 8
         
+        if bstate & curses.BUTTON1_DOUBLE_CLICKED:
+            append_button( 0 + escape.MOUSE_MULTIPLE_CLICK_FLAG )
+        if bstate & curses.BUTTON2_DOUBLE_CLICKED:
+            append_button( 1 + escape.MOUSE_MULTIPLE_CLICK_FLAG )
+        if bstate & curses.BUTTON3_DOUBLE_CLICKED:
+            append_button( 2 + escape.MOUSE_MULTIPLE_CLICK_FLAG )
+        if bstate & curses.BUTTON4_DOUBLE_CLICKED:
+            append_button( 64 + escape.MOUSE_MULTIPLE_CLICK_FLAG )
+
+        if bstate & curses.BUTTON1_TRIPLE_CLICKED:
+            append_button( 0 + escape.MOUSE_MULTIPLE_CLICK_FLAG*2 )
+        if bstate & curses.BUTTON2_TRIPLE_CLICKED:
+            append_button( 1 + escape.MOUSE_MULTIPLE_CLICK_FLAG*2 )
+        if bstate & curses.BUTTON3_TRIPLE_CLICKED:
+            append_button( 2 + escape.MOUSE_MULTIPLE_CLICK_FLAG*2 )
+        if bstate & curses.BUTTON4_TRIPLE_CLICKED:
+            append_button( 64 + escape.MOUSE_MULTIPLE_CLICK_FLAG*2 )
+
         self.last_bstate = next
         return l
             

--- a/urwid/escape.py
+++ b/urwid/escape.py
@@ -180,6 +180,8 @@ class KeyqueueTrie(object):
         if b & 4:    prefix = prefix + "shift "
         if b & 8:    prefix = prefix + "meta "
         if b & 16:    prefix = prefix + "ctrl "
+        if (b & MOUSE_MULTIPLE_CLICK_MASK)>>9 == 1:    prefix = prefix + "double "
+        if (b & MOUSE_MULTIPLE_CLICK_MASK)>>9 == 2:    prefix = prefix + "triple "
 
         # 0->1, 1->2, 2->3, 64->4, 65->5
         button = ((b&64)/64*3) + (b & 3) + 1
@@ -191,6 +193,8 @@ class KeyqueueTrie(object):
             action = "release"
         elif b & MOUSE_DRAG_FLAG:
             action = "drag"
+        elif b & MOUSE_MULTIPLE_CLICK_MASK:
+            action = "click"
         else:
             action = "press"
 
@@ -250,6 +254,16 @@ class KeyqueueTrie(object):
 # This is added to button value to signal mouse release by curses_display
 # and raw_display when we know which button was released.  NON-STANDARD 
 MOUSE_RELEASE_FLAG = 2048  
+
+# This 2-bit mask is used to check if the mouse release from curses or gpm
+# is a double or triple release. 00 means single click, 01 double,
+# 10 triple. NON-STANDARD
+MOUSE_MULTIPLE_CLICK_MASK = 1536
+
+# This is added to button value at mouse release to differentiate between
+# single, double and triple press. Double release adds this times one,
+# triple release adds this times two.  NON-STANDARD
+MOUSE_MULTIPLE_CLICK_FLAG = 512
 
 # xterm adds this to the button value to signal a mouse drag event
 MOUSE_DRAG_FLAG = 32

--- a/urwid/raw_display.py
+++ b/urwid/raw_display.py
@@ -480,7 +480,18 @@ class Screen(BaseScreen, RealTerminal):
             b |= mod
             l.extend([ 27, ord('['), ord('M'), b+32, x+32, y+32 ])
 
-        if ev == 20: # press
+        def determine_button_release( flag ):
+            if b & 4 and last & 1:
+                append_button( 0 + flag )
+                next |= 1
+            if b & 2 and last & 2:
+                append_button( 1 + flag )
+                next |= 2
+            if b & 1 and last & 4:
+                append_button( 2 + flag )
+                next |= 4
+
+        if ev == 20 or ev == 36 or ev == 52: # press
             if b & 4 and last & 1 == 0:
                 append_button( 0 )
                 next |= 1
@@ -507,7 +518,21 @@ class Screen(BaseScreen, RealTerminal):
             if b & 1 and last & 4:
                 append_button( 2 + escape.MOUSE_RELEASE_FLAG )
                 next &= ~ 4
-            
+        if ev == 40: # double click (release)
+            if b & 4 and last & 1:
+                append_button( 0 + escape.MOUSE_MULTIPLE_CLICK_FLAG )
+            if b & 2 and last & 2:
+                append_button( 1 + escape.MOUSE_MULTIPLE_CLICK_FLAG )
+            if b & 1 and last & 4:
+                append_button( 2 + escape.MOUSE_MULTIPLE_CLICK_FLAG )
+        elif ev == 52:
+            if b & 4 and last & 1:
+                append_button( 0 + escape.MOUSE_MULTIPLE_CLICK_FLAG*2 )
+            if b & 2 and last & 2:
+                append_button( 1 + escape.MOUSE_MULTIPLE_CLICK_FLAG*2 )
+            if b & 1 and last & 4:
+                append_button( 2 + escape.MOUSE_MULTIPLE_CLICK_FLAG*2 )
+
         self.last_bstate = next
         return l
     


### PR DESCRIPTION
This commit adds support for registering double and triple clicks in raw and curses displays.

The new clicks are registered independently from press and release events, and are sent as e.g. 'meta double mouse click', 'triple mouse click'. To save this information in input char list, they use a flag 1536, similar to mouse release flag.

The patch was tested on raw display and works fine. The urwid display was not tested, but should function properly.
