### PR TITLE
High color palette detection fix

### DIFF
--- a/urwid/display_common.py
+++ b/urwid/display_common.py
@@ -833,6 +833,8 @@ class BaseScreen(object):
         def large_h(desc):
             if not desc.startswith('h'):
                 return False
+            if ',' in desc:
+            	desc = desc.split(',',1)[0]
             num = int(desc[1:], 10)
             return num > 15
         if large_h(foreground_high) or large_h(background_high):


### PR DESCRIPTION
Palette entries with high colors combined with bold/underline/etc settings (eg h17,underline) would make register_palette_entry() throw an exception.
