### PR TITLE
Prevent UnboundLocalErrors on empty loops.

### DIFF
--- a/urwid/container.py
+++ b/urwid/container.py
@@ -1627,6 +1627,7 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
 
         #FIXME guessing focus==True
         focus=True
+        w = None
         wrow = 0
         item_rows = self.get_item_rows(size, focus)
         for i, (r, w) in enumerate(zip(item_rows,
@@ -1637,7 +1638,7 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         else:
             return False
 
-        if not w.selectable():
+        if w is None or not w.selectable():
             return False
 
         if hasattr(w, 'move_cursor_to_coords'):
@@ -1654,6 +1655,7 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         Pass the event to the contained widget.
         May change focus on button 1 press.
         """
+        w = None
         wrow = 0
         item_rows = self.get_item_rows(size, focus)
         for i, (r, w) in enumerate(zip(item_rows,
@@ -1661,6 +1663,9 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
             if wrow + r > row:
                 break
             wrow += r
+
+        if w is None:
+            return False
 
         focus = focus and self.focus_item == w
         if is_mouse_press(event) and button == 1:


### PR DESCRIPTION
If an empty loop occurs in the mouse_event or move_cursor_to_coords methods of
Pile, the variable w will not be defined, leading to an UnboundLocalError later
when those methods attempt to use it.  Set this variable to None and check its
value later to ensure that this error does not occur.
