### PR TITLE
 Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ before_install:
   - "sudo apt-get update"
   - "sudo apt-get install python-gi python3-gi"
 install:
-  - "pip install setuptools tornado"
+  - "pip install setuptools"
   - if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install "twisted<=15.4"; fi
-  - "[ $TRAVIS_PYTHON_VERSION == '3.2_with_system_site_packages' ] || pip install twisted"
+  - "[ $TRAVIS_PYTHON_VERSION == '3.2_with_system_site_packages' ] && pip install tornado<=4.3.0 || pip install twisted tornado"
 script:
   - "DEPS=\"$TRAVIS_PYTHON_VERSION `python bin/deps.py`\"; echo $DEPS"
   - "[ \"$DEPS\" == '2.6 tornado twisted' -o

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "2.7_with_system_site_packages"
   - "3.2_with_system_site_packages"
   - "3.3"
+  - "3.4"
   - "pypy"
 before_install:
   - "sudo apt-get update"
@@ -18,5 +19,6 @@ script:
        \"$DEPS\" == '2.7_with_system_site_packages pygobject tornado twisted' -o
        \"$DEPS\" == '3.2_with_system_site_packages pygobject tornado' -o
        \"$DEPS\" == '3.3 tornado twisted' -o
+       \"$DEPS\" == '3.4 tornado twisted' -o
        \"$DEPS\" == 'pypy tornado twisted' ]"
   - "python setup.py test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
 install:
   - "pip install setuptools"
   - if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install "twisted<=15.4"; fi
-  - "[ $TRAVIS_PYTHON_VERSION == '3.2_with_system_site_packages' ] && pip install tornado<=4.3.0 || pip install twisted tornado"
+  - "[ $TRAVIS_PYTHON_VERSION == '3.2_with_system_site_packages' ] && pip install 'tornado<=4.3.0' || pip install twisted tornado"
 script:
   - "DEPS=\"$TRAVIS_PYTHON_VERSION `python bin/deps.py`\"; echo $DEPS"
   - "[ \"$DEPS\" == '2.6 tornado twisted' -o

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ before_install:
   - "sudo apt-get update"
   - "sudo apt-get install python-gi python3-gi"
 install:
-  - "pip install --use-mirrors setuptools tornado"
+  - "pip install setuptools tornado"
   - if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install "twisted<=15.4"; fi
-  - "[ $TRAVIS_PYTHON_VERSION == '3.2_with_system_site_packages' ] || pip install --use-mirrors twisted"
+  - "[ $TRAVIS_PYTHON_VERSION == '3.2_with_system_site_packages' ] || pip install twisted"
 script:
   - "DEPS=\"$TRAVIS_PYTHON_VERSION `python bin/deps.py`\"; echo $DEPS"
   - "[ \"$DEPS\" == '2.6 tornado twisted' -o

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.2_with_system_site_packages"
   - "3.3"
   - "3.4"
+  - "3.5"
   - "pypy"
 before_install:
   - "sudo apt-get update"
@@ -20,5 +21,6 @@ script:
        \"$DEPS\" == '3.2_with_system_site_packages pygobject tornado' -o
        \"$DEPS\" == '3.3 tornado twisted' -o
        \"$DEPS\" == '3.4 tornado twisted' -o
+       \"$DEPS\" == '3.5 tornado twisted' -o
        \"$DEPS\" == 'pypy tornado twisted' ]"
   - "python setup.py test"

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setup_d = {
         "Programming Language :: Python :: 3.2",
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: Implementation :: PyPy",
         ],
      }


### PR DESCRIPTION
Done
* Fix tests for python version 2.6, 2.7, 3.3 and pypy (by removing --use-mirrors option in pip)
* Add successful tests for python version 3.4 and 3.5

[Edit: the following points are no more relevant]
Issue
* Test for python version 3.2 still fails.

I propose to remove the official support for python version 3.2
* tornado stops 3.2 support after tornado version 4.3
* twisted had never officially supported python 3.2.
pip provides the following (recent) versions of twisted : 15.0.0, 15.1.0, 15.2.0, 15.2.1, 15.3.0, 15.4.0, 15.5.0, 16.0.0, 16.1.0, 16.1.1, 16.2.0, 16.3.0, 16.3.1.
python 3 is supported since twisted 15.3.0 and none of the following versions show python3.2 according the provided categories.