### PR TITLE
Re-raise coroutine exceptions in AsyncioEventLoop properly

### DIFF
--- a/urwid/main_loop.py
+++ b/urwid/main_loop.py
@@ -1470,10 +1470,7 @@ class AsyncioEventLoop(EventLoop):
             loop.stop()
             if not isinstance(exc, ExitMainLoop):
                 # Store the exc_info so we can re-raise after the loop stops
-                import sys
-                self._exc_info = sys.exc_info()
-                if self._exc_info == (None, None, None):
-                    self._exc_info = exc
+                self._exc_info = (type(exc), exc, None)
         else:
             loop.default_exception_handler(context)
 
@@ -1487,8 +1484,6 @@ class AsyncioEventLoop(EventLoop):
         if self._exc_info:
             exc_info = self._exc_info
             self._exc_info = None
-            if isinstance(exc_info, BaseException):
-                raise exc_info
             reraise(*exc_info)
 
 

--- a/urwid/main_loop.py
+++ b/urwid/main_loop.py
@@ -1468,6 +1468,8 @@ class AsyncioEventLoop(EventLoop):
                 # Store the exc_info so we can re-raise after the loop stops
                 import sys
                 self._exc_info = sys.exc_info()
+                if self._exc_info == (None,None,None):
+                    self._exc_info=exc
         else:
             loop.default_exception_handler(context)
 
@@ -1481,6 +1483,8 @@ class AsyncioEventLoop(EventLoop):
         if self._exc_info:
             exc_info = self._exc_info
             self._exc_info = None
+            if isinstance(exc_info, BaseException):
+                raise exc_info
             reraise(*exc_info)
 
 

--- a/urwid/main_loop.py
+++ b/urwid/main_loop.py
@@ -1468,8 +1468,8 @@ class AsyncioEventLoop(EventLoop):
                 # Store the exc_info so we can re-raise after the loop stops
                 import sys
                 self._exc_info = sys.exc_info()
-                if self._exc_info == (None,None,None):
-                    self._exc_info=exc
+                if self._exc_info == (None, None, None):
+                    self._exc_info = exc
         else:
             loop.default_exception_handler(context)
 

--- a/urwid/tests/test_event_loops.py
+++ b/urwid/tests/test_event_loops.py
@@ -164,3 +164,14 @@ else:
             evl = self.evl
             evl.alarm(0.5, lambda: 1 / 0)  # Simulate error in event loop
             self.assertRaises(ZeroDivisionError, evl.run)
+
+        def test_coroutine_error(self):
+            evl = self.evl
+
+            @asyncio.coroutine
+            def error_coro():
+                result = 1 / 0 # Simulate error in coroutine
+                yield result
+
+            asyncio.ensure_future(error_coro())
+            self.assertRaises(ZeroDivisionError, evl.run)


### PR DESCRIPTION
##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
Fixes #235 

Exceptions raised within `Futures` and `coroutines` are passed through [`AbstractEventLoop.call_exception_handler`](https://docs.python.org/3.6/library/asyncio-eventloop.html#asyncio.AbstractEventLoop.call_exception_handler), not in the context that `sys.exc_info` is aware of.

This implements the fix proposed by @aathan with a test case included.