### PR TITLE
Don't use deprecated inspect.getargspec() with python3

### DIFF
--- a/urwid/split_repr.py
+++ b/urwid/split_repr.py
@@ -125,7 +125,6 @@ def remove_defaults(d, fn):
     >>> Foo()
     <Foo object>
     """
-    # args, varargs, varkw, defaults = getargspec(fn)
     if not PYTHON3:
         args, varargs, varkw, defaults = getargspec(fn)
     else:

--- a/urwid/split_repr.py
+++ b/urwid/split_repr.py
@@ -21,8 +21,11 @@
 
 from __future__ import division, print_function
 
-from inspect import getargspec
 from urwid.compat import PYTHON3, bytes
+if not PYTHON3:
+    from inspect import getargspec
+else:
+    from inspect import getfullargspec
 
 def split_repr(self):
     """
@@ -122,7 +125,11 @@ def remove_defaults(d, fn):
     >>> Foo()
     <Foo object>
     """
-    args, varargs, varkw, defaults = getargspec(fn)
+    # args, varargs, varkw, defaults = getargspec(fn)
+    if not PYTHON3:
+        args, varargs, varkw, defaults = getargspec(fn)
+    else:
+        args, varargs, varkw, defaults, _, _, _ = getfullargspec(fn)
 
     # ignore *varargs and **kwargs
     if varkw:


### PR DESCRIPTION
inspect.getargspec() has been deprecated since 3.0.

https://docs.python.org/3/library/inspect.html#inspect.getargspec

##### Checklist
- [ ] I've ensured that similar functionality has not already been implemented
- [ ] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)


