### PR TITLE
Remove method Text._calc_line_translation()

### DIFF
--- a/urwid/widget.py
+++ b/urwid/widget.py
@@ -1039,13 +1039,8 @@ class Text(Widget):
         else:
             text, attr = self.get_text()
         self._cache_maxcol = maxcol
-        self._cache_translation = self._calc_line_translation(
-            text, maxcol )
-
-    def _calc_line_translation(self, text, maxcol ):
-        return self.layout.layout(
-            text, self._cache_maxcol,
-            self._align_mode, self._wrap_mode )
+        self._cache_translation = self.layout.layout(
+            text, maxcol, self._align_mode, self._wrap_mode)
 
     def pack(self, size=None, focus=False):
         """


### PR DESCRIPTION
_calc_line_translation() is extremely simple and only used in one place.

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [ ] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
`_calc_line_translation` is a one-liner that is only called in one place. This PR simply replaces the call to it with it's content.

Besides the reduce code complexity this may also result in small performance improvements depending on the application.