### PR TITLE
Gate SIGWINCH behind GLib 2.54+

### DIFF
--- a/urwid/main_loop.py
+++ b/urwid/main_loop.py
@@ -888,8 +888,11 @@ class GLibEventLoop(EventLoop):
             signal.SIGTERM,
             signal.SIGUSR1,
             signal.SIGUSR2,
-            signal.SIGWINCH
         ]
+
+        # GLib supports SIGWINCH as of version 2.54.
+        if not self.GLib.check_version(2, 54, 0):
+            glib_signals.append(signal.SIGWINCH)
 
         if signum not in glib_signals:
             # The GLib event loop supports only the signals listed above


### PR DESCRIPTION
##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [N/A] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
Fixes compatibility with GLib versions less than 2.54 (Debian 9 defaults to 2.47). Otherwise, g_unix_signal_source_new assertion crashes the executable.

