### PR TITLE
Fixed issue with Unicode characters in ProgressBar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,11 @@ install:
   - "pip install setuptools"
   - if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install "twisted<=15.4"; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '2.7_with_system_site_packages' ]]; then pip install "twisted==16.6.0"; fi
-  - "[ $TRAVIS_PYTHON_VERSION == '3.2_with_system_site_packages' ] && pip install 'tornado<=4.3.0' || pip install twisted tornado"
+  - "[ $TRAVIS_PYTHON_VERSION == '3.4_with_system_site_packages' ] && pip install 'tornado<=4.3.0' || pip install twisted tornado"
 script:
   - "DEPS=\"$TRAVIS_PYTHON_VERSION `python bin/deps.py`\"; echo $DEPS"
   - "[ \"$DEPS\" == '2.7_with_system_site_packages pygobject tornado twisted' -o
-       \"$DEPS\" == '3.2_with_system_site_packages pygobject tornado' -o
+       \"$DEPS\" == '3.4_with_system_site_packages pygobject tornado' -o
        \"$DEPS\" == '3.3 tornado twisted' -o
        \"$DEPS\" == '3.4 tornado twisted' -o
        \"$DEPS\" == '3.5 tornado twisted' -o

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,12 @@ before_install:
 install:
   - "pip install setuptools"
   - if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install "twisted<=15.4"; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.7_with_system_site_packages' ]]; then pip install "twisted==16.6.0"; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.7_with_system_site_packages' -o $TRAVIS_PYTHON_VERSION == '3.2' ]]; then pip install "twisted==16.6.0"; fi
   - "[ $TRAVIS_PYTHON_VERSION == '3.2' ] && pip install 'tornado<=4.3.0' || pip install twisted tornado"
 script:
   - "DEPS=\"$TRAVIS_PYTHON_VERSION `python bin/deps.py`\"; echo $DEPS"
   - "[ \"$DEPS\" == '2.7_with_system_site_packages pygobject tornado twisted' -o
-       \"$DEPS\" == '3.2 pygobject tornado' -o
+       \"$DEPS\" == '3.2 tornado twisted' -o
        \"$DEPS\" == '3.3 tornado twisted' -o
        \"$DEPS\" == '3.4 tornado twisted' -o
        \"$DEPS\" == '3.5 tornado twisted' -o

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
 install:
   - "pip install setuptools"
   - if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install "twisted<=15.4"; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.7_with_system_site_packages' -o $TRAVIS_PYTHON_VERSION == '3.2' ]]; then pip install "twisted==16.6.0"; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.7_with_system_site_packages' ]] || [[ $TRAVIS_PYTHON_VERSION == '3.2' ]]; then pip install "twisted==16.6.0"; fi
   - "[ $TRAVIS_PYTHON_VERSION == '3.2' ] && pip install 'tornado<=4.3.0' || pip install twisted tornado"
 script:
   - "DEPS=\"$TRAVIS_PYTHON_VERSION `python bin/deps.py`\"; echo $DEPS"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   - "pip install setuptools"
   - if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install "twisted<=15.4"; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '2.7_with_system_site_packages' ]] || [[ $TRAVIS_PYTHON_VERSION == '3.2' ]]; then pip install "twisted==16.6.0"; fi
-  - "[ $TRAVIS_PYTHON_VERSION == '3.2' ] && pip install 'tornado<=4.3.0' || pip install twisted tornado"
+  - "[ $TRAVIS_PYTHON_VERSION == '3.2' ] && pip install 'tornado<=4.3.0' twisted || pip install twisted tornado"
 script:
   - "DEPS=\"$TRAVIS_PYTHON_VERSION `python bin/deps.py`\"; echo $DEPS"
   - "[ \"$DEPS\" == '2.7_with_system_site_packages pygobject tornado twisted' -o

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
   - "2.7_with_system_site_packages"
-  - "3.4_with_system_site_packages"
+  - "3.2"
   - "3.3"
   - "3.4"
   - "3.5"
@@ -14,11 +14,11 @@ install:
   - "pip install setuptools"
   - if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install "twisted<=15.4"; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '2.7_with_system_site_packages' ]]; then pip install "twisted==16.6.0"; fi
-  - "[ $TRAVIS_PYTHON_VERSION == '3.4_with_system_site_packages' ] && pip install 'tornado<=4.3.0' || pip install twisted tornado"
+  - "[ $TRAVIS_PYTHON_VERSION == '3.2' ] && pip install 'tornado<=4.3.0' || pip install twisted tornado"
 script:
   - "DEPS=\"$TRAVIS_PYTHON_VERSION `python bin/deps.py`\"; echo $DEPS"
   - "[ \"$DEPS\" == '2.7_with_system_site_packages pygobject tornado twisted' -o
-       \"$DEPS\" == '3.4_with_system_site_packages pygobject tornado' -o
+       \"$DEPS\" == '3.2 pygobject tornado' -o
        \"$DEPS\" == '3.3 tornado twisted' -o
        \"$DEPS\" == '3.4 tornado twisted' -o
        \"$DEPS\" == '3.5 tornado twisted' -o

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,8 @@ before_install:
   - "sudo apt-get update"
   - "sudo apt-get install python-gi python3-gi"
 install:
-  - "pip install setuptools twisted tornado"
-  - if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install "twisted<=15.4"; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '2.7_with_system_site_packages' ]]; then pip install "twisted==16.6.0"; fi
+  - "pip install setuptools twisted tornado"
 script:
   - "DEPS=\"$TRAVIS_PYTHON_VERSION `python bin/deps.py`\"; echo $DEPS"
   - "[ \"$DEPS\" == '2.7_with_system_site_packages pygobject tornado twisted' -o

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - "sudo apt-get update"
   - "sudo apt-get install python-gi python3-gi"
 install:
-  - "pip install setuptools"
+  - "pip install setuptools twisted tornado"
   - if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install "twisted<=15.4"; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '2.7_with_system_site_packages' ]]; then pip install "twisted==16.6.0"; fi
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7_with_system_site_packages"
-  - "3.2"
   - "3.3"
   - "3.4"
   - "3.5"
@@ -13,12 +12,10 @@ before_install:
 install:
   - "pip install setuptools"
   - if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install "twisted<=15.4"; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.7_with_system_site_packages' ]] || [[ $TRAVIS_PYTHON_VERSION == '3.2' ]]; then pip install "twisted==16.6.0"; fi
-  - "[ $TRAVIS_PYTHON_VERSION == '3.2' ] && pip install 'tornado<=4.3.0' twisted || pip install twisted tornado"
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.7_with_system_site_packages' ]]; then pip install "twisted==16.6.0"; fi
 script:
   - "DEPS=\"$TRAVIS_PYTHON_VERSION `python bin/deps.py`\"; echo $DEPS"
   - "[ \"$DEPS\" == '2.7_with_system_site_packages pygobject tornado twisted' -o
-       \"$DEPS\" == '3.2 tornado twisted' -o
        \"$DEPS\" == '3.3 tornado twisted' -o
        \"$DEPS\" == '3.4 tornado twisted' -o
        \"$DEPS\" == '3.5 tornado twisted' -o

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
   - "2.7_with_system_site_packages"
-  - "3.2_with_system_site_packages"
+  - "3.4_with_system_site_packages"
   - "3.3"
   - "3.4"
   - "3.5"

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup_d = {
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: Implementation :: PyPy",
         ],
      }

--- a/urwid/graphics.py
+++ b/urwid/graphics.py
@@ -853,7 +853,12 @@ class ProgressBar(Widget):
         c = txt.render((maxcol,))
 
         cf = float(self.current) * maxcol / self.done
-        ccol = int(cf)
+        ccol_dirty = int(cf)
+        ccol = len(c._text[0][:ccol_dirty].decode(
+            'utf-8', 'ignore'
+        ).encode(
+            'utf-8'
+        ))
         cs = 0
         if self.satt is not None:
             cs = int((cf - ccol) * 8)

--- a/urwid/graphics.py
+++ b/urwid/graphics.py
@@ -840,6 +840,7 @@ class ProgressBar(Widget):
     def get_text(self):
         """
         Return the progress bar percentage text.
+        You can override this method to display custom text.
         """
         percent = min(100, max(0, int(self.current * 100 / self.done)))
         return str(percent) + " %"


### PR DESCRIPTION
This commit fixes issues related to Unicode characters in `ProgressBar.get_text` method if overridden.

The problem was that `ProgressBar` tries to insert control characters into bytestring which may lead to the breaking of escape sequences.

For example:
- Char `▶` (`\u25B6`) is encoded into bytestring `'\xe2\x96\xb6'`
- At some point ProgressBar will attempt to split `\xe2` and `\x96` and insert ANSI escape sequence `\x1b[0m` between them to reset the color of the ProgressBar.
- Resulting bytestring will be `\xe2\x1b[0m\x96\xb6` which when decoded will result in `UnicodeDecodeError: [...] invalid continuation byte`

My solution is to slice the original string until the splitting position, encode it into bytes with "ignore" option (to throw away the broken escape sequences) and then decode it back to Unicode string. The resulting string length can be used as a safe position for splitting. This method has a slight overhead, but is very portable and shouldn't provide any significant overhead because ProgressBar content text is usually very short.

Tested in Python 2 and Python 3 with original & extended `ProgressBar.get_text` method.
