### PR TITLE
Re-raise exceptions in AsyncioEventLoop properly

### DIFF
--- a/urwid/tests/test_event_loops.py
+++ b/urwid/tests/test_event_loops.py
@@ -50,6 +50,8 @@ class EventLoopTestMixin(object):
             raise urwid.ExitMainLoop
         def exit_error():
             1/0
+        def exit_unicode_error():
+            bytearray([0x8f]).decode('utf-8')
         handle = evl.alarm(0.01, exit_clean)
         handle = evl.alarm(0.005, say_hello)
         idle_handle = evl.enter_idle(say_waiting)
@@ -67,6 +69,11 @@ class EventLoopTestMixin(object):
         self.assertRaises(ZeroDivisionError, evl.run)
         handle = evl.watch_file(rd, exit_error)
         self.assertRaises(ZeroDivisionError, evl.run)
+        self.assertTrue(evl.remove_watch_file(handle))
+        handle = evl.alarm(0, exit_unicode_error)
+        self.assertRaises(UnicodeDecodeError, evl.run)
+        handle = evl.watch_file(rd, exit_unicode_error)
+        self.assertRaises(UnicodeDecodeError, evl.run)
 
 
 class SelectEventLoopTest(unittest.TestCase, EventLoopTestMixin):


### PR DESCRIPTION
Some exceptions (at least UnicodeDecodeError) expect more than 1 argument.
This provides the new exception with all arguments of the original exception.
