### PR TITLE
fix #172 - html_fragment errors on Python 3.4

### DIFF
--- a/urwid/html_fragment.py
+++ b/urwid/html_fragment.py
@@ -96,6 +96,8 @@ class HtmlGenerator(BaseScreen):
             col = 0
 
             for a, cs, run in row:
+                if not str is bytes:
+                    run = run.decode()
                 run = run.translate(_trans_table)
                 if isinstance(a, AttrSpec):
                     aspec = a


### PR DESCRIPTION
Crude fix. Worked for me on Python 2.7 and Python 3.4

Looks like there is some setup.py magic to handle Python 2/3 already, but I didn't see how to hook this into that.
