### PR TITLE
Fix negative indices in MonitoredFocusList

### DIFF
--- a/urwid/monitored_list.py
+++ b/urwid/monitored_list.py
@@ -292,7 +292,8 @@ class MonitoredFocusList(MonitoredList):
         if isinstance(y, slice):
             focus = self._adjust_focus_on_contents_modified(y)
         else:
-            focus = self._adjust_focus_on_contents_modified(slice(y, y+1))
+            focus = self._adjust_focus_on_contents_modified(slice(y,
+                y+1 or None))
         rval = super(MonitoredFocusList, self).__delitem__(y)
         self._set_focus(focus)
         return rval


### PR DESCRIPTION
This is a fix for #73.

It turned out only MonitoredFocusList.**delitem**() was broken. This PR fixes it and adds a few doctest's that verify support of negative (slice) indices.

Please especially do check if you agree with ba1c39341504922d4a7af8453d929de71ad86c13 which deletes the bodies and doctest's of 2 (deprecated) methods and turns them into simple wrappers.
