### PR TITLE
Python3 fix in graph example

### DIFF
--- a/examples/graph.py
+++ b/examples/graph.py
@@ -48,7 +48,7 @@ class GraphModel:
     data_max_value = 100
 
     def __init__(self):
-        data = [ ('Saw', range(0,100,2)*2),
+        data = [ ('Saw', list(range(0,100,2))*2),
             ('Square', [0]*30 + [100]*30),
             ('Sine 1', [sin100(x) for x in range(100)] ),
             ('Sine 2', [(sin100(x) + sin100(x*2))/2


### PR DESCRIPTION
Hallo urwid devs and thanks for a cool library

I encountered a minor python 2 vs 3 incompatibility in the graph.py example. There is a range that is multiplied with 2, but in python 3 range returns a range object which is a iterator or sorts and it doesn't like to get multiplied. Fixed by wrapping list around the range in the one place where it happens.

NOTE: For efficiency, one might considered replacing range with xrange in python2;

``` python
try:
    range = xrange
except NameError:
    pass

```

but with only ever calling range on something like 100, I really don't think it is worth it..
