### PR TITLE
Remove pollinglistwalker

### DIFF
--- a/docs/reference/deprecated.rst
+++ b/docs/reference/deprecated.rst
@@ -10,5 +10,3 @@ Deprecated Classes
 .. autoclass:: FixedWidget
 
 .. autoclass:: AttrWrap
-
-.. autoclass:: PollingListWalker

--- a/examples/dialog.py
+++ b/examples/dialog.py
@@ -111,7 +111,7 @@ class DialogDisplay:
 class InputDialogDisplay(DialogDisplay):
     def __init__(self, text, height, width):
         self.edit = urwid.Edit()
-        body = urwid.ListBox([self.edit])
+        body = urwid.ListBox(urwid.SimpleListWalker([self.edit]))
         body = urwid.AttrWrap(body, 'selectable','focustext')
 
         DialogDisplay.__init__(self, text, height, width, body)
@@ -138,7 +138,7 @@ class TextDialogDisplay(DialogDisplay):
         # read the whole file (being slow, not lazy this time)
         for line in open(file).readlines():
             l.append( urwid.Text( line.rstrip() ))
-        body = urwid.ListBox(l)
+        body = urwid.ListBox(urwid.SimpleListWalker(l))
         body = urwid.AttrWrap(body, 'selectable','focustext')
 
         DialogDisplay.__init__(self, None, height, width, body)
@@ -172,7 +172,7 @@ class ListDialogDisplay(DialogDisplay):
             w = urwid.AttrWrap(w, 'selectable','focus')
             l.append(w)
 
-        lb = urwid.ListBox(l)
+        lb = urwid.ListBox(urwid.SimpleListWalker(l))
         lb = urwid.AttrWrap( lb, "selectable" )
         DialogDisplay.__init__(self, text, height, width, lb )
 

--- a/urwid/__init__.py
+++ b/urwid/__init__.py
@@ -35,8 +35,8 @@ from urwid.container import (GridFlowError, GridFlow, OverlayError, Overlay,
     WidgetContainerMixin)
 from urwid.wimp import (SelectableIcon, CheckBoxError, CheckBox, RadioButton,
     Button, PopUpLauncher, PopUpTarget)
-from urwid.listbox import (ListWalkerError, ListWalker, PollingListWalker,
-    SimpleListWalker, SimpleFocusListWalker, ListBoxError, ListBox)
+from urwid.listbox import (ListWalkerError, ListWalker, SimpleListWalker,
+    SimpleFocusListWalker, ListBoxError, ListBox)
 from urwid.graphics import (BigText, LineBox, BarGraphMeta, BarGraphError,
     BarGraph, GraphVScale, ProgressBar, scale_bar_values)
 from urwid.canvas import (CanvasCache, CanvasError, Canvas, TextCanvas,

--- a/urwid/tests/test_container.py
+++ b/urwid/tests/test_container.py
@@ -314,8 +314,8 @@ class WidgetSquishTest(unittest.TestCase):
         t(1, True)
 
     def test_listbox(self):
-        self.wstest(urwid.ListBox([]))
-        self.wstest(urwid.ListBox([urwid.Text("hello")]))
+        self.wstest(urwid.ListBox(urwid.SimpleListWalker([])))
+        self.wstest(urwid.ListBox(urwid.SimpleListWalker([urwid.Text("hello")])))
 
     def test_bargraph(self):
         self.wstest(urwid.BarGraph(['foo','bar']))

--- a/urwid/tests/test_listbox.py
+++ b/urwid/tests/test_listbox.py
@@ -9,7 +9,7 @@ class ListBoxCalculateVisibleTest(unittest.TestCase):
     def cvtest(self, desc, body, focus, offset_rows, inset_fraction,
         exp_offset_inset, exp_cur ):
 
-        lbox = urwid.ListBox(body)
+        lbox = urwid.ListBox(urwid.SimpleListWalker(body))
         lbox.body.set_focus( focus )
         lbox.offset_rows = offset_rows
         lbox.inset_fraction = inset_fraction
@@ -99,7 +99,7 @@ class ListBoxChangeFocusTest(unittest.TestCase):
             coming_from, cursor, snap_rows,
             exp_offset_rows, exp_inset_fraction, exp_cur ):
 
-        lbox = urwid.ListBox(body)
+        lbox = urwid.ListBox(urwid.SimpleListWalker(body))
 
         lbox.change_focus( (4,5), pos, offset_inset, coming_from,
             cursor, snap_rows )
@@ -207,7 +207,7 @@ class ListBoxChangeFocusTest(unittest.TestCase):
 class ListBoxRenderTest(unittest.TestCase):
     def ltest(self,desc,body,focus,offset_inset_rows,exp_text,exp_cur):
         exp_text = [B(t) for t in exp_text]
-        lbox = urwid.ListBox(body)
+        lbox = urwid.ListBox(urwid.SimpleListWalker(body))
         lbox.body.set_focus( focus )
         lbox.shift_focus((4,10), offset_inset_rows )
         canvas = lbox.render( (4,5), focus=1 )
@@ -305,7 +305,7 @@ class ListBoxKeypressTest(unittest.TestCase):
         exp_focus, exp_offset_inset, exp_cur, lbox = None):
 
         if lbox is None:
-            lbox = urwid.ListBox(body)
+            lbox = urwid.ListBox(urwid.SimpleListWalker(body))
             lbox.body.set_focus( focus )
             lbox.shift_focus((4,10), offset_inset )
 


### PR DESCRIPTION
Removes the PollingListWalker class and raises a ListBoxError when a ListBox is created without passing an object descending from ListWalker class. Despite its name, PollingListWalker is/was _not_ inheriting from the ListWalker class.

Also changes unit tests and example programs to always use a ListWalker object everywhere a ListBox is created.

Fixes #37 
