### PR TITLE
remove duplicate Columns.dividechars declaration

### DIFF
--- a/urwid/container.py
+++ b/urwid/container.py
@@ -1771,7 +1771,6 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
             self.focus_position = focus_column
         if focus_column is None:
             focus_column = 0
-        self.dividechars = dividechars
         self.pref_col = None
         self.min_width = min_width
         self._cache_maxcol = None


### PR DESCRIPTION
Seems to be a typo, dividechars is set twice in `Columns.__init__`
