### PR TITLE
Python33 twisted bug 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ matrix:
     env: TOXENV=py35
   - python: 3.6
     env: TOXENV=py36
+  - python: pypy
+    env: TOXENV=pypy
 before_install:
   - "sudo apt-get update"
   - "sudo apt-get install python-gi python3-gi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ matrix:
     env: TOXENV=py35
   - python: 3.6
     env: TOXENV=py36
-  - python: pypy
-    env: TOXENV=pypy
 before_install:
   - "sudo apt-get update"
   - "sudo apt-get install python-gi python3-gi"

--- a/urwid/tests/test_event_loops.py
+++ b/urwid/tests/test_event_loops.py
@@ -119,15 +119,20 @@ else:
             rd, wr = os.pipe()
             self.assertEqual(os.write(wr, "data".encode('ascii')), 4)
             def step2():
+                print('step2()')
                 out.append(os.read(rd, 2).decode('ascii'))
             def say_hello():
+                print('say_hello()')
                 out.append("hello")
             def say_waiting():
+                print('say_waiting()')
                 out.append("waiting")
             def exit_clean():
+                print('exit_clean()')
                 out.append("clean exit")
                 raise urwid.ExitMainLoop
             def exit_error():
+                print('exit_error()')
                 1/0
             handle = evl.watch_file(rd, step2)
             handle = evl.alarm(0.01, exit_clean)

--- a/urwid/tests/test_event_loops.py
+++ b/urwid/tests/test_event_loops.py
@@ -119,24 +119,19 @@ else:
             rd, wr = os.pipe()
             self.assertEqual(os.write(wr, "data".encode('ascii')), 4)
             def step2():
-                print('step2()')
                 out.append(os.read(rd, 2).decode('ascii'))
             def say_hello():
-                print('say_hello()')
                 out.append("hello")
             def say_waiting():
-                print('say_waiting()')
                 out.append("waiting")
             def exit_clean():
-                print('exit_clean()')
                 out.append("clean exit")
                 raise urwid.ExitMainLoop
             def exit_error():
-                print('exit_error()')
                 1/0
             handle = evl.watch_file(rd, step2)
-            handle = evl.alarm(0.01, exit_clean)
-            handle = evl.alarm(0.005, say_hello)
+            handle = evl.alarm(0.1, exit_clean)
+            handle = evl.alarm(0.05, say_hello)
             self.assertEqual(evl.enter_idle(say_waiting), 1)
             evl.run()
             self.assertTrue("da" in out, out)


### PR DESCRIPTION
##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
Fixed timings for `TwistedEventLoop` that were leading to `enter_idle` skipping on Python 3.3.