### PR TITLE
Fix .with_traceback for Python 2.x and add tests to cover this (#275)

### DIFF
--- a/urwid/compat.py
+++ b/urwid/compat.py
@@ -44,6 +44,21 @@ if PYTHON3:
     text_type = str
     xrange = range
     text_types = (str,)
+
+    def reraise(tp, value, tb=None):
+        """
+        Reraise an exception.
+        Taken from "six" library (https://pythonhosted.org/six/).
+        """
+        try:
+            if value is None:
+                value = tp()
+            if value.__traceback__ is not tb:
+                raise value.with_traceback(tb)
+            raise value
+        finally:
+            value = None
+            tb = None
 else:
     ord2 = ord
     chr2 = chr
@@ -53,6 +68,28 @@ else:
     xrange = xrange
     text_types = (str, unicode)
 
+    """
+    Reraise an exception.
+    Taken from "six" library (https://pythonhosted.org/six/).
+    """
+    def exec_(_code_, _globs_=None, _locs_=None):
+        """Execute code in a namespace."""
+        if _globs_ is None:
+            frame = sys._getframe(1)
+            _globs_ = frame.f_globals
+            if _locs_ is None:
+                _locs_ = frame.f_locals
+            del frame
+        elif _locs_ is None:
+            _locs_ = _globs_
+        exec("""exec _code_ in _globs_, _locs_""")
+
+    exec_("""def reraise(tp, value, tb=None):
+    try:
+        raise tp, value, tb
+    finally:
+        tb = None
+""")
 
 def with_metaclass(meta, *bases):
     """

--- a/urwid/main_loop.py
+++ b/urwid/main_loop.py
@@ -38,7 +38,7 @@ except ImportError:
     pass # windows
 
 from urwid.util import StoppingContext, is_mouse_event
-from urwid.compat import PYTHON3
+from urwid.compat import PYTHON3, reraise
 from urwid.command_map import command_map, REDRAW_SCREEN
 from urwid.wimp import PopUpTarget
 from urwid import signals
@@ -673,7 +673,7 @@ class EventLoop(object):
         """
         Sets the signal handler for signal signum.
 
-        The default implementation of :meth:`set_signal_handler` 
+        The default implementation of :meth:`set_signal_handler`
         is simply a proxy function that calls :func:`signal.signal()`
         and returns the resulting value.
 
@@ -1002,7 +1002,7 @@ class GLibEventLoop(EventLoop):
             # An exception caused us to exit, raise it now
             exc_info = self._exc_info
             self._exc_info = None
-            raise exc_info[0](exc_info[1]).with_traceback(exc_info[2])
+            reraise(*exc_info)
 
     def handle_exit(self,f):
         """
@@ -1337,7 +1337,7 @@ class TwistedEventLoop(EventLoop):
             # An exception caused us to exit, raise it now
             exc_info = self._exc_info
             self._exc_info = None
-            raise exc_info[0](exc_info[1]).with_traceback(exc_info[2])
+            reraise(*exc_info)
 
     def handle_exit(self, f, enable_idle=True):
         """
@@ -1479,8 +1479,9 @@ class AsyncioEventLoop(EventLoop):
         self._loop.set_exception_handler(self._exception_handler)
         self._loop.run_forever()
         if self._exc_info:
-            raise self._exc_info[0](self._exc_info[1]).with_traceback(self._exc_info[2])
+            exc_info = self._exc_info
             self._exc_info = None
+            reraise(*exc_info)
 
 
 def _refl(name, rval=None, exit=False):

--- a/urwid/tests/test_event_loops.py
+++ b/urwid/tests/test_event_loops.py
@@ -88,6 +88,11 @@ else:
         def setUp(self):
             self.evl = urwid.GLibEventLoop()
 
+        def test_error(self):
+            evl = self.evl
+            evl.alarm(0.5, lambda: 1 / 0)  # Simulate error in event loop
+            self.assertRaises(ZeroDivisionError, evl.run)
+
 
 try:
     import tornado
@@ -139,6 +144,10 @@ else:
             self.assertTrue("hello" in out, out)
             self.assertTrue("clean exit" in out, out)
 
+        def test_error(self):
+            evl = self.evl
+            evl.alarm(0.5, lambda: 1 / 0)  # Simulate error in event loop
+            self.assertRaises(ZeroDivisionError, evl.run)
 
 try:
     import asyncio
@@ -150,3 +159,8 @@ else:
             self.evl = urwid.AsyncioEventLoop()
 
         _expected_idle_handle = None
+
+        def test_error(self):
+            evl = self.evl
+            evl.alarm(0.5, lambda: 1 / 0)  # Simulate error in event loop
+            self.assertRaises(ZeroDivisionError, evl.run)


### PR DESCRIPTION
##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
Uses `reraise` function from "six". Fixes #275.