### PR TITLE
fix test_remove_watch_file flakiness

### DIFF
--- a/urwid/tests/test_event_loops.py
+++ b/urwid/tests/test_event_loops.py
@@ -30,9 +30,14 @@ class EventLoopTestMixin(object):
 
     def test_remove_watch_file(self):
         evl = self.evl
-        handle = evl.watch_file(5, lambda: None)
-        self.assertTrue(evl.remove_watch_file(handle))
-        self.assertFalse(evl.remove_watch_file(handle))
+        fd_r, fd_w = os.pipe()
+        try:
+            handle = evl.watch_file(fd_r, lambda: None)
+            self.assertTrue(evl.remove_watch_file(handle))
+            self.assertFalse(evl.remove_watch_file(handle))
+        finally:
+            os.close(fd_r)
+            os.close(fd_w)
 
     _expected_idle_handle = 1
 


### PR DESCRIPTION
pass a known-good file descriptor to watch_file rather than hard-coding 5

Fixes #164