### PR TITLE
Workaround to get Travis working again.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ before_install:
 install:
   - "pip install setuptools"
   - if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install "twisted<=15.4"; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.7_with_system_site_packages' ]]; then pip install "twisted==16.6.0"; fi
   - "[ $TRAVIS_PYTHON_VERSION == '3.2_with_system_site_packages' ] && pip install 'tornado<=4.3.0' || pip install twisted tornado"
 script:
   - "DEPS=\"$TRAVIS_PYTHON_VERSION `python bin/deps.py`\"; echo $DEPS"


### PR DESCRIPTION
* The Travis environment "2.7_with_system_site_packages" has Python 2.7.3
  installed, but recent updates to twisted require an update to 2.7.9.
* Explicitly pointing at twisted==16.6.0 when testing Python 2.7 seems to fix
  the problem.