### PR TITLE
minor compat issues

### DIFF
--- a/examples/bigtext.py
+++ b/examples/bigtext.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Urwid BigText example program
 #    Copyright (C) 2004-2009  Ian Ward

--- a/examples/browse.py
+++ b/examples/browse.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Urwid example lazy directory browser / tree view
 #    Copyright (C) 2004-2011  Ian Ward

--- a/examples/calc.py
+++ b/examples/calc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Urwid advanced example column calculator application
 #    Copyright (C) 2004-2009  Ian Ward

--- a/examples/dialog.py
+++ b/examples/dialog.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Urwid example similar to dialog(1) program
 #    Copyright (C) 2004-2009  Ian Ward

--- a/examples/edit.py
+++ b/examples/edit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Urwid example lazy text editor suitable for tabbed and format=flowed text
 #    Copyright (C) 2004-2009  Ian Ward

--- a/examples/fib.py
+++ b/examples/fib.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Urwid example fibonacci sequence viewer / unbounded data demo
 #    Copyright (C) 2004-2007  Ian Ward

--- a/examples/graph.py
+++ b/examples/graph.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Urwid graphics example program
 #    Copyright (C) 2004-2011  Ian Ward

--- a/examples/input_test.py
+++ b/examples/input_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Urwid keyboard input test app
 #    Copyright (C) 2004-2009  Ian Ward

--- a/examples/lcd_cf635.py
+++ b/examples/lcd_cf635.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """
 The crystalfontz 635 has these characters in ROM:

--- a/examples/palette_test.py
+++ b/examples/palette_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Urwid Palette Test.  Showing off highcolor support
 #    Copyright (C) 2004-2009  Ian Ward

--- a/examples/pop_up.py
+++ b/examples/pop_up.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import urwid
 

--- a/examples/subproc.py
+++ b/examples/subproc.py
@@ -1,9 +1,13 @@
-#!/usr/bin/python
-
+#!/usr/bin/env python
 import subprocess
 import urwid
 import os
 import sys
+
+if sys.version_info > (3,):
+    def decode(b): return b.decode('utf-8')
+else:
+    def decode(s): return s
 
 factor_me = 362923067964327863989661926737477737673859044111968554257667
 run_me = os.path.join(os.path.dirname(sys.argv[0]), 'subproc2.py')
@@ -21,7 +25,7 @@ def exit_on_enter(key):
 loop = urwid.MainLoop(frame_widget, unhandled_input=exit_on_enter)
 
 def received_output(data):
-    output_widget.set_text(output_widget.text + data)
+    output_widget.set_text(output_widget.text + decode(data))
 
 write_fd = loop.watch_pipe(received_output)
 proc = subprocess.Popen(

--- a/examples/subproc2.py
+++ b/examples/subproc2.py
@@ -1,7 +1,11 @@
 # this is part of the subproc.py example
 from __future__ import print_function
-from builtins import range
 import sys
+
+try:
+    from builtins import range
+except ImportError:
+    range = xrange
 
 num = int(sys.argv[1])
 

--- a/examples/subproc2.py
+++ b/examples/subproc2.py
@@ -1,8 +1,13 @@
 # this is part of the subproc.py example
-
+from __future__ import print_function
+from builtins import range
 import sys
 
 num = int(sys.argv[1])
-for c in xrange(1,10000000):
-    if num % c == 0:
-        print "factor:", c
+
+try:
+    for c in range(1,10000000):
+        if num % c == 0:
+            print("factor:", c)
+except BrokenPipeError:
+    pass

--- a/examples/terminal.py
+++ b/examples/terminal.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Urwid terminal emulation widget example app
 #    Copyright (C) 2010  aszlig

--- a/examples/tour.py
+++ b/examples/tour.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Urwid tour.  It slices, it dices..
 #    Copyright (C) 2004-2011  Ian Ward

--- a/examples/treesample.py
+++ b/examples/treesample.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Trivial data browser
 #    This version:

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Urwid setup.py exports the useful bits
 #    Copyright (C) 2004-2014  Ian Ward


### PR DESCRIPTION
Changed interpreter directives to use `/usr/bin/env python` so running examples will use virtual environment executables.

Minor changes to the subproc.py example for py2/3 cross-compat.
