### PR TITLE
Fix GridFlow focus issue

### DIFF
--- a/urwid/container.py
+++ b/urwid/container.py
@@ -342,14 +342,18 @@ class GridFlow(WidgetWrap, WidgetContainerMixin, WidgetContainerListContentsMixi
                 if self.v_sep:
                     p.contents.append((divider, p.options()))
                 c = Columns([], self.h_sep)
+                column_focused = False
                 pad = Padding(c, self.align)
                 # extra attribute to reference contents position
                 pad.first_position = i
                 p.contents.append((pad, p.options()))
 
             c.contents.append((w, c.options(GIVEN, width_amount)))
-            if i == self.focus_position:
+            if ((i == self.focus_position) or
+                (not column_focused and w.selectable())):
                 c.focus_position = len(c.contents) - 1
+                column_focused = True
+            if i == self.focus_position:
                 p.focus_position = len(p.contents) - 1
             used_space = (sum(x[1][1] for x in c.contents) +
                 self.h_sep * len(c.contents))


### PR DESCRIPTION
The GridFlow widget create a Pile which contains Columns, one per
row of the grid.  Because it creates the Columns widgets empty,
the Columns widgets all have their focus_position set to the default
of 0.  The only time the GridFlow widget will update the focus of
the Columns widgets when constructing them is if the widget it is
adding is the focus widget of the GridFlow.  This means that if
a GridFlow ends up with a row whose first widget is not selectable
and the current GridFlow focus position is not in that row, then
the entire Columns widget for that row will be considered not
selectable (as its focus position will remain 0).

Correct this by ensuring that the first selectable widget gets the
focus when a GridFlow creats a Columns widget (or the actual
GridFlow focus widget if it is in the row).

A similar fix is not needed for the Pile focus because as long as
the GridFlow focus position is set, the Pile focus will be as well.

Fixes issue #61.
