### PR TITLE
Add UTF-8 boundary split test

### DIFF
--- a/urwid/tests/test_widget.py
+++ b/urwid/tests/test_widget.py
@@ -38,6 +38,12 @@ class TextTest(unittest.TestCase):
         got = urwid.Text(u'û').render((3,))._text
         assert got == expected, "got: %r expected: %r" % (got, expected)
 
+    def test6_no_split_on_byte_boundary(self):
+        urwid.set_encoding("utf8")
+        expected = [B(t) for t in ["Mise à", "jour t", "erminé", "e     "]]
+        got = urwid.Text(u'Mise à jour terminée').render((6,))._text
+        assert got == expected, "got: %r expected: %r" % (got, expected)
+
 
 class EditTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This ensures splitting is done on code points, not bytes.

I was investigating an issue with a package that uses urwid, and this ensures the issue is not in urwid. I thought one more test was never a bad idea.