### PR TITLE
fix: raw display should release file descriptors (issue #221)

### DIFF
--- a/urwid/raw_display.py
+++ b/urwid/raw_display.py
@@ -392,9 +392,7 @@ class Screen(BaseScreen, RealTerminal):
             wrapper = lambda: self.parse_input(
                 event_loop, callback, self.get_available_raw_input())
         fds = self.get_input_descriptors()
-        handles = []
-        for fd in fds:
-            event_loop.watch_file(fd, wrapper)
+        handles = [event_loop.watch_file(fd, wrapper) for fd in fds]
         self._current_event_loop_handles = handles
 
     _input_timeout = None


### PR DESCRIPTION
`raw_display.Screen.hook_event_loop` does not fill
`self._current_event_loop_handles` with handled file descriptors.
So, `raw_display.Screen.hook_event_loop` can not release then.