### PR TITLE
Fixed Terminal widget crashes with Python3

### DIFF
--- a/urwid/raw_display.py
+++ b/urwid/raw_display.py
@@ -834,7 +834,7 @@ class Screen(BaseScreen, RealTerminal):
         try:
             for l in o:
                 if isinstance(l, bytes) and PYTHON3:
-                    l = l.decode('utf-8')
+                    l = l.decode('utf-8', 'replace')
                 self.write(l)
             self.flush()
         except IOError as e:


### PR DESCRIPTION
This stops the program crashing when opening certain programs in the Terminal widget.