### PR TITLE
extended numerical editing: integers and floats

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,3 +77,4 @@ Contributors
 - `grugq <//github.com/grugq>`_
 - `inducer <//github.com/inducer>`_
 - `winbornejw <//github.com/winbornejw>`_
+- `hootnot <//github.com/hootnot>`_

--- a/docs/reference/widget.rst
+++ b/docs/reference/widget.rst
@@ -68,6 +68,25 @@ TreeWidget
 
 .. autoclass:: TreeWidget
 
+
+.. currentmodule:: urwid.numedit
+
+Extended Numerical Editing Classes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+IntegerEdit
+~~~~~~~~~~~
+
+.. autoclass:: IntegerEdit
+
+FloatEdit
+~~~~~~~~~~~
+
+.. autoclass:: FloatEdit
+
+
+.. currentmodule:: urwid
+
 SelectableIcon
 ~~~~~~~~~~~~~~
 

--- a/urwid/numedit.py
+++ b/urwid/numedit.py
@@ -1,0 +1,230 @@
+# -*- coding: utf-8 -*-
+#
+# Urwid basic widget classes
+#    Copyright (C) 2004-2012  Ian Ward
+#
+#    This library is free software; you can redistribute it and/or
+#    modify it under the terms of the GNU Lesser General Public
+#    License as published by the Free Software Foundation; either
+#    version 2.1 of the License, or (at your option) any later version.
+#
+#    This library is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#    Lesser General Public License for more details.
+#
+#    You should have received a copy of the GNU Lesser General Public
+#    License along with this library; if not, write to the Free Software
+#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+# Urwid web site: http://excess.org/urwid/
+
+
+from urwid import Edit
+from decimal import Decimal
+
+
+class NumEdit(Edit):
+    """NumEdit - edit numerical types
+
+    based on the characters in 'allowed' different numerical types
+    can be edited:
+      + regular int: 0123456789
+      + regular float: 0123456789.
+      + regular oct: 01234567
+      + regular hex: 0123456789abcdef
+    """
+
+    def __init__(self, allowed, caption, default):
+        super(NumEdit, self).__init__(caption, default)
+        self._allowed = allowed
+
+    def valid_char(self, ch):
+        """
+        Return true for decimal digits.
+        """
+        return len(ch) == 1 and ch in self._allowed
+
+    def keypress(self, size, key):
+        """
+        Handle editing keystrokes.  Remove leading zeros.
+
+        >>> e, size = NumEdit("0123456789", u"", "5002"), (10,)
+        >>> e.keypress(size, 'home')
+        >>> e.keypress(size, 'delete')
+        >>> assert e.edit_text == "002"
+        >>> e.keypress(size, 'end')
+        >>> assert e.edit_text == "2"
+        >>> # binary only
+        >>> e, size = NumEdit("01", u"", ""), (10,)
+        >>> assert e.edit_text == ""
+        >>> e.keypress(size, '1')
+        >>> e.keypress(size, '0')
+        >>> e.keypress(size, '1')
+        >>> assert e.edit_text == "101"
+        """
+        (maxcol,) = size
+        unhandled = Edit.keypress(self, (maxcol,), key)
+
+        if not unhandled:
+            # trim leading zeros
+            while self.edit_pos > 0 and self.edit_text[:1] == "0":
+                self.set_edit_pos(self.edit_pos - 1)
+                self.set_edit_text(self.edit_text[1:])
+
+        return unhandled
+
+
+class IntegerEdit(NumEdit):
+    """Edit widget for integer values"""
+
+    ALLOWED = "0123456789"
+
+    def __init__(self, caption="", default=None):
+        """
+        caption -- caption markup
+        default -- default edit value
+
+        >>> IntegerEdit(u"", 42)
+        <IntegerEdit selectable flow widget '42' edit_pos=2>
+        >>> e, size = IntegerEdit(u"", "5002"), (10,)
+        >>> e.keypress(size, 'home')
+        >>> e.keypress(size, 'delete')
+        >>> assert e.edit_text == "002"
+        >>> e.keypress(size, 'end')
+        >>> assert e.edit_text == "2"
+        >>> e.keypress(size, '9')
+        >>> e.keypress(size, '0')
+        >>> assert e.edit_text == "290"
+        """
+        val = ""
+        if default is not None:
+            if not isinstance(default, (int, long, str, Decimal)):
+                raise ValueError("default: Only 'str', 'int', "
+                                 "'long' or Decimal input allowed")
+
+            # convert to a long first, this will raise a ValueError
+            # in case a float is passed or some other error
+            if isinstance(default, str) and len(default):
+                # check if it is a float, raises a ValueError otherwise
+                long(default)
+
+            elif isinstance(default, Decimal):
+                # a Decimal instance with no fractional part
+                if default.as_tuple()[2] != 0:
+                    raise ValueError("not an 'integer Decimal' instance")
+
+            # convert possible int, long or Decimal to str
+            val = str(default)
+
+        super(IntegerEdit, self).__init__(self.ALLOWED, caption, val)
+
+    def value(self):
+        """
+        Return the numeric value of self.edit_text.
+
+        >>> e, size = IntegerEdit(), (10,)
+        >>> e.keypress(size, '5')
+        >>> e.keypress(size, '1')
+        >>> assert e.value() == 51
+        """
+        if self.edit_text:
+            return Decimal(self.edit_text)
+
+        return None
+
+
+class FloatEdit(NumEdit):
+    """Edit widget for float values."""
+
+    ALLOWED = "0123456789"
+
+    def __init__(self, caption="", default=None,
+                 preserveSignificance=True, decimalSeparator='.'):
+        """
+        caption -- caption markup
+        default -- default edit value
+        preserveSignificance -- return value has the same signif. as default
+        decimalSeparator -- use '.' as separator by default, optionally a ','
+
+        >>> FloatEdit(u"",  "1.065434")
+        <FloatEdit selectable flow widget '1.065434' edit_pos=8>
+        >>> e, size = FloatEdit(u"", "1.065434"), (10,)
+        >>> e.keypress(size, 'home')
+        >>> e.keypress(size, 'delete')
+        >>> assert e.edit_text == ".065434"
+        >>> e.keypress(size, 'end')
+        >>> e.keypress(size, 'backspace')
+        >>> assert e.edit_text == ".06543"
+        >>> e, size = FloatEdit(), (10,)
+        >>> e.keypress(size, '5')
+        >>> e.keypress(size, '1')
+        >>> e.keypress(size, '.')
+        >>> e.keypress(size, '5')
+        >>> e.keypress(size, '1')
+        >>> assert e.value() == Decimal("51.51")
+        >>> e, size = FloatEdit(decimalSeparator=","), (10,)
+        >>> e.keypress(size, '5')
+        >>> e.keypress(size, '1')
+        >>> e.keypress(size, ',')
+        >>> e.keypress(size, '5')
+        >>> e.keypress(size, '1')
+        >>> assert e.edit_text == "51,51"
+        >>> e, size = FloatEdit("", "3.1415", preserveSignificance=True), (10,)
+        >>> e.keypress(size, 'end')
+        >>> e.keypress(size, 'backspace')
+        >>> e.keypress(size, 'backspace')
+        >>> assert e.edit_text == "3.14"
+        >>> assert e.value() == Decimal("3.1400")
+        >>> e, size = FloatEdit("", ""), (10,)
+        >>> assert e.value() is None
+        """
+        self.significance = None
+        self._decimalSeparator = decimalSeparator
+        if decimalSeparator not in ['.', ',']:
+            raise ValueError("invalid decimalSeparator: {}".format(
+                             decimalSeparator))
+
+        val = ""
+        if default is not None and default is not "":
+            if not isinstance(default, (int, long, str, Decimal)):
+                raise ValueError("default: Only 'str', 'int', "
+                                 "'long' or Decimal input allowed")
+
+            if isinstance(default, str) and len(default):
+                # check if it is a float, raises a ValueError otherwise
+                float(default)
+                default = Decimal(default)
+
+            if preserveSignificance:
+                self.significance = abs(default.as_tuple()[2])
+
+            val = str(default)
+
+        super(FloatEdit, self).__init__(self.ALLOWED + decimalSeparator,
+                                        caption, val)
+
+    def value(self):
+        """
+        Return the numeric value of self.edit_text.
+        """
+        if self.edit_text:
+            # integer part (before .) and fractional part (after .)
+            fmt = "{ip}.{fp}"
+            if self.significance:
+                # in case of preserved significance, construct the
+                # format string to fill with trailing 0
+                fmt = "{{ip}}.{{fp:<0{sig}d}}".format(sig=self.significance)
+
+            # get the ip and fp, handles also the case that there is no '.'
+            ip, fp = ([v for v in
+                      self.edit_text.split(self._decimalSeparator)] + [0])[0:2]
+
+            # in case the fp part surpasses the significance we round it
+            if self.significance and len(str(fp)) > self.significance:
+                fp = float(fp) / 10**(len(str(fp)) - self.significance)
+                fp = int(round(fp))
+
+            return Decimal(fmt.format(ip=ip, fp=int(fp)))
+
+        return None

--- a/urwid/numedit.py
+++ b/urwid/numedit.py
@@ -34,6 +34,7 @@ class NumEdit(Edit):
       + regular oct: 01234567
       + regular hex: 0123456789abcdef
     """
+    ALLOWED = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
     def __init__(self, allowed, caption, default):
         super(NumEdit, self).__init__(caption, default)
@@ -78,9 +79,7 @@ class NumEdit(Edit):
 class IntegerEdit(NumEdit):
     """Edit widget for integer values"""
 
-    ALLOWED = "0123456789"
-
-    def __init__(self, caption="", default=None):
+    def __init__(self, caption="", default=None, base=10):
         """
         caption -- caption markup
         default -- default edit value
@@ -96,6 +95,16 @@ class IntegerEdit(NumEdit):
         >>> e.keypress(size, '9')
         >>> e.keypress(size, '0')
         >>> assert e.edit_text == "290"
+        >>> # binary
+        >>> e, size = IntegerEdit(u"", "1010", base=2), (10,)
+        >>> e.keypress(size, 'end')
+        >>> e.keypress(size, '1')
+        >>> # HEX
+        >>> e, size = IntegerEdit(u"", "10", base=16), (10,)
+        >>> e.keypress(size, 'end')
+        >>> e.keypress(size, 'F')
+        >>> e.keypress(size, 'F')
+        >>> assert e.edit_text == "10FF"
         """
         val = ""
         if default is not None:
@@ -117,7 +126,7 @@ class IntegerEdit(NumEdit):
             # convert possible int, long or Decimal to str
             val = str(default)
 
-        super(IntegerEdit, self).__init__(self.ALLOWED, caption, val)
+        super(IntegerEdit, self).__init__(self.ALLOWED[:base], caption, val)
 
     def value(self):
         """
@@ -136,8 +145,6 @@ class IntegerEdit(NumEdit):
 
 class FloatEdit(NumEdit):
     """Edit widget for float values."""
-
-    ALLOWED = "0123456789"
 
     def __init__(self, caption="", default=None,
                  preserveSignificance=True, decimalSeparator='.'):
@@ -201,7 +208,7 @@ class FloatEdit(NumEdit):
 
             val = str(default)
 
-        super(FloatEdit, self).__init__(self.ALLOWED + decimalSeparator,
+        super(FloatEdit, self).__init__(self.ALLOWED[0:10] + decimalSeparator,
                                         caption, val)
 
     def value(self):

--- a/urwid/numedit.py
+++ b/urwid/numedit.py
@@ -104,6 +104,8 @@ class IntegerEdit(NumEdit):
         >>> e, size = IntegerEdit(u"", "1010", base=2), (10,)
         >>> e.keypress(size, 'end')
         >>> e.keypress(size, '1')
+        >>> assert e.edit_text == "10101"
+        >>> assert e.value() == Decimal("21")
         >>> # HEX
         >>> e, size = IntegerEdit(u"", "10", base=16), (10,)
         >>> e.keypress(size, 'end')
@@ -115,6 +117,7 @@ class IntegerEdit(NumEdit):
         >>> # keep leading 0's when not base 10
         >>> e, size = IntegerEdit(u"", "10FF", base=16), (10,)
         >>> assert e.edit_text == "10FF"
+        >>> assert e.value() == Decimal("4351")
         >>> e.keypress(size, 'home')
         >>> e.keypress(size, 'delete')
         >>> e.keypress(size, '0')
@@ -134,8 +137,9 @@ class IntegerEdit(NumEdit):
             ...
         ValueError: not an 'integer Decimal' instance
         """
+        self.base = base
         val = ""
-        allowed_chars = self.ALLOWED[:base]
+        allowed_chars = self.ALLOWED[:self.base]
         if default is not None:
             if not isinstance(default, (int, str, Decimal)):
                 raise ValueError("default: Only 'str', 'int', "
@@ -159,7 +163,7 @@ class IntegerEdit(NumEdit):
             val = str(default)
 
         super(IntegerEdit, self).__init__(allowed_chars, caption, val,
-                                          trimLeadingZeros=(base == 10))
+                                          trimLeadingZeros=(self.base == 10))
 
     def value(self):
         """
@@ -171,7 +175,7 @@ class IntegerEdit(NumEdit):
         >>> assert e.value() == 51
         """
         if self.edit_text:
-            return Decimal(self.edit_text)
+            return Decimal(int(self.edit_text, self.base))
 
         return None
 

--- a/urwid/numedit.py
+++ b/urwid/numedit.py
@@ -99,7 +99,7 @@ class IntegerEdit(NumEdit):
         """
         val = ""
         if default is not None:
-            if not isinstance(default, (int, long, str, Decimal)):
+            if not isinstance(default, (int, str, Decimal)):
                 raise ValueError("default: Only 'str', 'int', "
                                  "'long' or Decimal input allowed")
 
@@ -107,7 +107,7 @@ class IntegerEdit(NumEdit):
             # in case a float is passed or some other error
             if isinstance(default, str) and len(default):
                 # check if it is a float, raises a ValueError otherwise
-                long(default)
+                int(default)
 
             elif isinstance(default, Decimal):
                 # a Decimal instance with no fractional part
@@ -187,7 +187,7 @@ class FloatEdit(NumEdit):
 
         val = ""
         if default is not None and default is not "":
-            if not isinstance(default, (int, long, str, Decimal)):
+            if not isinstance(default, (int, str, Decimal)):
                 raise ValueError("default: Only 'str', 'int', "
                                  "'long' or Decimal input allowed")
 

--- a/urwid/numedit.py
+++ b/urwid/numedit.py
@@ -95,6 +95,8 @@ class IntegerEdit(NumEdit):
         >>> e.keypress(size, '9')
         >>> e.keypress(size, '0')
         >>> assert e.edit_text == "290"
+        >>> e, size = IntegerEdit("", ""), (10,)
+        >>> assert e.value() is None
         >>> # binary
         >>> e, size = IntegerEdit(u"", "1010", base=2), (10,)
         >>> e.keypress(size, 'end')
@@ -105,6 +107,16 @@ class IntegerEdit(NumEdit):
         >>> e.keypress(size, 'F')
         >>> e.keypress(size, 'F')
         >>> assert e.edit_text == "10FF"
+        >>> assert e.keypress(size, 'G') == 'G'  # unhandled key
+        >>> assert e.edit_text == "10FF"
+        >>> e, size = IntegerEdit(u"", 10.0), (10,)
+        Traceback (most recent call last):
+            ...
+        ValueError: default: Only 'str', 'int', 'long' or Decimal input allowed
+        >>> e, size = IntegerEdit(u"", Decimal("10.0")), (10,)
+        Traceback (most recent call last):
+            ...
+        ValueError: not an 'integer Decimal' instance
         """
         val = ""
         if default is not None:
@@ -170,6 +182,10 @@ class FloatEdit(NumEdit):
         >>> e.keypress(size, '5')
         >>> e.keypress(size, '1')
         >>> assert e.value() == Decimal("51.51")
+        >>> e, size = FloatEdit(decimalSeparator=":"), (10,)
+        Traceback (most recent call last):
+            ...
+        ValueError: invalid decimalSeparator: :
         >>> e, size = FloatEdit(decimalSeparator=","), (10,)
         >>> e.keypress(size, '5')
         >>> e.keypress(size, '1')
@@ -183,8 +199,16 @@ class FloatEdit(NumEdit):
         >>> e.keypress(size, 'backspace')
         >>> assert e.edit_text == "3.14"
         >>> assert e.value() == Decimal("3.1400")
+        >>> e.keypress(size, '1')
+        >>> e.keypress(size, '5')
+        >>> e.keypress(size, '9')
+        >>> assert e.value() == Decimal("3.1416")
         >>> e, size = FloatEdit("", ""), (10,)
         >>> assert e.value() is None
+        >>> e, size = FloatEdit(u"", 10.0), (10,)
+        Traceback (most recent call last):
+            ...
+        ValueError: default: Only 'str', 'int', 'long' or Decimal input allowed
         """
         self.significance = None
         self._decimalSeparator = decimalSeparator

--- a/urwid/numedit.py
+++ b/urwid/numedit.py
@@ -42,9 +42,9 @@ class NumEdit(Edit):
 
     def valid_char(self, ch):
         """
-        Return true for decimal digits.
+        Return true for allowed characters.
         """
-        return len(ch) == 1 and ch in self._allowed
+        return len(ch) == 1 and ch.upper() in self._allowed
 
     def keypress(self, size, key):
         """
@@ -105,10 +105,10 @@ class IntegerEdit(NumEdit):
         >>> e, size = IntegerEdit(u"", "10", base=16), (10,)
         >>> e.keypress(size, 'end')
         >>> e.keypress(size, 'F')
-        >>> e.keypress(size, 'F')
-        >>> assert e.edit_text == "10FF"
+        >>> e.keypress(size, 'f')
+        >>> assert e.edit_text == "10Ff"
         >>> assert e.keypress(size, 'G') == 'G'  # unhandled key
-        >>> assert e.edit_text == "10FF"
+        >>> assert e.edit_text == "10Ff"
         >>> e, size = IntegerEdit(u"", 10.0), (10,)
         Traceback (most recent call last):
             ...

--- a/urwid/numedit.py
+++ b/urwid/numedit.py
@@ -119,6 +119,12 @@ class IntegerEdit(NumEdit):
         >>> e.keypress(size, 'delete')
         >>> e.keypress(size, '0')
         >>> assert e.edit_text == "00FF"
+        >>> # test exception on incompatable value for base
+        >>> e, size = IntegerEdit(u"", "10FG", base=16), (10,)
+        Traceback (most recent call last):
+            ...
+        ValueError: invalid value: 10FG for base 16
+        >>> # test exception on float init value
         >>> e, size = IntegerEdit(u"", 10.0), (10,)
         Traceback (most recent call last):
             ...

--- a/urwid/tests/test_doctests.py
+++ b/urwid/tests/test_doctests.py
@@ -2,6 +2,7 @@ import unittest
 import doctest
 
 import urwid
+import urwid.numedit
 
 def load_tests(loader, tests, ignore):
     module_doctests = [
@@ -10,6 +11,7 @@ def load_tests(loader, tests, ignore):
         urwid.decoration,
         urwid.display_common,
         urwid.main_loop,
+        urwid.numedit,
         urwid.monitored_list,
         urwid.raw_display,
         'urwid.split_repr', # override function with same name


### PR DESCRIPTION
##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
See: #213 , changes implemented as proposed

  + only *Decimal* is returned, it is up to the user to perform other conversions from the return value if needed
  + input can be *str* or *Decimal*. Checks are performed on the input to check if it is a valid numerical value. If *float()* conversion fails it raises a ValueError
  + the *value()* raises a ValueError in case the default was None and the user did not edit the value. Currently 0 is returned (as IntEdit does) which is definitely not a correct value
  + a parameter *preserveSignificance=True* is added. If the initial value of 1234.0000 is passed and the user edits the 0-'os away to 1234. then the value will still get returned as 1234.0000

In a  new module *urwid.numedit*  you find the classes *IntegerEdit* and *FloatEdit*, *PEP8* compliant.
A few changes on the list above:
  +  regarding:  input can be *str* or *Decimal*:  integer values are allowed too
  +  the *value()* method raises a ValueError in case the default was None and the user did not edit the value: the *value()* method returns None in that case, so no exception is raised

The existing *IntEdit* class is untouched. As discussed earlier, it's return value of 0 in case it is un-edited is not OK. I think it should be deprecated in favor of the new *IntegerEdit*.

Apply the patch below to examples/calc.py to use the *FloatEdit* class in the calculator example.

```
diff --git a/examples/calc.py b/examples/calc.py
index 39c37f7..f584cf1 100755
--- a/examples/calc.py
+++ b/examples/calc.py
@@ -36,6 +36,7 @@ from __future__ import print_function
 import urwid
 import urwid.raw_display
 import urwid.web_display
+import urwid.numedit as numedit
 
 # use appropriate Screen class
 if urwid.web_display.is_web_request():
@@ -135,7 +136,8 @@ class Cell:
     def setup_edit(self):
         """Create the standard edit widget for this cell."""
 
-        self.edit = urwid.IntEdit()
+        #self.edit = urwid.FloatEdit(decimalSeparator=",")
+        self.edit = numedit.FloatEdit()
         if not self.is_top:
             self.edit.set_caption( self.op + " " )
         self.edit.set_layout( None, None, CALC_LAYOUT )
@@ -146,7 +148,7 @@ class Cell:
         if self.child is not None:
             return self.child.get_result()
         else:
-            return int("0"+self.edit.edit_text)
+            return float("0"+self.edit.edit_text)
 
     def get_result(self):
         """Return the numeric result of this cell's operation."""
@@ -155,7 +157,7 @@ class Cell:
             return self.get_value()
         if self.result.text == "":
             return None
-        return int(self.result.text)
+        return float(self.result.text)
 
     def set_result(self, result):
         """Set the numeric result for this cell."""
@@ -163,7 +165,7 @@ class Cell:
         if result == None:
             self.result.set_text("")
         else:
-            self.result.set_text( "%d" %result )
+            self.result.set_text( "%.5f" %result )
```

