### PR TITLE
Add a multi column container

### DIFF
--- a/urwid/container.py
+++ b/urwid/container.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+# -*- coding: utf-8 -*-
 #
 # Urwid container widget classes
 #    Copyright (C) 2004-2012  Ian Ward


### PR DESCRIPTION
This container can store an arbitrary amount of other columns
but only display a fixed amount of those columns, this is useful
when you have an unlimited number of columns but only want to display
a fixed amount of them to the user (it also provides visibility
notifications when there are more columns to be displayed on the
left or right of the currently active columns).
