### PR TITLE
Fix misleading indentation in Screen._stop()

### DIFF
--- a/urwid/raw_display.py
+++ b/urwid/raw_display.py
@@ -247,7 +247,7 @@ class Screen(BaseScreen, RealTerminal):
         fd = self._term_input_file.fileno()
         if os.isatty(fd):
             termios.tcsetattr(fd, termios.TCSADRAIN,
-        self._old_termios_settings)
+                self._old_termios_settings)
 
         self._mouse_tracking(False)
 


### PR DESCRIPTION
##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [ ] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:

Fix an indentation issue. Because of parentheses, it caused no syntax error, but it was misleading nonetheless.

