### PR TITLE
Fix underlining padded text

### DIFF
--- a/urwid/raw_display.py
+++ b/urwid/raw_display.py
@@ -787,7 +787,7 @@ class Screen(BaseScreen, RealTerminal):
                 if (run[-1:] == B(' ') and self.back_color_erase
                         and not using_standout(a)):
                     whitespace_at_end = True
-                    row = row[:-1] + [(a, cs, run.rstrip(B(' ')))]
+                    row = row[:-1] + [(a, cs, run)]
                 elif y == maxrow-1 and maxcol > 1:
                     row, back, ins = self._last_row(row)
 

--- a/urwid/raw_display.py
+++ b/urwid/raw_display.py
@@ -750,9 +750,9 @@ class Screen(BaseScreen, RealTerminal):
             return self._attrspec_to_escape(
                 AttrSpec('default','default'))
 
-        def using_standout(a):
+        def using_standout_or_underline(a):
             a = self._pal_attrspec.get(a, a)
-            return isinstance(a, AttrSpec) and a.standout
+            return isinstance(a, AttrSpec) and (a.standout or a.underline)
 
         ins = None
         o.append(set_cursor_home())
@@ -785,9 +785,9 @@ class Screen(BaseScreen, RealTerminal):
             if row:
                 a, cs, run = row[-1]
                 if (run[-1:] == B(' ') and self.back_color_erase
-                        and not using_standout(a)):
+                        and not using_standout_or_underline(a)):
                     whitespace_at_end = True
-                    row = row[:-1] + [(a, cs, run)]
+                    row = row[:-1] + [(a, cs, run.rstrip(B(' ')))]
                 elif y == maxrow-1 and maxcol > 1:
                     row, back, ins = self._last_row(row)
 


### PR DESCRIPTION
##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
When underlining text that ends with spaces, it is only underlined to where the spaces start. This fixes that so the spaces are also underlined.

This demonstrates the issue:

```python
palette = [('deco', 'underline,black', 'yellow')]
txt = urwid.Text('Hello', align='center')
fill = urwid.Filler(urwid.AttrMap(txt, 'deco'))
loop = urwid.MainLoop(fill, palette)
loop.run()
```

Note how the whole line is yellow, but only underlined up to the first space after "Hello".