### PR TITLE
Fix issue #324 "Non-integer division in bargraph when using set_bar_width(1)"

### DIFF
--- a/urwid/graphics.py
+++ b/urwid/graphics.py
@@ -400,7 +400,7 @@ class BarGraph(with_metaclass(BarGraphMeta, Widget)):
 
         if self.bar_width is not None:
             return [self.bar_width] * min(
-                len(bardata), maxcol / self.bar_width)
+                len(bardata), maxcol // self.bar_width)
 
         if len(bardata) >= maxcol:
             return [1] * maxcol


### PR DESCRIPTION
##### Checklist

- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:

This fixes issue #324 
