### PR TITLE
python 3.{4,5} test-suite, another test case for asyncio event loop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ python:
   - "2.7_with_system_site_packages"
   - "3.2_with_system_site_packages"
   - "3.3"
+  - "3.4"
+  - "3.5"
   - "pypy"
 before_install:
   - "sudo apt-get update"
@@ -18,5 +20,7 @@ script:
        \"$DEPS\" == '2.7_with_system_site_packages pygobject tornado twisted' -o
        \"$DEPS\" == '3.2_with_system_site_packages pygobject tornado' -o
        \"$DEPS\" == '3.3 tornado twisted' -o
+       \"$DEPS\" == '3.4 tornado twisted' -o
+       \"$DEPS\" == '3.5 tornado twisted' -o
        \"$DEPS\" == 'pypy tornado twisted' ]"
   - "python setup.py test"

--- a/urwid/main_loop.py
+++ b/urwid/main_loop.py
@@ -1326,7 +1326,6 @@ class AsyncioEventLoop(object):
         self._loop.run_forever()
         if self._exc_info:
             raise self._exc_info[0], self._exc_info[1], self._exc_info[2]
-            self._exc_info = None
 
 
 def _refl(name, rval=None, exit=False):

--- a/urwid/tests/test_event_loops.py
+++ b/urwid/tests/test_event_loops.py
@@ -144,4 +144,34 @@ else:
         def setUp(self):
             self.evl = urwid.AsyncioEventLoop()
 
-        _expected_idle_handle = None
+        def test_run(self):
+            evl = self.evl
+            out = []
+            rd, wr = os.pipe()
+            self.assertEqual(os.write(wr, "data".encode('ascii')), 4)
+            def say_hello():
+                out.append("hello")
+            def say_waiting():
+                out.append("waiting")
+            def exit_clean():
+                out.append("clean exit")
+                raise urwid.ExitMainLoop
+            def exit_error():
+                1/0
+            handle = evl.alarm(0.01, exit_clean)
+            handle = evl.alarm(0.005, say_hello)
+            idle_handle = evl.enter_idle(say_waiting)
+            if self._expected_idle_handle is not None:
+                self.assertEqual(len(idle_handle), 1)
+            evl.run()
+            self.assertTrue("hello" in out, out)
+            self.assertTrue("clean exit"in out, out)
+            handle = evl.watch_file(rd, exit_clean)
+            del out[:]
+            evl.run()
+            self.assertEqual(out, ["clean exit"])
+            self.assertTrue(evl.remove_watch_file(handle))
+            handle = evl.alarm(0, exit_error)
+            self.assertRaises(ZeroDivisionError, evl.run)
+            handle = evl.watch_file(rd, exit_error)
+            self.assertRaises(ZeroDivisionError, evl.run)


### PR DESCRIPTION
latest stable release gives me:

```
  File "~/.local/lib/python3.4/site-packages/urwid/main_loop.py", line 1328, in run
    raise self._exc_info[0](self._exc_info[1]).with_traceback(self._exc_info[2])
TypeError: __init__() missing 1 required positional argument: 'response'
```

(this is a custom exception from `requests`)

git master gives me

```
  File "~/.local/lib/python3.4/site-packages/urwid/main_loop.py", line 1328
    raise self._exc_info[0], self._exc_info[1], self._exc_info[2]
                           ^
SyntaxError: invalid syntax
```

also `self._exc_info = None` after `raise` is a deadcode.
