### PR TITLE
[Ready for review] Fix crash on click-Esc & Esc-click (#104, #188), add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
-*.cover
+*[.,]cover
 .hypothesis/
 
 # Translations

--- a/urwid/escape.py
+++ b/urwid/escape.py
@@ -35,6 +35,10 @@ except ImportError:
 
 from urwid.compat import bytes, bytes3
 
+# NOTE: because of circular imports (urwid.util -> urwid.escape -> urwid.util)
+# from urwid.util import is_mouse_event -- will not work here
+import urwid.util
+
 within_double_byte = str_util.within_double_byte
 
 SO = "\x0e"
@@ -384,6 +388,8 @@ def process_keyqueue(codes, more_available):
         # Meta keys -- ESC+Key form
         run, remaining_codes = process_keyqueue(codes[1:],
             more_available)
+        if urwid.util.is_mouse_event(run[0]):
+            return ['esc'] + run, remaining_codes
         if run[0] == "esc" or run[0].find("meta ") >= 0:
             return ['esc']+run, remaining_codes
         return ['meta '+run[0]]+run[1:], remaining_codes

--- a/urwid/tests/test_escapes.py
+++ b/urwid/tests/test_escapes.py
@@ -1,0 +1,79 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+""" Tests covering escape sequences processing """
+
+import unittest
+
+import urwid.escape
+
+
+class InputEscapeSequenceParserTest(unittest.TestCase):
+    """ Tests for parser of input escape sequences """
+
+    def test_bare_escape(self):
+        codes = [27]
+        expected = ['esc']
+        actual, rest = urwid.escape.process_keyqueue(codes, more_available=False)
+        self.assertListEqual(expected, actual)
+        self.assertListEqual([], rest)
+
+    def test_meta(self):
+        codes = [27, ord('4'), ord('2')]
+        expected = ['meta 4']
+        actual, rest = urwid.escape.process_keyqueue(codes, more_available=False)
+        self.assertListEqual(expected, actual)
+        self.assertListEqual([ord('2')], rest)
+
+    def test_shift_arrows(self):
+        codes = [27, ord('['), ord('a')]
+        expected = ['shift up']
+        actual, rest = urwid.escape.process_keyqueue(codes, more_available=False)
+        self.assertListEqual(expected, actual)
+        self.assertListEqual([], rest)
+
+    def test_ctrl_pgup(self):
+        codes = [27, 91, 53, 59, 53, 126]
+        expected = ['ctrl page up']
+        actual, rest = urwid.escape.process_keyqueue(codes, more_available=False)
+        self.assertListEqual(expected, actual)
+        self.assertListEqual([], rest)
+
+    def test_esc_meta_1(self):
+        codes = [27, 27, 49]
+        expected = ['esc', 'meta 1']
+        actual, rest = urwid.escape.process_keyqueue(codes, more_available=False)
+        self.assertListEqual(expected, actual)
+        self.assertListEqual([], rest)
+
+    def test_midsequence(self):
+        # '[11~' is F1, '[12~' is F2, etc
+        codes = [27, ord('['), ord('1')]
+
+        with self.assertRaises(urwid.escape.MoreInputRequired):
+            urwid.escape.process_keyqueue(codes, more_available=True)
+
+        actual, rest = urwid.escape.process_keyqueue(codes, more_available=False)
+        self.assertListEqual(['meta ['], actual)
+        self.assertListEqual([ord('1')], rest)
+
+    def test_mouse_press(self):
+        codes = [27, 91, 77, 32, 41, 48]
+        expected = [('mouse press', 1.0, 8, 15)]
+        actual, rest = urwid.escape.process_keyqueue(codes, more_available=False)
+        self.assertListEqual(expected, actual)
+        self.assertListEqual([], rest)
+
+    def test_bug_104(self):
+        """ GH #104: click-Esc & Esc-click crashes urwid apps """
+        codes = [27, 27, 91, 77, 32, 127, 59]
+        expected = ['esc', ('mouse press', 1.0, 94, 26)]
+        actual, rest = urwid.escape.process_keyqueue(codes, more_available=False)
+        self.assertListEqual(expected, actual)
+        self.assertListEqual([], rest)
+
+        codes = [27, 27, 91, 77, 35, 120, 59]
+        expected = ['esc', ('mouse release', 0, 87, 26)]
+        actual, rest = urwid.escape.process_keyqueue(codes, more_available=False)
+        self.assertListEqual(expected, actual)
+        self.assertListEqual([], rest)


### PR DESCRIPTION
There's missing handling of mouse events in `escape.py`, causing crashes in urwid apps with mouse tracking when the user clicks and presses the Escape key in quick succession (click-escape or escape-click, in either order). The stacktrace ends like this:

```
  File "/usr/local/lib/python2.7/dist-packages/urwid/escape.py", line 386, in process_keyqueue
    if run[0] == "esc" or run[0].find("meta ") >= 0:
AttributeError: 'tuple' object has no attribute 'find'
```

This has been reported years ago in #104.

I'm adding a safeguard to prevent the crash.

The code is slightly suboptimal to my taste; because of circular imports, `from urwid.utils import is_mouse_event` doesn't work, it has to be `import urwid.utils; ... urwid.utils.is_mouse_event`.  
I'm not touching any of this to limit the PR scope; but feel free to request a wider changeset that will fix this issue as well.


##### Checklist
- [✔] I've ensured that similar functionality has not already been implemented
- [✔] I've ensured that similar functionality has not earlier been proposed and declined
- [✔] I've branched off the `master` o̶r̶ ̶p̶y̶t̶h̶o̶n̶-̶d̶u̶a̶l̶-̶s̶u̶p̶p̶o̶r̶t̶ branch
- [✔] I've merged fresh upstream into my branch recently
- [–] I've ran `tox` successfully in local environment
- [–] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

