### PR TITLE
ListBox: Offer page up/down keys to focused widget

### DIFF
--- a/urwid/listbox.py
+++ b/urwid/listbox.py
@@ -994,12 +994,11 @@ class ListBox(Widget, WidgetContainerMixin):
         if focus_widget is None: # empty listbox, can't do anything
             return key
 
-        if self._command_map[key] not in [CURSOR_PAGE_UP, CURSOR_PAGE_DOWN]:
-            if focus_widget.selectable():
-                key = focus_widget.keypress((maxcol,),key)
+        if focus_widget.selectable():
+            key = focus_widget.keypress((maxcol,),key)
             if key is None:
                 self.make_cursor_visible((maxcol,maxrow))
-                return
+                return None
 
         def actual_key(unhandled):
             if unhandled:


### PR DESCRIPTION
Child widgets of ListBoxes should get all keys before ListBox uses them,
including 'page up' and 'page down'.

In my case, I've mapped 'space' to CURSOR_PAGE_DOWN application-wide, so the
user can scroll down in text like in a pager ('less'). In other cases, ListBox
child widgets use 'space' for being marked and unmarked, but they never get the
key because ListBox doesn't CURSOR_PAGE_DOWN/UP.