### PR TITLE
Add a ReadlineMixin class to emulate some of readline behavior

### DIFF
--- a/docs/reference/widget.rst
+++ b/docs/reference/widget.rst
@@ -200,3 +200,10 @@ Terminal
 
 .. autoclass:: Terminal
 
+Widget Mixin Classes
+----------------------
+
+ReadlineMixin
+~~~~~~~~~~~~~
+
+.. autoclass:: ReadlineMixin

--- a/examples/readline_edit.py
+++ b/examples/readline_edit.py
@@ -1,0 +1,76 @@
+#!/usr/bin/python
+#
+# Urwid readline-emulated edit widget example app
+#    Copyright (C) 2010  aszlig
+#
+#    This library is free software; you can redistribute it and/or
+#    modify it under the terms of the GNU Lesser General Public
+#    License as published by the Free Software Foundation; either
+#    version 2.1 of the License, or (at your option) any later version.
+#
+#    This library is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#    Lesser General Public License for more details.
+#
+#    You should have received a copy of the GNU Lesser General Public
+#    License along with this library; if not, write to the Free Software
+#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+# Urwid web site: http://excess.org/urwid/
+
+import textwrap
+import urwid
+
+class ReadlineEdit(urwid.ReadlineMixin, urwid.Edit):
+    """
+    To create an Edit with readline emulated behaviour, just inherit from the
+    mixin (it has to be set to the left of the parent class).
+    """
+    pass
+
+class ReadlineEditWithPasteBuffer(urwid.Frame):
+    def __init__(self):
+        """Create a frame with:
+        - A Text widget that shows the current content of the yank buffer.
+        - An Edit widget for the user to write free text and use the
+          implemented readline shortcuts.
+        """
+        self.yank_display = urwid.Text('Yank buffer: (empty)\n------------')
+        self.edit = ReadlineEdit(textwrap.dedent('''
+        Please type some text. Available shortcuts:
+        CTRL-w - delete last word
+        CTRL-k - delete the line from the cursor
+        CTRL-u - delete the line up to the cursor
+        CTRL-y - paste the yank (paste) buffer
+
+        Additional shortcuts:
+        F1-F10 - Select word 1-10
+        F12    - quit
+
+        '''), multiline=True)
+        body = urwid.Filler(self.edit, valign='top')
+        super(ReadlineEditWithPasteBuffer, self).__init__(body, header=self.yank_display)
+    def keypress(self, size, input):
+        ret = super(ReadlineEditWithPasteBuffer, self).keypress(size, input)
+        self.yank_display.set_text('Yank buffer: %s\n------------' %
+                (self.edit.yank_buffer or '(empty)'))
+        import logging; logging.basicConfig(filename='/tmp/example.log',level=logging.DEBUG)
+        logging.debug('keypress: %s / returned: %s' % (input, ret))
+        return ret
+
+def main():
+
+    def keypress(input):
+        if input in ('f12', 'ctrl c'):
+            raise urwid.ExitMainLoop()
+
+    frame = ReadlineEditWithPasteBuffer()
+    loop = urwid.MainLoop(frame, unhandled_input=keypress)
+    loop.run()
+
+
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/readline_edit.py
+++ b/examples/readline_edit.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 #
 # Urwid readline-emulated edit widget example app
-#    Copyright (C) 2010  aszlig
+#    Copyright (C) 2013  Romain Chossart
 #
 #    This library is free software; you can redistribute it and/or
 #    modify it under the terms of the GNU Lesser General Public

--- a/examples/readline_edit.py
+++ b/examples/readline_edit.py
@@ -45,7 +45,6 @@ class ReadlineEditWithPasteBuffer(urwid.Frame):
         CTRL-y - paste the yank (paste) buffer
 
         Additional shortcuts:
-        F1-F10 - Select word 1-10
         F12    - quit
 
         '''), multiline=True)

--- a/urwid/__init__.py
+++ b/urwid/__init__.py
@@ -26,7 +26,7 @@ from urwid.widget import (FLOW, BOX, FIXED, LEFT, RIGHT, CENTER, TOP, MIDDLE,
     WidgetMeta,
     WidgetError, Widget, FlowWidget, BoxWidget, fixed_size, FixedWidget,
     Divider, SolidFill, TextError, Text, EditError, Edit, IntEdit,
-    delegate_to_widget_mixin, WidgetWrapError, WidgetWrap)
+    ReadlineMixin, delegate_to_widget_mixin, WidgetWrapError, WidgetWrap)
 from urwid.decoration import (WidgetDecoration, WidgetPlaceholder,
     AttrMapError, AttrMap, AttrWrap, BoxAdapterError, BoxAdapter, PaddingError,
     Padding, FillerError, Filler, WidgetDisable)

--- a/urwid/widget.py
+++ b/urwid/widget.py
@@ -171,7 +171,7 @@ def nocache_widget_render(cls):
 def nocache_widget_render_instance(self):
     """
     Return a function that wraps the cls.render() method
-    and finalizes the canvas that it returns, but does not 
+    and finalizes the canvas that it returns, but does not
     cache the canvas.
     """
     fn = self.render.original_fn
@@ -852,10 +852,10 @@ class Text(Widget):
 
     def _repr_attrs(self):
         attrs = dict(self.__super._repr_attrs(),
-            align=self._align_mode, 
+            align=self._align_mode,
             wrap=self._wrap_mode)
         return remove_defaults(attrs, Text.__init__)
-    
+
     def _invalidate(self):
         self._cache_maxcol = None
         self.__super._invalidate()
@@ -1497,7 +1497,7 @@ class Edit(Text):
             x,y = self.get_cursor_coords((maxcol,))
             pref_col = self.get_pref_col((maxcol,))
             assert pref_col is not None
-            #if pref_col is None: 
+            #if pref_col is None:
             #    pref_col = x
 
             if self._command_map[key] == CURSOR_UP: y -= 1
@@ -1511,7 +1511,7 @@ class Edit(Text):
             if not self._delete_highlighted():
                 if p == 0: return key
                 p = move_prev_char(self.edit_text,0,p)
-                self.set_edit_text( self.edit_text[:p] + 
+                self.set_edit_text( self.edit_text[:p] +
                     self.edit_text[self.edit_pos:] )
                 self.set_edit_pos( p )
 


### PR DESCRIPTION
Here is a mixin class to add common readline shortcuts to Edit widgets.

It contains tests, doc and an example that I put in the examples/ directory. One might argue that the example is a bit too simple to be there - please give me your feedback.

I think it is compatible with the "highlights" but if I understand correctly, the latter is not working at the moment I could not really test it.

Cheers,
Sitaktif
