### PR TITLE
Switch to relative imports of the urwid modules

### DIFF
--- a/urwid/__init__.py
+++ b/urwid/__init__.py
@@ -20,59 +20,59 @@
 #
 # Urwid web site: http://excess.org/urwid/
 
-from urwid.version import VERSION, __version__
-from urwid.widget import (FLOW, BOX, FIXED, LEFT, RIGHT, CENTER, TOP, MIDDLE,
+from .version import VERSION, __version__
+from .widget import (FLOW, BOX, FIXED, LEFT, RIGHT, CENTER, TOP, MIDDLE,
     BOTTOM, SPACE, ANY, CLIP, PACK, GIVEN, RELATIVE, RELATIVE_100, WEIGHT,
     WidgetMeta,
     WidgetError, Widget, FlowWidget, BoxWidget, fixed_size, FixedWidget,
     Divider, SolidFill, TextError, Text, EditError, Edit, IntEdit,
     delegate_to_widget_mixin, WidgetWrapError, WidgetWrap)
-from urwid.decoration import (WidgetDecoration, WidgetPlaceholder,
+from .decoration import (WidgetDecoration, WidgetPlaceholder,
     AttrMapError, AttrMap, AttrWrap, BoxAdapterError, BoxAdapter, PaddingError,
     Padding, FillerError, Filler, WidgetDisable)
-from urwid.container import (GridFlowError, GridFlow, OverlayError, Overlay,
+from .container import (GridFlowError, GridFlow, OverlayError, Overlay,
     FrameError, Frame, PileError, Pile, ColumnsError, Columns,
     WidgetContainerMixin)
-from urwid.wimp import (SelectableIcon, CheckBoxError, CheckBox, RadioButton,
+from .wimp import (SelectableIcon, CheckBoxError, CheckBox, RadioButton,
     Button, PopUpLauncher, PopUpTarget)
-from urwid.listbox import (ListWalkerError, ListWalker, PollingListWalker,
+from .listbox import (ListWalkerError, ListWalker, PollingListWalker,
     SimpleListWalker, SimpleFocusListWalker, ListBoxError, ListBox)
-from urwid.graphics import (BigText, LineBox, BarGraphMeta, BarGraphError,
+from .graphics import (BigText, LineBox, BarGraphMeta, BarGraphError,
     BarGraph, GraphVScale, ProgressBar, scale_bar_values)
-from urwid.canvas import (CanvasCache, CanvasError, Canvas, TextCanvas,
+from .canvas import (CanvasCache, CanvasError, Canvas, TextCanvas,
     BlankCanvas, SolidCanvas, CompositeCanvas, CanvasCombine, CanvasOverlay,
     CanvasJoin)
-from urwid.font import (get_all_fonts, Font, Thin3x3Font, Thin4x3Font,
+from .font import (get_all_fonts, Font, Thin3x3Font, Thin4x3Font,
     HalfBlock5x4Font, HalfBlock6x5Font, HalfBlockHeavy6x5Font, Thin6x6Font,
     HalfBlock7x7Font)
-from urwid.signals import (MetaSignals, Signals, emit_signal, register_signal,
+from .signals import (MetaSignals, Signals, emit_signal, register_signal,
     connect_signal, disconnect_signal)
-from urwid.monitored_list import MonitoredList, MonitoredFocusList
-from urwid.command_map import (CommandMap, command_map,
+from .monitored_list import MonitoredList, MonitoredFocusList
+from .command_map import (CommandMap, command_map,
     REDRAW_SCREEN, CURSOR_UP, CURSOR_DOWN, CURSOR_LEFT, CURSOR_RIGHT,
     CURSOR_PAGE_UP, CURSOR_PAGE_DOWN, CURSOR_MAX_LEFT, CURSOR_MAX_RIGHT,
     ACTIVATE)
-from urwid.main_loop import (ExitMainLoop, MainLoop, SelectEventLoop,
+from .main_loop import (ExitMainLoop, MainLoop, SelectEventLoop,
     GLibEventLoop, TornadoEventLoop, AsyncioEventLoop)
 try:
-    from urwid.main_loop import TwistedEventLoop
+    from .main_loop import TwistedEventLoop
 except ImportError:
     pass
-from urwid.text_layout import (TextLayout, StandardTextLayout, default_layout,
+from .text_layout import (TextLayout, StandardTextLayout, default_layout,
     LayoutSegment)
-from urwid.display_common import (UPDATE_PALETTE_ENTRY, DEFAULT, BLACK,
+from .display_common import (UPDATE_PALETTE_ENTRY, DEFAULT, BLACK,
     DARK_RED, DARK_GREEN, BROWN, DARK_BLUE, DARK_MAGENTA, DARK_CYAN,
     LIGHT_GRAY, DARK_GRAY, LIGHT_RED, LIGHT_GREEN, YELLOW, LIGHT_BLUE,
     LIGHT_MAGENTA, LIGHT_CYAN, WHITE, AttrSpecError, AttrSpec, RealTerminal,
     ScreenError, BaseScreen)
-from urwid.util import (calc_text_pos, calc_width, is_wide_char,
+from .util import (calc_text_pos, calc_width, is_wide_char,
     move_next_char, move_prev_char, within_double_byte, detected_encoding,
     set_encoding, get_encoding_mode, apply_target_encoding, supports_unicode,
     calc_trim_text, TagMarkupException, decompose_tagmarkup, MetaSuper,
     int_scale, is_mouse_event)
-from urwid.treetools import (TreeWidgetError, TreeWidget, TreeNode,
+from .treetools import (TreeWidgetError, TreeWidget, TreeNode,
     ParentNode, TreeWalker, TreeListBox)
-from urwid.vterm import (TermModes, TermCharset, TermScroller, TermCanvas,
+from .vterm import (TermModes, TermCharset, TermScroller, TermCanvas,
     Terminal)
 
-from urwid import raw_display
+from . import raw_display

--- a/urwid/canvas.py
+++ b/urwid/canvas.py
@@ -21,10 +21,10 @@
 
 import weakref
 
-from urwid.util import rle_len, rle_append_modify, rle_join_modify, rle_product, \
+from .util import rle_len, rle_append_modify, rle_join_modify, rle_product, \
     calc_width, calc_text_pos, apply_target_encoding, trim_text_attr_cs
-from urwid.text_layout import trim_line, LayoutSegment
-from urwid.compat import bytes
+from .text_layout import trim_line, LayoutSegment
+from .compat import bytes
 
 
 class CanvasCache(object):

--- a/urwid/container.py
+++ b/urwid/container.py
@@ -21,15 +21,15 @@
 
 from itertools import chain, repeat
 
-from urwid.util import is_mouse_press
-from urwid.widget import (Widget, Divider, FLOW, FIXED, PACK, BOX, WidgetWrap,
+from .util import is_mouse_press
+from .widget import (Widget, Divider, FLOW, FIXED, PACK, BOX, WidgetWrap,
     GIVEN, WEIGHT, LEFT, RIGHT, RELATIVE, TOP, BOTTOM, CLIP, RELATIVE_100)
-from urwid.decoration import (Padding, Filler, calculate_left_right_padding,
+from .decoration import (Padding, Filler, calculate_left_right_padding,
     calculate_top_bottom_filler, normalize_align, normalize_width,
     normalize_valign, normalize_height, simplify_align, simplify_width,
     simplify_valign, simplify_height)
-from urwid.monitored_list import MonitoredList, MonitoredFocusList
-from urwid.canvas import (CompositeCanvas, CanvasOverlay, CanvasCombine,
+from .monitored_list import MonitoredList, MonitoredFocusList
+from .canvas import (CompositeCanvas, CanvasOverlay, CanvasCombine,
     SolidCanvas, CanvasJoin)
 
 

--- a/urwid/curses_display.py
+++ b/urwid/curses_display.py
@@ -26,11 +26,11 @@ Curses-based UI implementation
 import curses
 import _curses
 
-from urwid import escape
+from . import escape
 
-from urwid.display_common import BaseScreen, RealTerminal, AttrSpec, \
+from .display_common import BaseScreen, RealTerminal, AttrSpec, \
     UNPRINTABLE_TRANS_TABLE
-from urwid.compat import bytes, PYTHON3
+from .compat import bytes, PYTHON3
 
 KEY_RESIZE = 410 # curses.KEY_RESIZE (sometimes not defined)
 KEY_MOUSE = 409 # curses.KEY_MOUSE

--- a/urwid/decoration.py
+++ b/urwid/decoration.py
@@ -20,13 +20,13 @@
 # Urwid web site: http://excess.org/urwid/
 
 
-from urwid.util import int_scale
-from urwid.widget import (Widget, WidgetError,
+from .util import int_scale
+from .widget import (Widget, WidgetError,
     BOX, FLOW, LEFT, CENTER, RIGHT, PACK, CLIP, GIVEN, RELATIVE, RELATIVE_100,
     TOP, MIDDLE, BOTTOM, delegate_to_widget_mixin)
-from urwid.split_repr import remove_defaults
-from urwid.canvas import CompositeCanvas, SolidCanvas
-from urwid.widget import Divider, Edit, Text, SolidFill # doctests
+from .split_repr import remove_defaults
+from .canvas import CompositeCanvas, SolidCanvas
+from .widget import Divider, Edit, Text, SolidFill # doctests
 
 
 class WidgetDecoration(Widget):  # "decorator" was already taken

--- a/urwid/display_common.py
+++ b/urwid/display_common.py
@@ -26,9 +26,9 @@ try:
 except ImportError:
     pass # windows
 
-from urwid.util import StoppingContext, int_scale
-from urwid import signals
-from urwid.compat import B, bytes3
+from .util import StoppingContext, int_scale
+from . import signals
+from .compat import B, bytes3
 
 # for replacing unprintable bytes with '?'
 UNPRINTABLE_TRANS_TABLE = B("?") * 32 + bytes3(range(32,256))

--- a/urwid/escape.py
+++ b/urwid/escape.py
@@ -27,11 +27,11 @@ Terminal Escape Sequences for input and display
 import re
 
 try:
-    from urwid import str_util
+    from . import str_util
 except ImportError:
-    from urwid import old_str_util as str_util
+    from . import old_str_util as str_util
 
-from urwid.compat import bytes, bytes3
+from .compat import bytes, bytes3
 
 within_double_byte = str_util.within_double_byte
 

--- a/urwid/font.py
+++ b/urwid/font.py
@@ -20,9 +20,9 @@
 #
 # Urwid web site: http://excess.org/urwid/
 
-from urwid.escape import SAFE_ASCII_DEC_SPECIAL_RE
-from urwid.util import apply_target_encoding, str_util
-from urwid.canvas import TextCanvas
+from .escape import SAFE_ASCII_DEC_SPECIAL_RE
+from .util import apply_target_encoding, str_util
+from .canvas import TextCanvas
 
 
 def separate_glyphs(gdata, height):

--- a/urwid/graphics.py
+++ b/urwid/graphics.py
@@ -20,15 +20,15 @@
 #
 # Urwid web site: http://excess.org/urwid/
 
-from urwid.util import decompose_tagmarkup, get_encoding_mode
-from urwid.canvas import CompositeCanvas, CanvasJoin, TextCanvas, \
+from .util import decompose_tagmarkup, get_encoding_mode
+from .canvas import CompositeCanvas, CanvasJoin, TextCanvas, \
     CanvasCombine, SolidCanvas
-from urwid.widget import WidgetMeta, Widget, BOX, FIXED, FLOW, \
+from .widget import WidgetMeta, Widget, BOX, FIXED, FLOW, \
     nocache_widget_render, nocache_widget_render_instance, fixed_size, \
     WidgetWrap, Divider, SolidFill, Text, CENTER, CLIP
-from urwid.container import Pile, Columns
-from urwid.display_common import AttrSpec
-from urwid.decoration import WidgetDecoration
+from .container import Pile, Columns
+from .display_common import AttrSpec
+from .decoration import WidgetDecoration
 
 
 class BigText(Widget):

--- a/urwid/html_fragment.py
+++ b/urwid/html_fragment.py
@@ -23,9 +23,9 @@
 HTML PRE-based UI implementation
 """
 
-from urwid import util
-from urwid.main_loop import ExitMainLoop
-from urwid.display_common import AttrSpec, BaseScreen
+from . import util
+from .main_loop import ExitMainLoop
+from .display_common import AttrSpec, BaseScreen
 
 
 # replace control characters with ?'s
@@ -229,9 +229,9 @@ def screenshot_init( sizes, keys ):
     except (AssertionError, ValueError):
         raise Exception, "keys must be in the form [ [keyA1, keyA2, ..], [keyB1, ..], ...]"
 
-    import curses_display
+    from . import curses_display
     curses_display.Screen = HtmlGenerator
-    import raw_display
+    from . import raw_display
     raw_display.Screen = HtmlGenerator
 
     HtmlGenerator.sizes = sizes

--- a/urwid/lcd_display.py
+++ b/urwid/lcd_display.py
@@ -21,7 +21,7 @@
 # Urwid web site: http://excess.org/urwid/
 
 
-from display_common import BaseScreen
+from .display_common import BaseScreen
 
 import time
 

--- a/urwid/listbox.py
+++ b/urwid/listbox.py
@@ -19,15 +19,15 @@
 #
 # Urwid web site: http://excess.org/urwid/
 
-from urwid.util import is_mouse_press
-from urwid.canvas import SolidCanvas, CanvasCombine
-from urwid.widget import Widget, nocache_widget_render_instance, BOX, GIVEN
-from urwid.decoration import calculate_top_bottom_filler, normalize_valign
-from urwid import signals
-from urwid.signals import connect_signal
-from urwid.monitored_list import MonitoredList, MonitoredFocusList
-from urwid.container import WidgetContainerMixin
-from urwid.command_map import (CURSOR_UP, CURSOR_DOWN,
+from .util import is_mouse_press
+from .canvas import SolidCanvas, CanvasCombine
+from .widget import Widget, nocache_widget_render_instance, BOX, GIVEN
+from .decoration import calculate_top_bottom_filler, normalize_valign
+from . import signals
+from .signals import connect_signal
+from .monitored_list import MonitoredList, MonitoredFocusList
+from .container import WidgetContainerMixin
+from .command_map import (CURSOR_UP, CURSOR_DOWN,
     CURSOR_PAGE_UP, CURSOR_PAGE_DOWN)
 
 class ListWalkerError(Exception):

--- a/urwid/main_loop.py
+++ b/urwid/main_loop.py
@@ -34,12 +34,12 @@ try:
 except ImportError:
     pass # windows
 
-from urwid.util import StoppingContext, is_mouse_event
-from urwid.compat import PYTHON3
-from urwid.command_map import command_map, REDRAW_SCREEN
-from urwid.wimp import PopUpTarget
-from urwid import signals
-from urwid.display_common import INPUT_DESCRIPTORS_CHANGED
+from .util import StoppingContext, is_mouse_event
+from .compat import PYTHON3
+from .command_map import command_map, REDRAW_SCREEN
+from .wimp import PopUpTarget
+from . import signals
+from .display_common import INPUT_DESCRIPTORS_CHANGED
 
 PIPE_BUFFER_READ_SIZE = 4096 # can expect this much on Linux, so try for that
 
@@ -107,7 +107,7 @@ class MainLoop(object):
         self.pop_ups = pop_ups # triggers property setting side-effect
 
         if not screen:
-            from urwid import raw_display
+            from . import raw_display
             screen = raw_display.Screen()
 
         if palette:

--- a/urwid/monitored_list.py
+++ b/urwid/monitored_list.py
@@ -19,7 +19,7 @@
 #
 # Urwid web site: http://excess.org/urwid/
 
-from urwid.compat import PYTHON3
+from .compat import PYTHON3
 
 
 def _call_modified(fn):

--- a/urwid/old_str_util.py
+++ b/urwid/old_str_util.py
@@ -23,7 +23,7 @@ from __future__ import print_function
 
 import re
 
-from urwid.compat import bytes, B, ord2
+from .compat import bytes, B, ord2
 
 SAFE_ASCII_RE = re.compile(u"^[ -~]*$")
 SAFE_ASCII_BYTES_RE = re.compile(B("^[ -~]*$"))

--- a/urwid/raw_display.py
+++ b/urwid/raw_display.py
@@ -36,13 +36,13 @@ try:
 except ImportError:
     pass # windows
 
-from urwid import util
-from urwid import escape
-from urwid.display_common import BaseScreen, RealTerminal, \
+from . import util
+from . import escape
+from .display_common import BaseScreen, RealTerminal, \
     UPDATE_PALETTE_ENTRY, AttrSpec, UNPRINTABLE_TRANS_TABLE, \
     INPUT_DESCRIPTORS_CHANGED
-from urwid import signals
-from urwid.compat import PYTHON3, bytes, B
+from . import signals
+from .compat import PYTHON3, bytes, B
 
 from subprocess import Popen, PIPE
 

--- a/urwid/split_repr.py
+++ b/urwid/split_repr.py
@@ -20,7 +20,7 @@
 # Urwid web site: http://excess.org/urwid/
 
 from inspect import getargspec
-from urwid.compat import PYTHON3, bytes
+from .compat import PYTHON3, bytes
 
 def split_repr(self):
     """

--- a/urwid/tests/test_canvas.py
+++ b/urwid/tests/test_canvas.py
@@ -1,32 +1,31 @@
 import unittest
 
-from urwid import canvas
-from urwid.compat import B
-import urwid
+from .. import canvas, widget, util
+from ..compat import B
 
 
 class CanvasCacheTest(unittest.TestCase):
     def setUp(self):
         # purge the cache
-        urwid.CanvasCache._widgets.clear()
+        canvas.CanvasCache._widgets.clear()
 
-    def cct(self, widget, size, focus, expected):
-        got = urwid.CanvasCache.fetch(widget, urwid.Widget, size, focus)
+    def cct(self, widg, size, focus, expected):
+        got = canvas.CanvasCache.fetch(widg, widget.Widget, size, focus)
         assert expected==got, "got: %s expected: %s"%(got, expected)
 
     def test1(self):
-        a = urwid.Text("")
-        b = urwid.Text("")
-        blah = urwid.TextCanvas()
+        a = widget.Text("")
+        b = widget.Text("")
+        blah = canvas.TextCanvas()
         blah.finalize(a, (10,1), False)
-        blah2 = urwid.TextCanvas()
+        blah2 = canvas.TextCanvas()
         blah2.finalize(a, (15,1), False)
-        bloo = urwid.TextCanvas()
+        bloo = canvas.TextCanvas()
         bloo.finalize(b, (20,2), True)
 
-        urwid.CanvasCache.store(urwid.Widget, blah)
-        urwid.CanvasCache.store(urwid.Widget, blah2)
-        urwid.CanvasCache.store(urwid.Widget, bloo)
+        canvas.CanvasCache.store(widget.Widget, blah)
+        canvas.CanvasCache.store(widget.Widget, blah2)
+        canvas.CanvasCache.store(widget.Widget, bloo)
 
         self.cct(a, (10,1), False, blah)
         self.cct(a, (15,1), False, blah2)
@@ -34,7 +33,7 @@ class CanvasCacheTest(unittest.TestCase):
         self.cct(a, (10,2), False, None)
         self.cct(b, (20,2), True, bloo)
         self.cct(b, (21,2), True, None)
-        urwid.CanvasCache.invalidate(a)
+        canvas.CanvasCache.invalidate(a)
         self.cct(a, (10,1), False, None)
         self.cct(a, (15,1), False, None)
         self.cct(b, (20,2), True, bloo)
@@ -42,13 +41,13 @@ class CanvasCacheTest(unittest.TestCase):
 
 class CanvasTest(unittest.TestCase):
     def ct(self, text, attr, exp_content):
-        c = urwid.TextCanvas([B(t) for t in text], attr)
+        c = canvas.TextCanvas([B(t) for t in text], attr)
         content = list(c.content())
         assert content == exp_content, "got: %r expected: %r" % (content,
                                                                  exp_content)
 
     def ct2(self, text, attr, left, top, cols, rows, def_attr, exp_content):
-        c = urwid.TextCanvas([B(t) for t in text], attr)
+        c = canvas.TextCanvas([B(t) for t in text], attr)
         content = list(c.content(left, top, cols, rows, def_attr))
         assert content == exp_content, "got: %r expected: %r" % (content,
                                                                  exp_content)
@@ -138,15 +137,15 @@ class ShardBodyTest(unittest.TestCase):
 class ShardsTrimTest(unittest.TestCase):
     def sttop(self, shards, top, expected):
         result = canvas.shards_trim_top(shards, top)
-        assert result == expected, "got: %r expected: %r" (result, expected)
+        assert result == expected, "got: %r expected: %r" % (result, expected)
 
     def strows(self, shards, rows, expected):
         result = canvas.shards_trim_rows(shards, rows)
-        assert result == expected, "got: %r expected: %r" (result, expected)
+        assert result == expected, "got: %r expected: %r" % (result, expected)
 
     def stsides(self, shards, left, cols, expected):
         result = canvas.shards_trim_sides(shards, left, cols)
-        assert result == expected, "got: %r expected: %r" (result, expected)
+        assert result == expected, "got: %r expected: %r" % (result, expected)
 
 
     def test1(self):
@@ -229,7 +228,7 @@ class ShardsTrimTest(unittest.TestCase):
 class ShardsJoinTest(unittest.TestCase):
     def sjt(self, shard_lists, expected):
         result = canvas.shards_join(shard_lists)
-        assert result == expected, "got: %r expected: %r" (result, expected)
+        assert result == expected, "got: %r expected: %r" % (result, expected)
 
     def test(self):
         shards1 = [(5, [(0,0,10,5,None,"foo"), (0,0,5,8,None,"baz")]),
@@ -261,13 +260,13 @@ class ShardsJoinTest(unittest.TestCase):
 class CanvasJoinTest(unittest.TestCase):
     def cjtest(self, desc, l, expected):
         l = [(c, None, False, n) for c, n in l]
-        result = list(urwid.CanvasJoin(l).content())
+        result = list(canvas.CanvasJoin(l).content())
 
         assert result == expected, "%s expected %r, got %r"%(
             desc, expected, result)
 
     def test(self):
-        C = urwid.TextCanvas
+        C = canvas.TextCanvas
         hello = C([B("hello")])
         there = C([B("there")], [[("a",5)]])
         a = C([B("a")])
@@ -307,10 +306,10 @@ class CanvasOverlayTest(unittest.TestCase):
     def cotest(self, desc, bgt, bga, fgt, fga, l, r, et):
         bgt = B(bgt)
         fgt = B(fgt)
-        bg = urwid.CompositeCanvas(
-            urwid.TextCanvas([bgt],[bga]))
-        fg = urwid.CompositeCanvas(
-            urwid.TextCanvas([fgt],[fga]))
+        bg = canvas.CompositeCanvas(
+            canvas.TextCanvas([bgt], [bga]))
+        fg = canvas.CompositeCanvas(
+            canvas.TextCanvas([fgt], [fga]))
         bg.overlay(fg, l, 0)
         result = list(bg.content())
         assert result == et, "%s expected %r, got %r"%(
@@ -352,7 +351,7 @@ class CanvasOverlayTest(unittest.TestCase):
             [[('a',None,B("asdf")),('b',None,B("HI")),('c',None,B("jkl"))]])
 
     def test3(self):
-        urwid.set_encoding("euc-jp")
+        util.set_encoding("euc-jp")
         self.cotest("db0","\xA1\xA1\xA1\xA1\xA1\xA1",[],"HI",[],2,2,
             [[(None,None,B("\xA1\xA1")),(None,None,B("HI")),
             (None,None,B("\xA1\xA1"))]])
@@ -369,8 +368,8 @@ class CanvasOverlayTest(unittest.TestCase):
 class CanvasPadTrimTest(unittest.TestCase):
     def cptest(self, desc, ct, ca, l, r, et):
         ct = B(ct)
-        c = urwid.CompositeCanvas(
-            urwid.TextCanvas([ct], [ca]))
+        c = canvas.CompositeCanvas(
+            canvas.TextCanvas([ct], [ca]))
         c.pad_trim_left_right(l, r)
         result = list(c.content())
         assert result == et, "%s expected %r, got %r"%(

--- a/urwid/tests/test_container.py
+++ b/urwid/tests/test_container.py
@@ -1,7 +1,7 @@
 import unittest
 
-from urwid.tests.util import SelectableText
-import urwid
+from .. import container, widget, wimp, font, listbox, decoration, graphics
+from .util import SelectableText
 
 
 class FrameTest(unittest.TestCase):
@@ -22,7 +22,7 @@ class FrameTest(unittest.TestCase):
             footer = FakeWidget(footer_rows,
                 focus and focus_part == 'footer')
 
-        f = urwid.Frame(None, header, footer, focus_part)
+        f = container.Frame(None, header, footer, focus_part)
 
         rval = f.frame_top_bottom(size, focus)
         exp = (top, bottom), (header_rows, footer_rows)
@@ -63,7 +63,7 @@ class FrameTest(unittest.TestCase):
 class PileTest(unittest.TestCase):
     def ktest(self, desc, l, focus_item, key,
             rkey, rfocus, rpref_col):
-        p = urwid.Pile( l, focus_item )
+        p = container.Pile(l, focus_item)
         rval = p.keypress( (20,), key )
         assert rkey == rval, "%s key expected %r but got %r" %(
             desc, rkey, rval)
@@ -76,7 +76,7 @@ class PileTest(unittest.TestCase):
             desc, rpref_col, new_pref))
 
     def test_select_change(self):
-        T,S,E = urwid.Text, SelectableText, urwid.Edit
+        T, S, E = widget.Text, SelectableText, widget.Edit
 
         self.ktest("simple up", [S("")], 0, "up", "up", 0, 0)
         self.ktest("simple down", [S("")], 0, "down", "down", 0, 0)
@@ -114,35 +114,35 @@ class PileTest(unittest.TestCase):
         assert z.get_pref_col((20,)) == 2
 
     def test_init_with_a_generator(self):
-        urwid.Pile(urwid.Text(c) for c in "ABC")
+        container.Pile(widget.Text(c) for c in "ABC")
 
     def test_change_focus_with_mouse(self):
-        p = urwid.Pile([urwid.Edit(), urwid.Edit()])
+        p = container.Pile([widget.Edit(), widget.Edit()])
         self.assertEqual(p.focus_position, 0)
         p.mouse_event((10,), 'button press', 1, 1, 1, True)
         self.assertEqual(p.focus_position, 1)
 
     def test_zero_weight(self):
-        p = urwid.Pile([
-            urwid.SolidFill('a'),
-            ('weight', 0, urwid.SolidFill('d')),
+        p = container.Pile([
+            widget.SolidFill('a'),
+            ('weight', 0, widget.SolidFill('d')),
             ])
         p.render((5, 4))
 
     def test_mouse_event_in_empty_pile(self):
-        p = urwid.Pile([])
+        p = container.Pile([])
         p.mouse_event((5,), 'button press', 1, 1, 1, False)
         p.mouse_event((5,), 'button press', 1, 1, 1, True)
 
 
 class ColumnsTest(unittest.TestCase):
     def cwtest(self, desc, l, divide, size, exp, focus_column=0):
-        c = urwid.Columns(l, divide, focus_column)
+        c = container.Columns(l, divide, focus_column)
         rval = c.column_widths( size )
         assert rval == exp, "%s expected %s, got %s"%(desc,exp,rval)
 
     def test_widths(self):
-        x = urwid.Text("") # sample "column"
+        x = widget.Text("") # sample "column"
         self.cwtest( "simple 1", [x], 0, (20,), [20] )
         self.cwtest( "simple 2", [x,x], 0, (20,), [10,10] )
         self.cwtest( "simple 2+1", [x,x], 1, (20,), [10,9] )
@@ -171,7 +171,7 @@ class ColumnsTest(unittest.TestCase):
             x, ('weight',3,x)], 1, (20,), [4,5,2,6] )
 
     def test_widths_focus_end(self):
-        x = urwid.Text("") # sample "column"
+        x = widget.Text("") # sample "column"
         self.cwtest("end simple 2", [x,x], 0, (20,), [10,10], 1)
         self.cwtest("end simple 2+1", [x,x], 1, (20,), [10,9], 1)
         self.cwtest("end simple 3+1", [x,x,x], 1, (20,), [6,6,6], 2)
@@ -199,7 +199,7 @@ class ColumnsTest(unittest.TestCase):
             x, ('weight',3,x)], 1, (20,), [4,5,2,6], 3)
 
     def mctest(self, desc, l, divide, size, col, row, exp, f_col, pref_col):
-        c = urwid.Columns( l, divide )
+        c = container.Columns(l, divide)
         rval = c.move_cursor_to_coords( size, col, row )
         assert rval == exp, "%s expected %r, got %r"%(desc,exp,rval)
         assert c.focus_col == f_col, "%s expected focus_col %s got %s"%(
@@ -209,7 +209,7 @@ class ColumnsTest(unittest.TestCase):
             desc, pref_col, pc)
 
     def test_move_cursor(self):
-        e, s, x = urwid.Edit("",""),SelectableText(""), urwid.Text("")
+        e, s, x = widget.Edit("", ""), SelectableText(""), widget.Text("")
         self.mctest("nothing selectbl",[x,x,x],1,(20,),9,0,False,0,None)
         self.mctest("dead on",[x,s,x],1,(20,),9,0,True,1,9)
         self.mctest("l edge",[x,s,x],1,(20,),6,0,True,1,6)
@@ -235,17 +235,17 @@ class ColumnsTest(unittest.TestCase):
         self.mctest("left", [e, e, e], 0, (12,), 'left', 0, True, 0, 'left')
 
     def test_init_with_a_generator(self):
-        urwid.Columns(urwid.Text(c) for c in "ABC")
+        container.Columns(widget.Text(c) for c in "ABC")
 
     def test_old_attributes(self):
-        c = urwid.Columns([urwid.Text(u'a'), urwid.SolidFill(u'x')],
+        c = container.Columns([widget.Text(u'a'), widget.SolidFill(u'x')],
             box_columns=[1])
         self.assertEqual(c.box_columns, [1])
         c.box_columns=[]
         self.assertEqual(c.box_columns, [])
 
     def test_box_column(self):
-        c = urwid.Columns([urwid.Filler(urwid.Edit()),urwid.Text('')],
+        c = container.Columns([decoration.Filler(widget.Edit()), widget.Text('')],
             box_columns=[0])
         c.keypress((10,), 'x')
         c.get_cursor_coords((10,))
@@ -257,13 +257,13 @@ class ColumnsTest(unittest.TestCase):
 
 class OverlayTest(unittest.TestCase):
     def test_old_params(self):
-        o1 = urwid.Overlay(urwid.SolidFill(u'X'), urwid.SolidFill(u'O'),
+        o1 = container.Overlay(widget.SolidFill(u'X'), widget.SolidFill(u'O'),
             ('fixed left', 5), ('fixed right', 4),
             ('fixed top', 3), ('fixed bottom', 2),)
         self.assertEqual(o1.contents[1][1], (
             'left', None, 'relative', 100, None, 5, 4,
             'top', None, 'relative', 100, None, 3, 2))
-        o2 = urwid.Overlay(urwid.SolidFill(u'X'), urwid.SolidFill(u'O'),
+        o2 = container.Overlay(widget.SolidFill(u'X'), widget.SolidFill(u'O'),
             ('fixed right', 5), ('fixed left', 4),
             ('fixed bottom', 3), ('fixed top', 2),)
         self.assertEqual(o2.contents[1][1], (
@@ -271,21 +271,21 @@ class OverlayTest(unittest.TestCase):
             'bottom', None, 'relative', 100, None, 2, 3))
 
     def test_get_cursor_coords(self):
-        self.assertEqual(urwid.Overlay(urwid.Filler(urwid.Edit()),
-            urwid.SolidFill(u'B'),
+        self.assertEqual(container.Overlay(decoration.Filler(widget.Edit()),
+            widget.SolidFill(u'B'),
             'right', 1, 'bottom', 1).get_cursor_coords((2,2)), (1,1))
 
 
 class GridFlowTest(unittest.TestCase):
     def test_cell_width(self):
-        gf = urwid.GridFlow([], 5, 0, 0, 'left')
+        gf = container.GridFlow([], 5, 0, 0, 'left')
         self.assertEqual(gf.cell_width, 5)
 
     def test_basics(self):
-        repr(urwid.GridFlow([], 5, 0, 0, 'left')) # should not fail
+        repr(container.GridFlow([], 5, 0, 0, 'left')) # should not fail
 
     def test_v_sep(self):
-        gf = urwid.GridFlow([urwid.Text("test")], 10, 3, 1, "center")
+        gf = container.GridFlow([widget.Text("test")], 10, 3, 1, "center")
         self.assertEqual(gf.rows((40,), False), 1)
 
 
@@ -314,60 +314,60 @@ class WidgetSquishTest(unittest.TestCase):
         t(1, True)
 
     def test_listbox(self):
-        self.wstest(urwid.ListBox([]))
-        self.wstest(urwid.ListBox([urwid.Text("hello")]))
+        self.wstest(listbox.ListBox([]))
+        self.wstest(listbox.ListBox([widget.Text("hello")]))
 
     def test_bargraph(self):
-        self.wstest(urwid.BarGraph(['foo','bar']))
+        self.wstest(graphics.BarGraph(['foo', 'bar']))
 
     def test_graphvscale(self):
-        self.wstest(urwid.GraphVScale([(0,"hello")], 1))
-        self.wstest(urwid.GraphVScale([(5,"hello")], 1))
+        self.wstest(graphics.GraphVScale([(0, "hello")], 1))
+        self.wstest(graphics.GraphVScale([(5, "hello")], 1))
 
     def test_solidfill(self):
-        self.wstest(urwid.SolidFill())
+        self.wstest(widget.SolidFill())
 
     def test_filler(self):
-        self.wstest(urwid.Filler(urwid.Text("hello")))
+        self.wstest(decoration.Filler(widget.Text("hello")))
 
     def test_overlay(self):
-        self.wstest(urwid.Overlay(
-            urwid.BigText("hello",urwid.Thin6x6Font()),
-            urwid.SolidFill(),
+        self.wstest(container.Overlay(
+            graphics.BigText("hello", font.Thin6x6Font()),
+            widget.SolidFill(),
             'center', None, 'middle', None))
-        self.wstest(urwid.Overlay(
-            urwid.Text("hello"), urwid.SolidFill(),
+        self.wstest(container.Overlay(
+            widget.Text("hello"), widget.SolidFill(),
             'center',  ('relative', 100), 'middle', None))
 
     def test_frame(self):
-        self.wstest(urwid.Frame(urwid.SolidFill()))
-        self.wstest(urwid.Frame(urwid.SolidFill(),
-            header=urwid.Text("hello")))
-        self.wstest(urwid.Frame(urwid.SolidFill(),
-            header=urwid.Text("hello"),
-            footer=urwid.Text("hello")))
+        self.wstest(container.Frame(widget.SolidFill()))
+        self.wstest(container.Frame(widget.SolidFill(),
+            header=widget.Text("hello")))
+        self.wstest(container.Frame(widget.SolidFill(),
+            header=widget.Text("hello"),
+            footer=widget.Text("hello")))
 
     def test_pile(self):
-        self.wstest(urwid.Pile([urwid.SolidFill()]))
-        self.wstest(urwid.Pile([('flow', urwid.Text("hello"))]))
-        self.wstest(urwid.Pile([]))
+        self.wstest(container.Pile([widget.SolidFill()]))
+        self.wstest(container.Pile([('flow', widget.Text("hello"))]))
+        self.wstest(container.Pile([]))
 
     def test_columns(self):
-        self.wstest(urwid.Columns([urwid.SolidFill()]))
-        self.wstest(urwid.Columns([(4, urwid.SolidFill())]))
+        self.wstest(container.Columns([widget.SolidFill()]))
+        self.wstest(container.Columns([(4, widget.SolidFill())]))
 
     def test_buttons(self):
-        self.fwstest(urwid.Button(u"hello"))
-        self.fwstest(urwid.RadioButton([], u"hello"))
+        self.fwstest(wimp.Button(u"hello"))
+        self.fwstest(wimp.RadioButton([], u"hello"))
 
 
 class CommonContainerTest(unittest.TestCase):
     def test_pile(self):
-        t1 = urwid.Text(u'one')
-        t2 = urwid.Text(u'two')
-        t3 = urwid.Text(u'three')
-        sf = urwid.SolidFill('x')
-        p = urwid.Pile([])
+        t1 = widget.Text(u'one')
+        t2 = widget.Text(u'two')
+        t3 = widget.Text(u'three')
+        sf = widget.SolidFill('x')
+        p = container.Pile([])
         self.assertEqual(p.focus, None)
         self.assertRaises(IndexError, lambda: getattr(p, 'focus_position'))
         self.assertRaises(IndexError, lambda: setattr(p, 'focus_position',
@@ -381,11 +381,11 @@ class CommonContainerTest(unittest.TestCase):
         p.contents[0:0] = [(t3, ('pack', None)), (t2, ('pack', None))]
         p.contents.insert(3, (t1, ('pack', None)))
         self.assertEqual(p.focus_position, 2)
-        self.assertRaises(urwid.PileError, lambda: p.contents.append(t1))
-        self.assertRaises(urwid.PileError, lambda: p.contents.append((t1, None)))
-        self.assertRaises(urwid.PileError, lambda: p.contents.append((t1, 'given')))
+        self.assertRaises(container.PileError, lambda: p.contents.append(t1))
+        self.assertRaises(container.PileError, lambda: p.contents.append((t1, None)))
+        self.assertRaises(container.PileError, lambda: p.contents.append((t1, 'given')))
 
-        p = urwid.Pile([t1, t2])
+        p = container.Pile([t1, t2])
         self.assertEqual(p.focus, t1)
         self.assertEqual(p.focus_position, 0)
         p.focus_position = 1
@@ -422,11 +422,11 @@ class CommonContainerTest(unittest.TestCase):
         self.assertEqual(len(p.contents), 1)
 
     def test_columns(self):
-        t1 = urwid.Text(u'one')
-        t2 = urwid.Text(u'two')
-        t3 = urwid.Text(u'three')
-        sf = urwid.SolidFill('x')
-        c = urwid.Columns([])
+        t1 = widget.Text(u'one')
+        t2 = widget.Text(u'two')
+        t3 = widget.Text(u'three')
+        sf = widget.SolidFill('x')
+        c = container.Columns([])
         self.assertEqual(c.focus, None)
         self.assertRaises(IndexError, lambda: getattr(c, 'focus_position'))
         self.assertRaises(IndexError, lambda: setattr(c, 'focus_position',
@@ -445,11 +445,11 @@ class CommonContainerTest(unittest.TestCase):
             (t2, ('weight', 1, False))]
         c.contents.insert(3, (t1, ('pack', None, False)))
         self.assertEqual(c.focus_position, 2)
-        self.assertRaises(urwid.ColumnsError, lambda: c.contents.append(t1))
-        self.assertRaises(urwid.ColumnsError, lambda: c.contents.append((t1, None)))
-        self.assertRaises(urwid.ColumnsError, lambda: c.contents.append((t1, 'given')))
+        self.assertRaises(container.ColumnsError, lambda: c.contents.append(t1))
+        self.assertRaises(container.ColumnsError, lambda: c.contents.append((t1, None)))
+        self.assertRaises(container.ColumnsError, lambda: c.contents.append((t1, 'given')))
 
-        c = urwid.Columns([t1, t2])
+        c = container.Columns([t1, t2])
         self.assertEqual(c.focus, t1)
         self.assertEqual(c.focus_position, 0)
         c.focus_position = 1
@@ -459,7 +459,7 @@ class CommonContainerTest(unittest.TestCase):
         self.assertRaises(IndexError, lambda: setattr(c, 'focus_position', -1))
         self.assertRaises(IndexError, lambda: setattr(c, 'focus_position', 2))
         # old methods:
-        c = urwid.Columns([t1, ('weight', 3, t2), sf], box_columns=[2])
+        c = container.Columns([t1, ('weight', 3, t2), sf], box_columns=[2])
         c.set_focus(0)
         self.assertRaises(IndexError, lambda: c.set_focus(-1))
         self.assertRaises(IndexError, lambda: c.set_focus(3))
@@ -503,16 +503,16 @@ class CommonContainerTest(unittest.TestCase):
         self.assertEqual(len(c.contents), 1)
 
     def test_list_box(self):
-        lb = urwid.ListBox(urwid.SimpleFocusListWalker([]))
+        lb = listbox.ListBox(listbox.SimpleFocusListWalker([]))
         self.assertEqual(lb.focus, None)
         self.assertRaises(IndexError, lambda: getattr(lb, 'focus_position'))
         self.assertRaises(IndexError, lambda: setattr(lb, 'focus_position',
             None))
         self.assertRaises(IndexError, lambda: setattr(lb, 'focus_position', 0))
 
-        t1 = urwid.Text(u'one')
-        t2 = urwid.Text(u'two')
-        lb = urwid.ListBox(urwid.SimpleListWalker([t1, t2]))
+        t1 = widget.Text(u'one')
+        t2 = widget.Text(u'two')
+        lb = listbox.ListBox(listbox.SimpleListWalker([t1, t2]))
         self.assertEqual(lb.focus, t1)
         self.assertEqual(lb.focus_position, 0)
         lb.focus_position = 1
@@ -523,7 +523,7 @@ class CommonContainerTest(unittest.TestCase):
         self.assertRaises(IndexError, lambda: setattr(lb, 'focus_position', 2))
 
     def test_grid_flow(self):
-        gf = urwid.GridFlow([], 5, 1, 0, 'left')
+        gf = container.GridFlow([], 5, 1, 0, 'left')
         self.assertEqual(gf.focus, None)
         self.assertEqual(gf.contents, [])
         self.assertRaises(IndexError, lambda: getattr(gf, 'focus_position'))
@@ -532,12 +532,12 @@ class CommonContainerTest(unittest.TestCase):
         self.assertRaises(IndexError, lambda: setattr(gf, 'focus_position', 0))
         self.assertEqual(gf.options(), ('given', 5))
         self.assertEqual(gf.options(width_amount=9), ('given', 9))
-        self.assertRaises(urwid.GridFlowError, lambda: gf.options(
+        self.assertRaises(container.GridFlowError, lambda: gf.options(
             'pack', None))
 
-        t1 = urwid.Text(u'one')
-        t2 = urwid.Text(u'two')
-        gf = urwid.GridFlow([t1, t2], 5, 1, 0, 'left')
+        t1 = widget.Text(u'one')
+        t2 = widget.Text(u'two')
+        gf = container.GridFlow([t1, t2], 5, 1, 0, 'left')
         self.assertEqual(gf.focus, t1)
         self.assertEqual(gf.focus_position, 0)
         self.assertEqual(gf.contents, [(t1, ('given', 5)), (t2, ('given', 5))])
@@ -546,8 +546,8 @@ class CommonContainerTest(unittest.TestCase):
         self.assertEqual(gf.focus_position, 1)
         gf.contents.insert(0, (t2, ('given', 5)))
         self.assertEqual(gf.focus_position, 2)
-        self.assertRaises(urwid.GridFlowError, lambda: gf.contents.append(()))
-        self.assertRaises(urwid.GridFlowError, lambda: gf.contents.insert(1,
+        self.assertRaises(container.GridFlowError, lambda: gf.contents.append(()))
+        self.assertRaises(container.GridFlowError, lambda: gf.contents.insert(1,
             (t1, ('pack', None))))
         gf.focus_position = 0
         self.assertRaises(IndexError, lambda: setattr(gf, 'focus_position', -1))
@@ -561,9 +561,9 @@ class CommonContainerTest(unittest.TestCase):
         self.assertRaises(ValueError, lambda: gf.set_focus('nonexistant'))
 
     def test_overlay(self):
-        s1 = urwid.SolidFill(u'1')
-        s2 = urwid.SolidFill(u'2')
-        o = urwid.Overlay(s1, s2,
+        s1 = widget.SolidFill(u'1')
+        s2 = widget.SolidFill(u'2')
+        o = container.Overlay(s1, s2,
             'center', ('relative', 50), 'middle', ('relative', 50))
         self.assertEqual(o.focus, s1)
         self.assertEqual(o.focus_position, 1)
@@ -572,15 +572,15 @@ class CommonContainerTest(unittest.TestCase):
         self.assertRaises(IndexError, lambda: setattr(o, 'focus_position', 2))
 
         self.assertEqual(o.contents[0], (s2,
-            urwid.Overlay._DEFAULT_BOTTOM_OPTIONS))
+            container.Overlay._DEFAULT_BOTTOM_OPTIONS))
         self.assertEqual(o.contents[1], (s1, (
             'center', None, 'relative', 50, None, 0, 0,
             'middle', None, 'relative', 50, None, 0, 0)))
 
     def test_frame(self):
-        s1 = urwid.SolidFill(u'1')
+        s1 = widget.SolidFill(u'1')
 
-        f = urwid.Frame(s1)
+        f = container.Frame(s1)
         self.assertEqual(f.focus, s1)
         self.assertEqual(f.focus_position, 'body')
         self.assertRaises(IndexError, lambda: setattr(f, 'focus_position',
@@ -588,10 +588,10 @@ class CommonContainerTest(unittest.TestCase):
         self.assertRaises(IndexError, lambda: setattr(f, 'focus_position',
             'header'))
 
-        t1 = urwid.Text(u'one')
-        t2 = urwid.Text(u'two')
-        t3 = urwid.Text(u'three')
-        f = urwid.Frame(s1, t1, t2, 'header')
+        t1 = widget.Text(u'one')
+        t2 = widget.Text(u'two')
+        t3 = widget.Text(u'three')
+        f = container.Frame(s1, t1, t2, 'header')
         self.assertEqual(f.focus, t1)
         self.assertEqual(f.focus_position, 'header')
         f.focus_position = 'footer'
@@ -607,25 +607,25 @@ class CommonContainerTest(unittest.TestCase):
         self.assertEqual(f.footer, t3)
         def set1():
             f.contents['body'] = t1
-        self.assertRaises(urwid.FrameError, set1)
+        self.assertRaises(container.FrameError, set1)
         def set2():
             f.contents['body'] = (t1, 'given')
-        self.assertRaises(urwid.FrameError, set2)
+        self.assertRaises(container.FrameError, set2)
 
     def test_focus_path(self):
         # big tree of containers
-        t = urwid.Text(u'x')
-        e = urwid.Edit(u'?')
-        c = urwid.Columns([t, e, t, t])
-        p = urwid.Pile([t, t, c, t])
-        a = urwid.AttrMap(p, 'gets ignored')
-        s = urwid.SolidFill(u'/')
-        o = urwid.Overlay(e, s, 'center', 'pack', 'middle', 'pack')
-        lb = urwid.ListBox(urwid.SimpleFocusListWalker([t, a, o, t]))
+        t = widget.Text(u'x')
+        e = widget.Edit(u'?')
+        c = container.Columns([t, e, t, t])
+        p = container.Pile([t, t, c, t])
+        a = decoration.AttrMap(p, 'gets ignored')
+        s = widget.SolidFill(u'/')
+        o = container.Overlay(e, s, 'center', 'pack', 'middle', 'pack')
+        lb = listbox.ListBox(listbox.SimpleFocusListWalker([t, a, o, t]))
         lb.focus_position = 1
-        g = urwid.GridFlow([t, t, t, t, e, t], 10, 0, 0, 'left')
+        g = container.GridFlow([t, t, t, t, e, t], 10, 0, 0, 'left')
         g.focus_position = 4
-        f = urwid.Frame(lb, header=t, footer=g)
+        f = container.Frame(lb, header=t, footer=g)
 
         self.assertEqual(f.get_focus_path(), ['body', 1, 2, 1])
         f.set_focus_path(['footer']) # same as f.focus_position = 'footer'

--- a/urwid/tests/test_decoration.py
+++ b/urwid/tests/test_decoration.py
@@ -1,18 +1,18 @@
 import unittest
 
-import urwid
+from .. import decoration, widget
 
 
 class PaddingTest(unittest.TestCase):
     def ptest(self, desc, align, width, maxcol, left, right,min_width=None):
-        p = urwid.Padding(None, align, width, min_width)
+        p = decoration.Padding(None, align, width, min_width)
         l, r = p.padding_values((maxcol,),False)
         assert (l,r)==(left,right), "%s expected %s but got %s"%(
             desc, (left,right), (l,r))
 
     def petest(self, desc, align, width):
-        self.assertRaises(urwid.PaddingError, lambda:
-            urwid.Padding(None, align, width))
+        self.assertRaises(decoration.PaddingError, lambda:
+            decoration.Padding(None, align, width))
 
     def test_create(self):
         self.petest("invalid pad",6,5)
@@ -61,7 +61,7 @@ class PaddingTest(unittest.TestCase):
             def move_cursor_to_coords(self,size,cx,cy):
                 assert cx==self.innercx, desc
         i = Inner(desc,innercx)
-        p = urwid.Padding(i, ('fixed left',left),
+        p = decoration.Padding(i, ('fixed left', left),
             ('fixed right',right))
         p.move_cursor_to_coords(size, cx, 0)
 
@@ -77,13 +77,13 @@ class PaddingTest(unittest.TestCase):
         # fixing this gets deep into things like Edit._shift_view_to_cursor
         # though, so this might not get fixed for a while
 
-        p = urwid.Padding(urwid.Edit(u'',u''), width='pack', left=4)
+        p = decoration.Padding(widget.Edit(u'', u''), width='pack', left=4)
         self.assertEqual(p.render((10,), True).cursor, None)
         self.assertEqual(p.get_cursor_coords((10,)), None)
         self.assertEqual(p.render((4,), True).cursor, None)
         self.assertEqual(p.get_cursor_coords((4,)), None)
 
-        p = urwid.Padding(urwid.Edit(u'',u''), width=('relative', 100), left=4)
+        p = decoration.Padding(widget.Edit(u'', u''), width=('relative', 100), left=4)
         self.assertEqual(p.render((10,), True).cursor, (4, 0))
         self.assertEqual(p.get_cursor_coords((10,)), (4, 0))
         self.assertEqual(p.render((4,), True).cursor, None)
@@ -93,14 +93,14 @@ class PaddingTest(unittest.TestCase):
 class FillerTest(unittest.TestCase):
     def ftest(self, desc, valign, height, maxrow, top, bottom,
             min_height=None):
-        f = urwid.Filler(None, valign, height, min_height)
+        f = decoration.Filler(None, valign, height, min_height)
         t, b = f.filler_values((20,maxrow), False)
         assert (t,b)==(top,bottom), "%s expected %s but got %s"%(
             desc, (top,bottom), (t,b))
 
     def fetest(self, desc, valign, height):
-        self.assertRaises(urwid.FillerError, lambda:
-            urwid.Filler(None, valign, height))
+        self.assertRaises(decoration.FillerError, lambda:
+            decoration.Filler(None, valign, height))
 
     def test_create(self):
         self.fetest("invalid pad",6,5)
@@ -146,4 +146,4 @@ class FillerTest(unittest.TestCase):
             10,1,1,8)
 
     def test_repr(self):
-        repr(urwid.Filler(urwid.Text(u'hai')))
+        repr(decoration.Filler(widget.Text(u'hai')))

--- a/urwid/tests/test_doctests.py
+++ b/urwid/tests/test_doctests.py
@@ -1,20 +1,22 @@
 import unittest
 import doctest
 
-import urwid
+from .. import (widget, wimp, decoration, display_common, main_loop,
+                monitored_list, raw_display, split_repr, util, signals)
+
 
 def load_tests(loader, tests, ignore):
     module_doctests = [
-        urwid.widget,
-        urwid.wimp,
-        urwid.decoration,
-        urwid.display_common,
-        urwid.main_loop,
-        urwid.monitored_list,
-        urwid.raw_display,
-        'urwid.split_repr', # override function with same name
-        urwid.util,
-        urwid.signals,
+        widget,
+        wimp,
+        decoration,
+        display_common,
+        main_loop,
+        monitored_list,
+        raw_display,
+        split_repr,
+        util,
+        signals,
         ]
     for m in module_doctests:
         tests.addTests(doctest.DocTestSuite(m,

--- a/urwid/tests/test_event_loops.py
+++ b/urwid/tests/test_event_loops.py
@@ -2,8 +2,8 @@ import os
 import unittest
 import platform
 
-import urwid
-from urwid.compat import PYTHON3
+from .. import main_loop
+from ..compat import PYTHON3
 
 
 class EventLoopTestMixin(object):
@@ -16,7 +16,7 @@ class EventLoopTestMixin(object):
             os.write(wr, "hi".encode('ascii'))
         def step2():
             out.append(os.read(rd, 2).decode('ascii'))
-            raise urwid.ExitMainLoop
+            raise main_loop.ExitMainLoop
         handle = evl.alarm(0, step1)
         handle = evl.watch_file(rd, step2)
         evl.run()
@@ -47,7 +47,7 @@ class EventLoopTestMixin(object):
             out.append("waiting")
         def exit_clean():
             out.append("clean exit")
-            raise urwid.ExitMainLoop
+            raise main_loop.ExitMainLoop
         def exit_error():
             1/0
         handle = evl.alarm(0.01, exit_clean)
@@ -71,7 +71,7 @@ class EventLoopTestMixin(object):
 
 class SelectEventLoopTest(unittest.TestCase, EventLoopTestMixin):
     def setUp(self):
-        self.evl = urwid.SelectEventLoop()
+        self.evl = main_loop.SelectEventLoop()
 
 
 try:
@@ -81,7 +81,7 @@ except ImportError:
 else:
     class GLibEventLoopTest(unittest.TestCase, EventLoopTestMixin):
         def setUp(self):
-            self.evl = urwid.GLibEventLoop()
+            self.evl = main_loop.GLibEventLoop()
 
 
 try:
@@ -92,7 +92,7 @@ else:
     class TornadoEventLoopTest(unittest.TestCase, EventLoopTestMixin):
         def setUp(self):
             from tornado.ioloop import IOLoop
-            self.evl = urwid.TornadoEventLoop(IOLoop())
+            self.evl = main_loop.TornadoEventLoop(IOLoop())
 
 
 try:
@@ -102,7 +102,7 @@ except ImportError:
 else:
     class TwistedEventLoopTest(unittest.TestCase, EventLoopTestMixin):
         def setUp(self):
-            self.evl = urwid.TwistedEventLoop()
+            self.evl = main_loop.TwistedEventLoop()
 
         # can't restart twisted reactor, so use shortened tests
         def test_event_loop(self):
@@ -121,7 +121,7 @@ else:
                 out.append("waiting")
             def exit_clean():
                 out.append("clean exit")
-                raise urwid.ExitMainLoop
+                raise main_loop.ExitMainLoop
             def exit_error():
                 1/0
             handle = evl.watch_file(rd, step2)
@@ -142,6 +142,6 @@ except ImportError:
 else:
     class AsyncioEventLoopTest(unittest.TestCase, EventLoopTestMixin):
         def setUp(self):
-            self.evl = urwid.AsyncioEventLoop()
+            self.evl = main_loop.AsyncioEventLoop()
 
         _expected_idle_handle = None

--- a/urwid/tests/test_graphics.py
+++ b/urwid/tests/test_graphics.py
@@ -1,8 +1,7 @@
 import unittest
 
-from urwid import graphics
-from urwid.compat import B
-import urwid
+from .. import graphics, widget, util
+from ..compat import B
 
 
 class LineBoxTest(unittest.TestCase):
@@ -12,10 +11,10 @@ class LineBoxTest(unittest.TestCase):
                 bytes().join([bl, b, br]),]
 
     def test_linebox_border(self):
-        urwid.set_encoding("utf-8")
-        t = urwid.Text("")
+        util.set_encoding("utf-8")
+        t = widget.Text("")
 
-        l = urwid.LineBox(t).render((3,)).text
+        l = graphics.LineBox(t).render((3,)).text
 
         # default
         self.assertEqual(l,
@@ -26,7 +25,7 @@ class LineBoxTest(unittest.TestCase):
         nums = [B(str(n)) for n in range(8)]
         b = dict(zip(["tlcorner", "tline", "trcorner", "lline", "rline",
             "blcorner", "bline", "brcorner"], nums))
-        l = urwid.LineBox(t, **b).render((3,)).text
+        l = graphics.LineBox(t, **b).render((3,)).text
 
         self.assertEqual(l, self.border(*nums))
 
@@ -77,8 +76,8 @@ class BarGraphTest(unittest.TestCase):
 
 class SmoothBarGraphTest(unittest.TestCase):
     def sbgtest(self, desc, data, top, exp ):
-        urwid.set_encoding('utf-8')
-        g = urwid.BarGraph( ['black','red','blue'],
+        util.set_encoding('utf-8')
+        g = graphics.BarGraph(['black', 'red', 'blue'],
                 None, {(1,0):'red/black', (2,1):'blue/red'})
         g.set_data( data, top )
         rval = g.calculate_display((5,3))

--- a/urwid/tests/test_listbox.py
+++ b/urwid/tests/test_listbox.py
@@ -1,15 +1,15 @@
 import unittest
 
-from urwid.compat import B
-from urwid.tests.util import SelectableText
-import urwid
+from ..compat import B
+from .. import listbox, widget, container
+from ..tests.util import SelectableText
 
 
 class ListBoxCalculateVisibleTest(unittest.TestCase):
     def cvtest(self, desc, body, focus, offset_rows, inset_fraction,
         exp_offset_inset, exp_cur ):
 
-        lbox = urwid.ListBox(body)
+        lbox = listbox.ListBox(body)
         lbox.body.set_focus( focus )
         lbox.offset_rows = offset_rows
         lbox.inset_fraction = inset_fraction
@@ -26,7 +26,7 @@ class ListBoxCalculateVisibleTest(unittest.TestCase):
         assert cursor == exp_cur, "%s (cursor) got: %r expected: %r" %(desc,cursor,exp_cur)
 
     def test1_simple(self):
-        T = urwid.Text
+        T = widget.Text
 
         l = [T(""),T(""),T("\n"),T("\n\n"),T("\n"),T(""),T("")]
 
@@ -71,7 +71,7 @@ class ListBoxCalculateVisibleTest(unittest.TestCase):
 
 
     def test2_cursor(self):
-        T, E = urwid.Text, urwid.Edit
+        T, E = widget.Text, widget.Edit
 
         l1 = [T(""),T(""),T("\n"),E("","\n\nX"),T("\n"),T(""),T("")]
         l2 = [T(""),T(""),T("\n"),E("","YY\n\n"),T("\n"),T(""),T("")]
@@ -99,7 +99,7 @@ class ListBoxChangeFocusTest(unittest.TestCase):
             coming_from, cursor, snap_rows,
             exp_offset_rows, exp_inset_fraction, exp_cur ):
 
-        lbox = urwid.ListBox(body)
+        lbox = listbox.ListBox(body)
 
         lbox.change_focus( (4,5), pos, offset_inset, coming_from,
             cursor, snap_rows )
@@ -118,7 +118,7 @@ class ListBoxChangeFocusTest(unittest.TestCase):
 
 
     def test1unselectable(self):
-        T = urwid.Text
+        T = widget.Text
         l = [T("\n"),T("\n\n"),T("\n\n"),T("\n\n"),T("\n")]
 
         self.cftest( "simple unselectable",
@@ -134,7 +134,7 @@ class ListBoxChangeFocusTest(unittest.TestCase):
             l, 3, 2, None, None, None, 2, (0,1), None )
 
     def test2selectable(self):
-        T, S = urwid.Text, SelectableText
+        T, S = widget.Text, SelectableText
         l = [T("\n"),T("\n\n"),S("\n\n"),T("\n\n"),T("\n")]
 
         self.cftest( "simple selectable",
@@ -162,7 +162,7 @@ class ListBoxChangeFocusTest(unittest.TestCase):
             l, 2, 3, 'below', None, None, 3, (0,1), None )
 
     def test3large_selectable(self):
-        T, S = urwid.Text, SelectableText
+        T, S = widget.Text, SelectableText
         l = [T("\n"),S("\n\n\n\n\n\n"),T("\n")]
         self.cftest( "large selectable no snap",
             l, 1, -1, None, None, None, 0, (1,7), None )
@@ -193,12 +193,12 @@ class ListBoxChangeFocusTest(unittest.TestCase):
             m, 1, -5, 'below', None, None, 0, (1,6), None )
 
     def test4cursor(self):
-        T,E = urwid.Text, urwid.Edit
+        T, E = widget.Text, widget.Edit
         #...
 
     def test5set_focus_valign(self):
-        T,E = urwid.Text, urwid.Edit
-        lbox = urwid.ListBox(urwid.SimpleFocusListWalker([
+        T, E = widget.Text, widget.Edit
+        lbox = listbox.ListBox(listbox.SimpleFocusListWalker([
             T(''), T('')]))
         lbox.set_focus_valign('middle')
         # TODO: actually test the result
@@ -207,7 +207,7 @@ class ListBoxChangeFocusTest(unittest.TestCase):
 class ListBoxRenderTest(unittest.TestCase):
     def ltest(self,desc,body,focus,offset_inset_rows,exp_text,exp_cur):
         exp_text = [B(t) for t in exp_text]
-        lbox = urwid.ListBox(body)
+        lbox = listbox.ListBox(body)
         lbox.body.set_focus( focus )
         lbox.shift_focus((4,10), offset_inset_rows )
         canvas = lbox.render( (4,5), focus=1 )
@@ -221,7 +221,7 @@ class ListBoxRenderTest(unittest.TestCase):
 
 
     def test1_simple(self):
-        T = urwid.Text
+        T = widget.Text
 
         self.ltest( "simple one text item render",
             [T("1\n2")], 0, 0,
@@ -236,7 +236,7 @@ class ListBoxRenderTest(unittest.TestCase):
             ["2   ","3   ","4   ","5   ","6   "],None)
 
     def test2_trim(self):
-        T = urwid.Text
+        T = widget.Text
 
         self.ltest( "trim unfocused bottom",
             [T("1\n2"),T("3\n4"),T("5\n6")], 1, 2,
@@ -263,7 +263,7 @@ class ListBoxRenderTest(unittest.TestCase):
             ["2   ","3   ","4   ","5   ","6   "],None)
 
     def test3_shift(self):
-        T,E = urwid.Text, urwid.Edit
+        T, E = widget.Text, widget.Edit
 
         self.ltest( "shift up one fit",
             [T("1\n2"),T("3"),T("4"),T("5"),T("6")], 4, 5,
@@ -290,7 +290,7 @@ class ListBoxRenderTest(unittest.TestCase):
             ["1   ","2   ","3   ","4   ","abc "], (3,4))
 
     def test4_really_large_contents(self):
-        T,E = urwid.Text, urwid.Edit
+        T, E = widget.Text, widget.Edit
         self.ltest("really large edit",
             [T(u"hello"*100)], 0, 0,
             ["hell","ohel","lohe","lloh","ello"], None)
@@ -305,7 +305,7 @@ class ListBoxKeypressTest(unittest.TestCase):
         exp_focus, exp_offset_inset, exp_cur, lbox = None):
 
         if lbox is None:
-            lbox = urwid.ListBox(body)
+            lbox = listbox.ListBox(body)
             lbox.body.set_focus( focus )
             lbox.shift_focus((4,10), offset_inset )
 
@@ -326,7 +326,7 @@ class ListBoxKeypressTest(unittest.TestCase):
 
 
     def test1_up(self):
-        T,S,E = urwid.Text, SelectableText, urwid.Edit
+        T, S, E = widget.Text, SelectableText, widget.Edit
 
         self.ktest( "direct selectable both visible", 'up',
             [S(""),S("")], 1, 1,
@@ -426,7 +426,7 @@ class ListBoxKeypressTest(unittest.TestCase):
         assert lbox.inset_fraction[0] == 0
 
     def test2_down(self):
-        T,S,E = urwid.Text, SelectableText, urwid.Edit
+        T, S, E = widget.Text, SelectableText, widget.Edit
 
         self.ktest( "direct selectable both visible", 'down',
             [S(""),S("")], 0, 0,
@@ -531,7 +531,7 @@ class ListBoxKeypressTest(unittest.TestCase):
         assert lbox.inset_fraction[0] == 1
 
     def test3_page_up(self):
-        T,S,E = urwid.Text, SelectableText, urwid.Edit
+        T, S, E = widget.Text, SelectableText, widget.Edit
 
         self.ktest( "unselectable aligned to aligned", 'page up',
             [T(""),T("\n"),T("\n\n"),T(""),T("\n"),T("\n\n")], 3, 0,
@@ -642,7 +642,7 @@ class ListBoxKeypressTest(unittest.TestCase):
             1, 1, None )
 
     def test4_page_down(self):
-        T,S,E = urwid.Text, SelectableText, urwid.Edit
+        T, S, E = widget.Text, SelectableText, widget.Edit
 
         self.ktest( "unselectable aligned to aligned", 'page down',
             [T("\n\n"),T("\n"),T(""),T("\n\n"),T("\n"),T("")], 2, 4,
@@ -762,21 +762,21 @@ class ListBoxKeypressTest(unittest.TestCase):
 
 class ZeroHeightContentsTest(unittest.TestCase):
     def test_listbox_pile(self):
-        lb = urwid.ListBox(urwid.SimpleListWalker(
-            [urwid.Pile([])]))
+        lb = listbox.ListBox(listbox.SimpleListWalker(
+            [container.Pile([])]))
         lb.render((40,10), focus=True)
 
     def test_listbox_text_pile_page_down(self):
-        lb = urwid.ListBox(urwid.SimpleListWalker(
-            [urwid.Text(u'above'), urwid.Pile([])]))
+        lb = listbox.ListBox(listbox.SimpleListWalker(
+            [widget.Text(u'above'), container.Pile([])]))
         lb.keypress((40,10), 'page down')
         self.assertEqual(lb.get_focus()[1], 0)
         lb.keypress((40,10), 'page down') # second one caused ListBox failure
         self.assertEqual(lb.get_focus()[1], 0)
 
     def test_listbox_text_pile_page_up(self):
-        lb = urwid.ListBox(urwid.SimpleListWalker(
-            [urwid.Pile([]), urwid.Text(u'below')]))
+        lb = listbox.ListBox(listbox.SimpleListWalker(
+            [container.Pile([]), widget.Text(u'below')]))
         lb.set_focus(1)
         lb.keypress((40,10), 'page up')
         self.assertEqual(lb.get_focus()[1], 1)
@@ -784,18 +784,18 @@ class ZeroHeightContentsTest(unittest.TestCase):
         self.assertEqual(lb.get_focus()[1], 1)
 
     def test_listbox_text_pile_down(self):
-        sp = urwid.Pile([])
+        sp = container.Pile([])
         sp.selectable = lambda: True # abuse our Pile
-        lb = urwid.ListBox(urwid.SimpleListWalker([urwid.Text(u'above'), sp]))
+        lb = listbox.ListBox(listbox.SimpleListWalker([widget.Text(u'above'), sp]))
         lb.keypress((40,10), 'down')
         self.assertEqual(lb.get_focus()[1], 0)
         lb.keypress((40,10), 'down')
         self.assertEqual(lb.get_focus()[1], 0)
 
     def test_listbox_text_pile_up(self):
-        sp = urwid.Pile([])
+        sp = container.Pile([])
         sp.selectable = lambda: True # abuse our Pile
-        lb = urwid.ListBox(urwid.SimpleListWalker([sp, urwid.Text(u'below')]))
+        lb = listbox.ListBox(listbox.SimpleListWalker([sp, widget.Text(u'below')]))
         lb.set_focus(1)
         lb.keypress((40,10), 'up')
         self.assertEqual(lb.get_focus()[1], 1)

--- a/urwid/tests/test_str_util.py
+++ b/urwid/tests/test_str_util.py
@@ -1,7 +1,7 @@
 import unittest
 
-from urwid.compat import B
-from urwid.escape import str_util
+from ..compat import B
+from ..escape import str_util
 
 
 class DecodeOneTest(unittest.TestCase):

--- a/urwid/tests/test_text_layout.py
+++ b/urwid/tests/test_text_layout.py
@@ -1,8 +1,8 @@
 import unittest
 
-from urwid import text_layout
-from urwid.compat import B
-import urwid
+from .. import text_layout
+from .. import util
+from ..compat import B
 
 
 class CalcBreaksTest(object):
@@ -32,7 +32,7 @@ class CalcBreaksCharTest(CalcBreaksTest, unittest.TestCase):
 
 class CalcBreaksDBCharTest(CalcBreaksTest, unittest.TestCase):
     def setUp(self):
-        urwid.set_encoding("euc-jp")
+        util.set_encoding("euc-jp")
 
     mode = 'any'
     text = "abfgh\xA1\xA1j\xA1\xA1xskhtrvs\naltjhgsdf\xA1\xA1jahtshgf"
@@ -67,7 +67,7 @@ class CalcBreaksWordTest2(CalcBreaksTest, unittest.TestCase):
 
 class CalcBreaksDBWordTest(CalcBreaksTest, unittest.TestCase):
     def setUp(self):
-        urwid.set_encoding("euc-jp")
+        util.set_encoding("euc-jp")
 
     mode = 'space'
     text = "hel\xA1\xA1 world\nout-\xA1\xA1tre blah"
@@ -81,7 +81,7 @@ class CalcBreaksDBWordTest(CalcBreaksTest, unittest.TestCase):
 
 class CalcBreaksUTF8Test(CalcBreaksTest, unittest.TestCase):
     def setUp(self):
-        urwid.set_encoding("utf-8")
+        util.set_encoding("utf-8")
 
     mode = 'space'
     text = '\xe6\x9b\xbf\xe6\xb4\xbc\xe6\xb8\x8e\xe6\xba\x8f\xe6\xbd\xba'
@@ -94,11 +94,11 @@ class CalcBreaksUTF8Test(CalcBreaksTest, unittest.TestCase):
 
 class CalcBreaksCantDisplayTest(unittest.TestCase):
     def test(self):
-        urwid.set_encoding("euc-jp")
+        util.set_encoding("euc-jp")
         self.assertRaises(text_layout.CanNotDisplayText,
             text_layout.default_layout.calculate_text_segments,
             B('\xA1\xA1'), 1, 'space' )
-        urwid.set_encoding("utf-8")
+        util.set_encoding("utf-8")
         self.assertRaises(text_layout.CanNotDisplayText,
             text_layout.default_layout.calculate_text_segments,
             B('\xe9\xa2\x96'), 1, 'space' )
@@ -106,11 +106,11 @@ class CalcBreaksCantDisplayTest(unittest.TestCase):
 
 class SubsegTest(unittest.TestCase):
     def setUp(self):
-        urwid.set_encoding("euc-jp")
+        util.set_encoding("euc-jp")
 
     def st(self, seg, text, start, end, exp):
         text = B(text)
-        s = urwid.LayoutSegment(seg)
+        s = text_layout.LayoutSegment(seg)
         result = s.subseg( text, start, end )
         assert result == exp, "Expected %r, got %r"%(exp,result)
 
@@ -151,20 +151,20 @@ class SubsegTest(unittest.TestCase):
 
 class CalcTranslateTest(object):
     def setUp(self):
-        urwid.set_encoding("utf-8")
+        util.set_encoding("utf-8")
 
     def test1_left(self):
-        result = urwid.default_layout.layout( self.text,
+        result = text_layout.default_layout.layout(self.text,
             self.width, 'left', self.mode)
         assert result == self.result_left, result
 
     def test2_right(self):
-        result = urwid.default_layout.layout( self.text,
+        result = text_layout.default_layout.layout(self.text,
             self.width, 'right', self.mode)
         assert result == self.result_right, result
 
     def test3_center(self):
-        result = urwid.default_layout.layout( self.text,
+        result = text_layout.default_layout.layout(self.text,
             self.width, 'center', self.mode)
         assert result == self.result_center, result
 
@@ -225,7 +225,7 @@ class CalcTranslateWordTest2(CalcTranslateTest, unittest.TestCase):
 
 class CalcTranslateWordTest3(CalcTranslateTest, unittest.TestCase):
     def setUp(self):
-        urwid.set_encoding('utf-8')
+        util.set_encoding('utf-8')
 
     text = B('\xe6\x9b\xbf\xe6\xb4\xbc\n\xe6\xb8\x8e\xe6\xba\x8f\xe6\xbd\xba')
     width = 10

--- a/urwid/tests/test_util.py
+++ b/urwid/tests/test_util.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 import unittest
 
-import urwid
-from urwid import util
-from urwid.compat import B
+from .. import util
+from .. import widget
+from ..compat import B
 
 
 class CalcWidthTest(unittest.TestCase):
@@ -31,7 +31,7 @@ class ConvertDecSpecialTest(unittest.TestCase):
     def ctest(self, desc, s, exp, expcs):
         exp = B(exp)
         util.set_encoding('ascii')
-        c = urwid.Text(s).render((5,))
+        c = widget.Text(s).render((5,))
         result = c._text[0]
         assert result==exp, "%s got:%r expected:%r" % (desc, result, exp)
         resultcs = c._cs[0]
@@ -40,9 +40,9 @@ class ConvertDecSpecialTest(unittest.TestCase):
 
     def test1(self):
         self.ctest("no conversion", u"hello", "hello", [(None,5)])
-        self.ctest("only special", u"£££££", "}}}}}", [("0",5)])
-        self.ctest("mix left", u"££abc", "}}abc", [("0",2),(None,3)])
-        self.ctest("mix right", u"abc££", "abc}}", [(None,3),("0",2)])
+        self.ctest("only special", u"£££££", "}}}}}", [("0", 5)])
+        self.ctest("mix left", u"££abc", "}}abc", [("0", 2), (None, 3)])
+        self.ctest("mix right", u"abc££", "abc}}", [(None, 3), ("0", 2)])
         self.ctest("mix inner", u"a££bc", "a}}bc",
             [(None,1),("0",2),(None,2)] )
         self.ctest("mix well", u"£a£b£", "}a}b}",
@@ -51,7 +51,7 @@ class ConvertDecSpecialTest(unittest.TestCase):
 
 class WithinDoubleByteTest(unittest.TestCase):
     def setUp(self):
-        urwid.set_encoding("euc-jp")
+        util.set_encoding("euc-jp")
 
     def wtest(self, s, ls, pos, expected, desc):
         result = util.within_double_byte(B(s), ls, pos)
@@ -165,14 +165,14 @@ class TagMarkupTest(unittest.TestCase):
 
     def test(self):
         for input, text, attr in self.mytests:
-            restext,resattr = urwid.decompose_tagmarkup( input )
+            restext, resattr = util.decompose_tagmarkup(input)
             assert restext == text, "got: %r expected: %r" % (restext, text)
             assert resattr == attr, "got: %r expected: %r" % (resattr, attr)
 
     def test_bad_tuple(self):
-        self.assertRaises(urwid.TagMarkupException, lambda:
-            urwid.decompose_tagmarkup((1,2,3)))
+        self.assertRaises(util.TagMarkupException, lambda:
+            util.decompose_tagmarkup((1, 2, 3)))
 
     def test_bad_type(self):
-        self.assertRaises(urwid.TagMarkupException, lambda:
-            urwid.decompose_tagmarkup(5))
+        self.assertRaises(util.TagMarkupException, lambda:
+            util.decompose_tagmarkup(5))

--- a/urwid/tests/test_vterm.py
+++ b/urwid/tests/test_vterm.py
@@ -24,9 +24,9 @@ import unittest
 
 from itertools import dropwhile
 
-from urwid import vterm
-from urwid import signals
-from urwid.compat import B
+from .. import vterm
+from .. import signals
+from ..compat import B
 
 
 class DummyCommand(object):

--- a/urwid/tests/test_widget.py
+++ b/urwid/tests/test_widget.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 import unittest
 
-from urwid.compat import B
-import urwid
+from ..compat import B
+from ..widget import Text, Edit
+from .. import set_encoding
 
 
 class TextTest(unittest.TestCase):
     def setUp(self):
-        self.t = urwid.Text("I walk the\ncity in the night")
+        self.t = Text("I walk the\ncity in the night")
 
     def test1_wrap(self):
         expected = [B(t) for t in "I walk the","city in   ","the night "]
@@ -33,24 +34,24 @@ class TextTest(unittest.TestCase):
         assert got == expected, "got: %r expected: %r" % (got, expected)
 
     def test5_encode_error(self):
-        urwid.set_encoding("ascii")
+        set_encoding("ascii")
         expected = [B("?  ")]
-        got = urwid.Text(u'û').render((3,))._text
+        got = Text(u'û').render((3,))._text
         assert got == expected, "got: %r expected: %r" % (got, expected)
 
 
 class EditTest(unittest.TestCase):
     def setUp(self):
-        self.t1 = urwid.Edit(B(""),"blah blah")
-        self.t2 = urwid.Edit(B("stuff:"), "blah blah")
-        self.t3 = urwid.Edit(B("junk:\n"),"blah blah\n\nbloo",1)
-        self.t4 = urwid.Edit(u"better:")
+        self.t1 = Edit(B(""), "blah blah")
+        self.t2 = Edit(B("stuff:"), "blah blah")
+        self.t3 = Edit(B("junk:\n"), "blah blah\n\nbloo", 1)
+        self.t4 = Edit(u"better:")
 
     def ktest(self, e, key, expected, pos, desc):
         got= e.keypress((12,),key)
         assert got == expected, "%s.  got: %r expected:%r" % (desc, got,
                                                               expected)
-        assert e.edit_pos == pos, "%s. pos: %r expected pos: " % (
+        assert e.edit_pos == pos, "%s. pos: %r expected pos: %r" % (
             desc, e.edit_pos, pos)
 
     def test1_left(self):
@@ -89,7 +90,7 @@ class EditTest(unittest.TestCase):
         self.ktest(self.t3,'down','down',15,"down at bottom")
 
     def test_utf8_input(self):
-        urwid.set_encoding("utf-8")
+        set_encoding("utf-8")
         self.t1.set_edit_text('')
         self.t1.keypress((12,), u'û')
         self.assertEqual(self.t1.edit_text, u'û'.encode('utf-8'))
@@ -111,7 +112,7 @@ class EditRenderTest(unittest.TestCase):
             r.cursor, expected_cursor)
 
     def test1_SpaceWrap(self):
-        w = urwid.Edit("","blah blah")
+        w = Edit("", "blah blah")
         w.set_edit_pos(0)
         self.rtest(w,["blah","blah"],(0,0))
 
@@ -125,7 +126,7 @@ class EditRenderTest(unittest.TestCase):
         self.rtest(w,["blah","lah "],(3,1))
 
     def test2_ClipWrap(self):
-        w = urwid.Edit("","blah\nblargh",1)
+        w = Edit("", "blah\nblargh", 1)
         w.set_wrap_mode('clip')
         w.set_edit_pos(0)
         self.rtest(w,["blah","blar"],(0,0))
@@ -138,13 +139,13 @@ class EditRenderTest(unittest.TestCase):
         self.rtest(w,["blah","larg"],(0,1))
 
     def test3_AnyWrap(self):
-        w = urwid.Edit("","blah blah")
+        w = Edit("", "blah blah")
         w.set_wrap_mode('any')
 
         self.rtest(w,["blah"," bla","h   "],(1,2))
 
     def test4_CursorNudge(self):
-        w = urwid.Edit("","hi",align='right')
+        w = Edit("", "hi", align='right')
         w.keypress((4,),'end')
 
         self.rtest(w,[" hi "],(3,0))

--- a/urwid/tests/util.py
+++ b/urwid/tests/util.py
@@ -1,6 +1,6 @@
-import urwid
+from ..widget import Text
 
-class SelectableText(urwid.Text):
+class SelectableText(Text):
     def selectable(self):
         return 1
 

--- a/urwid/text_layout.py
+++ b/urwid/text_layout.py
@@ -19,9 +19,9 @@
 #
 # Urwid web site: http://excess.org/urwid/
 
-from urwid.util import calc_width, calc_text_pos, calc_trim_text, is_wide_char, \
+from .util import calc_width, calc_text_pos, calc_trim_text, is_wide_char, \
     move_prev_char, move_next_char
-from urwid.compat import bytes, PYTHON3, B
+from .compat import bytes, PYTHON3, B
 
 class TextLayout:
     def supports_align_mode(self, align):

--- a/urwid/treetools.py
+++ b/urwid/treetools.py
@@ -29,15 +29,15 @@ Features:
 """
 
 
-import urwid
-from urwid.wimp import SelectableIcon
+from . import widget, container, decoration, listbox
+from .wimp import SelectableIcon
 
 
 class TreeWidgetError(RuntimeError):
     pass
 
 
-class TreeWidget(urwid.WidgetWrap):
+class TreeWidget(widget.WidgetWrap):
     """A widget representing something in a nested tree display."""
     indent_cols = 3
     unexpanded_icon = SelectableIcon('+', 0)
@@ -60,11 +60,11 @@ class TreeWidget(urwid.WidgetWrap):
     def get_indented_widget(self):
         widget = self.get_inner_widget()
         if not self.is_leaf:
-            widget = urwid.Columns([('fixed', 1,
+            widget = container.Columns([('fixed', 1,
                 [self.unexpanded_icon, self.expanded_icon][self.expanded]),
                 widget], dividechars=1)
         indent_cols = self.get_indent_cols()
-        return urwid.Padding(widget,
+        return decoration.Padding(widget,
             width=('relative', 100), left=indent_cols)
 
     def update_expanded_icon(self):
@@ -82,7 +82,7 @@ class TreeWidget(urwid.WidgetWrap):
         return self._innerwidget
 
     def load_inner_widget(self):
-        return urwid.Text(self.get_display_text())
+        return widget.Text(self.get_display_text())
 
     def get_node(self):
         return self._node
@@ -377,7 +377,7 @@ class ParentNode(TreeNode):
         return len(self.get_child_keys())>0
 
 
-class TreeWalker(urwid.ListWalker):
+class TreeWalker(listbox.ListWalker):
     """ListWalker-compatible class for displaying TreeWidgets
 
     positions are TreeNodes."""
@@ -411,7 +411,7 @@ class TreeWalker(urwid.ListWalker):
             return target, target.get_node()
 
 
-class TreeListBox(urwid.ListBox):
+class TreeListBox(listbox.ListBox):
     """A ListBox with special handling for navigation and
     collapsing of TreeWidgets"""
 

--- a/urwid/util.py
+++ b/urwid/util.py
@@ -20,8 +20,8 @@
 #
 # Urwid web site: http://excess.org/urwid/
 
-from urwid import escape
-from urwid.compat import bytes
+from . import escape
+from .compat import bytes
 
 import codecs
 

--- a/urwid/vterm.py
+++ b/urwid/vterm.py
@@ -38,12 +38,12 @@ try:
 except ImportError:
     pass # windows
 
-from urwid import util
-from urwid.escape import DEC_SPECIAL_CHARS, ALT_DEC_SPECIAL_CHARS
-from urwid.canvas import Canvas
-from urwid.widget import Widget, BOX
-from urwid.display_common import AttrSpec, RealTerminal, _BASIC_COLORS
-from urwid.compat import ord2, chr2, B, bytes, PYTHON3
+from . import util
+from .escape import DEC_SPECIAL_CHARS, ALT_DEC_SPECIAL_CHARS
+from .canvas import Canvas
+from .widget import Widget, BOX
+from .display_common import AttrSpec, RealTerminal, _BASIC_COLORS
+from .compat import ord2, chr2, B, bytes, PYTHON3
 
 ESC = chr(27)
 

--- a/urwid/web_display.py
+++ b/urwid/web_display.py
@@ -30,7 +30,7 @@ import select
 import socket
 import glob
 
-from urwid import util
+from . import util
 _js_code = r"""
 // Urwid web (CGI/Asynchronous Javascript) display module
 //    Copyright (C) 2004-2005  Ian Ward

--- a/urwid/widget.py
+++ b/urwid/widget.py
@@ -21,16 +21,16 @@
 
 from operator import attrgetter
 
-from urwid.util import (MetaSuper, decompose_tagmarkup, calc_width,
+from .util import (MetaSuper, decompose_tagmarkup, calc_width,
     is_wide_char, move_prev_char, move_next_char)
-from urwid.text_layout import calc_pos, calc_coords, shift_line
-from urwid import signals
-from urwid import text_layout
-from urwid.canvas import (CanvasCache, CompositeCanvas, SolidCanvas,
+from .text_layout import calc_pos, calc_coords, shift_line
+from . import signals
+from . import text_layout
+from .canvas import (CanvasCache, CompositeCanvas, SolidCanvas,
     apply_text_layout)
-from urwid.command_map import (command_map, CURSOR_LEFT, CURSOR_RIGHT,
+from .command_map import (command_map, CURSOR_LEFT, CURSOR_RIGHT,
     CURSOR_UP, CURSOR_DOWN, CURSOR_MAX_LEFT, CURSOR_MAX_RIGHT)
-from urwid.split_repr import split_repr, remove_defaults, python3_repr
+from .split_repr import split_repr, remove_defaults, python3_repr
 
 
 # define some names for these constants to avoid misspellings in the source

--- a/urwid/wimp.py
+++ b/urwid/wimp.py
@@ -19,17 +19,16 @@
 #
 # Urwid web site: http://excess.org/urwid/
 
-from urwid.widget import (Text, WidgetWrap, delegate_to_widget_mixin, BOX,
-    FLOW)
-from urwid.canvas import CompositeCanvas
-from urwid.signals import connect_signal
-from urwid.container import Columns, Overlay
-from urwid.util import is_mouse_press
-from urwid.text_layout import calc_coords
-from urwid.signals import disconnect_signal # doctests
-from urwid.split_repr import python3_repr
-from urwid.decoration import WidgetDecoration
-from urwid.command_map import ACTIVATE
+from .widget import (Text, WidgetWrap, delegate_to_widget_mixin, BOX, FLOW)
+from .canvas import CompositeCanvas
+from .signals import connect_signal
+from .container import Columns, Overlay
+from .util import is_mouse_press
+from .text_layout import calc_coords
+from .signals import disconnect_signal # doctests
+from .split_repr import python3_repr
+from .decoration import WidgetDecoration
+from .command_map import ACTIVATE
 
 class SelectableIcon(Text):
     _selectable = True


### PR DESCRIPTION
For my project I cannot install `urwid` in standard `PYTHONPATH` and I cannot easily change `PYTHONPATH` for other clients that use my project.To handle this I'd like to copy `urwid` inside my own project and import it with `import from` syntax, e.g.:

```
from my_project.extras import urwid
```

Right now `urwid` imports its own modules using absolute names (e.g. `from urwid.container import Frame`) which makes it impossible to relocate easily. 

Proposed patch replaces all absolute imports for `urwid` modules in `urwid` source with relative ones. I have tested it to the best of my ability and also ran it through `pylint` to verify that all imports look OK. I'd appreciate if this could be incorporated into one of the next `urwid` versions.
