### PR TITLE
[WIP] Trio event loop

### DIFF
--- a/bin/deps.py
+++ b/bin/deps.py
@@ -22,4 +22,10 @@ try:
 except ImportError:
     pass
 
+try:
+    import trio
+    deps.append("trio")
+except ImportError:
+    pass
+
 print(" ".join(deps))

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,19 @@ usedevelop = true
 deps =
     setuptools
     tornado
+    coverage
+    py27: twisted==16.6.0
+    py33: twisted
+    py34: twisted
+    py35: twisted
+    py36: twisted
+    pypy: twisted
+
+[testenv:py35]
+usedevelop = true
+deps =
+    setuptools
+    tornado
     trio
     coverage
     py27: twisted==16.6.0
@@ -20,6 +33,21 @@ deps =
     py35: twisted
     py36: twisted
     pypy: twisted
+
+[testenv:py36]
+usedevelop = true
+deps =
+    setuptools
+    tornado
+    trio
+    coverage
+    py27: twisted==16.6.0
+    py33: twisted
+    py34: twisted
+    py35: twisted
+    py36: twisted
+    pypy: twisted
+
 commands =
     coverage run ./setup.py test
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ usedevelop = true
 deps =
     setuptools
     tornado
+    trio
     coverage
     py27: twisted==16.6.0
     py33: twisted

--- a/urwid/__init__.py
+++ b/urwid/__init__.py
@@ -55,7 +55,7 @@ from urwid.command_map import (CommandMap, command_map,
     CURSOR_PAGE_UP, CURSOR_PAGE_DOWN, CURSOR_MAX_LEFT, CURSOR_MAX_RIGHT,
     ACTIVATE)
 from urwid.main_loop import (ExitMainLoop, MainLoop, SelectEventLoop,
-    GLibEventLoop, TornadoEventLoop, AsyncioEventLoop)
+    GLibEventLoop, TornadoEventLoop, AsyncioEventLoop, TrioEventLoop)
 try:
     from urwid.main_loop import TwistedEventLoop
 except ImportError:

--- a/urwid/_async_kw_main_loop.py
+++ b/urwid/_async_kw_main_loop.py
@@ -1,0 +1,172 @@
+#!/usr/bin/python
+#
+# Urwid main loop code using Python-3.5 features (Trio, Curio, etc)
+#    Copyright (C) 2018 Toshio Kuratomi
+#
+#    This library is free software; you can redistribute it and/or
+#    modify it under the terms of the GNU Lesser General Public
+#    License as published by the Free Software Foundation; either
+#    version 2.1 of the License, or (at your option) any later version.
+#
+#    This library is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#    Lesser General Public License for more details.
+#
+#    You should have received a copy of the GNU Lesser General Public
+#    License along with this library; if not, write to the Free Software
+#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+# Urwid web site: http://excess.org/urwid/
+
+from __future__ import division, print_function
+
+from .main_loop import EventLoop, ExitMainLoop
+
+
+try:
+    import trio
+except Exception:
+    trio = None
+
+
+class TrioEventLoop(EventLoop):
+    """
+    Event loop based on the ``trio`` module.
+
+    ``trio`` is an async library for Python 3.5 and later.
+    """
+    #_we_started_event_loop = False
+
+    _idle_emulation_delay = 1.0/256  # a short time (in seconds)
+
+    def __init__(self, nursery=None):
+        self.nursery = nursery
+        self._alarm_queue = []
+        self._watcher_queue = []
+        self._idle_queue = []
+
+    async def _trio_alarm(self, seconds, callback, cancel):
+        await trio.sleep(seconds)
+        if cancel.is_set():
+            return
+        callback()
+
+    def alarm(self, seconds, callback):
+        """
+        Call callback() a given time from now.  No parameters are
+        passed to callback.
+
+        Returns a handle that may be passed to remove_alarm()
+
+        seconds -- time in seconds to wait before calling callback
+        callback -- function to call from event loop
+        """
+        cancel = trio.Event()
+        if self.nursery:
+            self.nursery.start_soon(self._trio_alarm, seconds, callback, cancel)
+        else:
+            self._alarm_queue.append((seconds, callback, cancel))
+        return cancel
+
+    def remove_alarm(self, handle):
+        """
+        Remove an alarm.
+
+        Returns True if the alarm exists, False otherwise
+        """
+        # Alarm has already been scheduled to be removed or has exited
+        if handle.is_set():
+            return False
+
+        handle.set()
+        return True
+
+    async def _trio_watch_file(self, fd, callback, cancel):
+        while True:
+            await trio.hazmat.wait_readable(fd)
+            if cancel.is_set():
+                return
+            callback()
+
+    def watch_file(self, fd, callback):
+        """
+        Call callback() when fd has some data to read.  No parameters
+        are passed to callback.
+
+        Returns a handle that may be passed to remove_watch_file()
+
+        fd -- file descriptor to watch for input
+        callback -- function to call when input is available
+        """
+        cancel = trio.Event()
+        if self.nursery:
+            self.nursery.start_soon(self._trio_watch_file, fd, callback, cancel)
+        else:
+            self._watcher_queue.append((fd, callback, cancel))
+        return cancel
+
+    remove_watch_file = remove_alarm
+
+    def enter_idle(self, callback):
+        """
+        Add a callback for entering idle.
+
+        Returns a handle that may be passed to remove_idle()
+        """
+        # XXX there's no such thing as "idle" in most event loops; (scheduling a task with a lower
+        # priority than everything else)  this fakes it the same way as Twisted, by scheduling the
+        # callback to be called repeatedly
+        cancel = trio.Event()
+
+        def faux_idle_callback():
+            callback()
+            if self.nursery:
+                self.nursery.start_soon(self._trio_alarm, self._idle_emulation_delay, faux_idle_callback, cancel)
+            else:
+                self._alarm_queue.append((self._idle_emulation_delay, faux_idle_callback, cancel))
+
+        if self.nursery:
+            self.nursery.start_soon(self._trio_alarm, self._idle_emulation_delay, faux_idle_callback, cancel)
+        else:
+            self._alarm_queue.append((self._idle_emulation_delay, faux_idle_callback, cancel))
+        return cancel
+
+    remove_enter_idle = remove_alarm
+
+    def _register_queued_tasks(self):
+        for alarm in self._alarm_queue:
+            self.nursery.start_soon(self._trio_alarm, *alarm)
+        self._alarm_queue = []
+
+        for watcher in self._watcher_queue:
+            self.nursery.start_soon(self._trio_watch_file, *watcher)
+        self._watcher_queue = []
+
+        for idle in self._idle_queue:
+            self.nursery.start_soon(self._trio_idle, *idle)
+        self._idle_queue = []
+
+    async def _parent(self):
+        """
+        Create a nursery and register all of the tasks that were scheduled before trio initialized
+        """
+        if not self.nursery:
+            async with trio.open_nursery() as nursery:
+                self.nursery = nursery
+                self._register_queued_tasks()
+        else:
+            self._register_queued_tasks()
+
+    def run(self):
+        """
+        Start the event loop.  Exit the loop when any callback raises
+        an exception.  If ExitMainLoop is raised, exit cleanly.
+        """
+        if not self.nursery:
+            try:
+                trio.run(self._parent)
+            except ExitMainLoop:
+                pass
+            finally:
+                self.nursery = None

--- a/urwid/main_loop.py
+++ b/urwid/main_loop.py
@@ -1506,6 +1506,149 @@ class AsyncioEventLoop(EventLoop):
             reraise(*exc_info)
 
 
+try:
+    import trio
+except Exception:
+    trio = None
+
+
+class TrioEventLoop(EventLoop):
+    """
+    Event loop based on the ``trio`` module.
+
+    ``trio`` is an async library for Python 3.5 and later.
+    """
+    #_we_started_event_loop = False
+
+    _idle_emulation_delay = 1.0/256  # a short time (in seconds)
+
+    def __init__(self, nursery=None):
+        self.nursery = nursery
+        self._alarm_queue = []
+        self._watcher_queue = []
+        self._idle_queue = []
+
+    async def _trio_alarm(self, seconds, callback, cancel):
+        await trio.sleep(seconds)
+        if cancel.is_set():
+            return
+        callback()
+
+    def alarm(self, seconds, callback):
+        """
+        Call callback() a given time from now.  No parameters are
+        passed to callback.
+
+        Returns a handle that may be passed to remove_alarm()
+
+        seconds -- time in seconds to wait before calling callback
+        callback -- function to call from event loop
+        """
+        cancel = trio.Event()
+        if self.nursery:
+            self.nursery.start_soon(self._trio_alarm, seconds, callback, cancel)
+        else:
+            self._alarm_queue.append((seconds, callback, cancel))
+        return cancel
+
+    def remove_alarm(self, handle):
+        """
+        Remove an alarm.
+
+        Returns True if the alarm exists, False otherwise
+        """
+        # Alarm has already been scheduled to be removed or has exited
+        if handle.is_set():
+            return False
+
+        handle.set()
+        return True
+
+    async def _trio_watch_file(self, fd, callback, cancel):
+        while True:
+            await trio.hazmat.wait_readable(fd)
+            if cancel.is_set():
+                return
+            callback()
+
+    def watch_file(self, fd, callback):
+        """
+        Call callback() when fd has some data to read.  No parameters
+        are passed to callback.
+
+        Returns a handle that may be passed to remove_watch_file()
+
+        fd -- file descriptor to watch for input
+        callback -- function to call when input is available
+        """
+        cancel = trio.Event()
+        if self.nursery:
+            self.nursery.start_soon(self._trio_watch_file, fd, callback, cancel)
+        else:
+            self._watcher_queue.append((fd, callback, cancel))
+        return cancel
+
+    remove_watch_file = remove_alarm
+
+    def enter_idle(self, callback):
+        """
+        Add a callback for entering idle.
+
+        Returns a handle that may be passed to remove_idle()
+        """
+        # XXX there's no such thing as "idle" in most event loops; (scheduling a task with a lower
+        # priority than everything else)  this fakes it the same way as Twisted, by scheduling the
+        # callback to be called repeatedly
+        cancel = trio.Event()
+
+        def faux_idle_callback():
+            callback()
+            self.nursery.start_soon(self._trio_alarm, self._idle_emulation_delay, faux_idle_callback, cancel)
+
+        if self.nursery:
+            self.nursery.start_soon(self._trio_alarm, self._idle_emulation_delay, faux_idle_callback, cancel)
+        else:
+            self._alarm_queue.append((self._idle_emulation_delay, faux_idle_callback, cancel))
+        return cancel
+
+    remove_enter_idle = remove_alarm
+
+    def _register_queued_tasks(self):
+        for alarm in self._alarm_queue:
+            self.nursery.start_soon(self._trio_alarm, *alarm)
+        self._alarm_queue = []
+
+        for watcher in self._watcher_queue:
+            self.nursery.start_soon(self._trio_watch_file, *watcher)
+        self._watcher_queue = []
+
+        for idle in self._idle_queue:
+            self.nursery.start_soon(self._trio_idle, *idle)
+        self._idle_queue = []
+
+    async def _parent(self):
+        """
+        Create a nursery and register all of the tasks that were scheduled before trio initialized
+        """
+        if not self.nursery:
+            async with trio.open_nursery() as nursery:
+                self.nursery = nursery
+                self._register_queued_tasks()
+        else:
+            self._register_queued_tasks()
+
+    def run(self):
+        """
+        Start the event loop.  Exit the loop when any callback raises
+        an exception.  If ExitMainLoop is raised, exit cleanly.
+        """
+        if not self.nursery:
+            try:
+                trio.run(self._parent)
+            except ExitMainLoop:
+                pass
+
+
 def _refl(name, rval=None, exit=False):
     """
     This function is used to test the main loop classes.

--- a/urwid/main_loop.py
+++ b/urwid/main_loop.py
@@ -1603,7 +1603,10 @@ class TrioEventLoop(EventLoop):
 
         def faux_idle_callback():
             callback()
-            self.nursery.start_soon(self._trio_alarm, self._idle_emulation_delay, faux_idle_callback, cancel)
+            if self.nursery:
+                self.nursery.start_soon(self._trio_alarm, self._idle_emulation_delay, faux_idle_callback, cancel)
+            else:
+                self._alarm_queue.append((self._idle_emulation_delay, faux_idle_callback, cancel))
 
         if self.nursery:
             self.nursery.start_soon(self._trio_alarm, self._idle_emulation_delay, faux_idle_callback, cancel)
@@ -1647,7 +1650,8 @@ class TrioEventLoop(EventLoop):
                 trio.run(self._parent)
             except ExitMainLoop:
                 pass
-
+            finally:
+                self.nursery = None
 
 def _refl(name, rval=None, exit=False):
     """

--- a/urwid/main_loop.py
+++ b/urwid/main_loop.py
@@ -28,6 +28,7 @@ import heapq
 import select
 import os
 import signal
+import sys
 from functools import wraps
 from itertools import count
 from weakref import WeakKeyDictionary
@@ -1506,152 +1507,10 @@ class AsyncioEventLoop(EventLoop):
             reraise(*exc_info)
 
 
-try:
-    import trio
-except Exception:
-    trio = None
+# Some main loops make use of Python-3.5+ syntax.  Only import their code if we're on Python-3.5+
+if sys.version_info >= (3, 5):
+    from ._async_kw_main_loop import TrioEventLoop
 
-
-class TrioEventLoop(EventLoop):
-    """
-    Event loop based on the ``trio`` module.
-
-    ``trio`` is an async library for Python 3.5 and later.
-    """
-    #_we_started_event_loop = False
-
-    _idle_emulation_delay = 1.0/256  # a short time (in seconds)
-
-    def __init__(self, nursery=None):
-        self.nursery = nursery
-        self._alarm_queue = []
-        self._watcher_queue = []
-        self._idle_queue = []
-
-    async def _trio_alarm(self, seconds, callback, cancel):
-        await trio.sleep(seconds)
-        if cancel.is_set():
-            return
-        callback()
-
-    def alarm(self, seconds, callback):
-        """
-        Call callback() a given time from now.  No parameters are
-        passed to callback.
-
-        Returns a handle that may be passed to remove_alarm()
-
-        seconds -- time in seconds to wait before calling callback
-        callback -- function to call from event loop
-        """
-        cancel = trio.Event()
-        if self.nursery:
-            self.nursery.start_soon(self._trio_alarm, seconds, callback, cancel)
-        else:
-            self._alarm_queue.append((seconds, callback, cancel))
-        return cancel
-
-    def remove_alarm(self, handle):
-        """
-        Remove an alarm.
-
-        Returns True if the alarm exists, False otherwise
-        """
-        # Alarm has already been scheduled to be removed or has exited
-        if handle.is_set():
-            return False
-
-        handle.set()
-        return True
-
-    async def _trio_watch_file(self, fd, callback, cancel):
-        while True:
-            await trio.hazmat.wait_readable(fd)
-            if cancel.is_set():
-                return
-            callback()
-
-    def watch_file(self, fd, callback):
-        """
-        Call callback() when fd has some data to read.  No parameters
-        are passed to callback.
-
-        Returns a handle that may be passed to remove_watch_file()
-
-        fd -- file descriptor to watch for input
-        callback -- function to call when input is available
-        """
-        cancel = trio.Event()
-        if self.nursery:
-            self.nursery.start_soon(self._trio_watch_file, fd, callback, cancel)
-        else:
-            self._watcher_queue.append((fd, callback, cancel))
-        return cancel
-
-    remove_watch_file = remove_alarm
-
-    def enter_idle(self, callback):
-        """
-        Add a callback for entering idle.
-
-        Returns a handle that may be passed to remove_idle()
-        """
-        # XXX there's no such thing as "idle" in most event loops; (scheduling a task with a lower
-        # priority than everything else)  this fakes it the same way as Twisted, by scheduling the
-        # callback to be called repeatedly
-        cancel = trio.Event()
-
-        def faux_idle_callback():
-            callback()
-            if self.nursery:
-                self.nursery.start_soon(self._trio_alarm, self._idle_emulation_delay, faux_idle_callback, cancel)
-            else:
-                self._alarm_queue.append((self._idle_emulation_delay, faux_idle_callback, cancel))
-
-        if self.nursery:
-            self.nursery.start_soon(self._trio_alarm, self._idle_emulation_delay, faux_idle_callback, cancel)
-        else:
-            self._alarm_queue.append((self._idle_emulation_delay, faux_idle_callback, cancel))
-        return cancel
-
-    remove_enter_idle = remove_alarm
-
-    def _register_queued_tasks(self):
-        for alarm in self._alarm_queue:
-            self.nursery.start_soon(self._trio_alarm, *alarm)
-        self._alarm_queue = []
-
-        for watcher in self._watcher_queue:
-            self.nursery.start_soon(self._trio_watch_file, *watcher)
-        self._watcher_queue = []
-
-        for idle in self._idle_queue:
-            self.nursery.start_soon(self._trio_idle, *idle)
-        self._idle_queue = []
-
-    async def _parent(self):
-        """
-        Create a nursery and register all of the tasks that were scheduled before trio initialized
-        """
-        if not self.nursery:
-            async with trio.open_nursery() as nursery:
-                self.nursery = nursery
-                self._register_queued_tasks()
-        else:
-            self._register_queued_tasks()
-
-    def run(self):
-        """
-        Start the event loop.  Exit the loop when any callback raises
-        an exception.  If ExitMainLoop is raised, exit cleanly.
-        """
-        if not self.nursery:
-            try:
-                trio.run(self._parent)
-            except ExitMainLoop:
-                pass
-            finally:
-                self.nursery = None
 
 def _refl(name, rval=None, exit=False):
     """

--- a/urwid/tests/test_event_loops.py
+++ b/urwid/tests/test_event_loops.py
@@ -58,7 +58,7 @@ class EventLoopTestMixin(object):
         handle = evl.alarm(0.01, exit_clean)
         handle = evl.alarm(0.005, say_hello)
         idle_handle = evl.enter_idle(say_waiting)
-        if self._expected_idle_handle is not None:
+        if self._expected_idle_handle is not None and not PYTHON3:
             self.assertEqual(idle_handle, 1)
         evl.run()
         self.assertTrue("hello" in out, out)

--- a/urwid/tests/test_event_loops.py
+++ b/urwid/tests/test_event_loops.py
@@ -164,3 +164,20 @@ else:
             evl = self.evl
             evl.alarm(0.5, lambda: 1 / 0)  # Simulate error in event loop
             self.assertRaises(ZeroDivisionError, evl.run)
+
+
+try:
+    import trio
+except ImportError:
+    pass
+else:
+    class TrioEventLoopTest(unittest.TestCase, EventLoopTestMixin):
+        def setUp(self):
+            self.evl = urwid.TrioEventLoop()
+
+        _expected_idle_handle = None
+
+        def test_error(self):
+            evl = self.evl
+            evl.alarm(0.5, lambda: 1 / 0)  # Simulate error in event loop
+            self.assertRaises(ZeroDivisionError, evl.run)


### PR DESCRIPTION
##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [ ] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
Trio is an alternative async framework based around the async and await keywords that were added to recent python versions.  This PR adds an EventLoop class which uses trio as its backend.

I've marked this as a work in progress as async and await are only available in python-3.6 or greater.  I'll have to reorganize the new code so that it is only parsed if we're on python-3.6 or higher.  I also want to check whether the eventloop is being tested in tox and try to get a trio developer to look over my work and make sure I'm not making any big mistakes.