### PR TITLE
urwid.util: Fix bug in rle_append_beginning_modify

### DIFF
--- a/urwid/util.py
+++ b/urwid/util.py
@@ -301,7 +301,7 @@ def rle_append_beginning_modify(rle, a_r):
         if a == al:
             rle[0] = (a,run+r)
         else:
-            rle[0:0] = [(al, r)]
+            rle[0:0] = [(a, r)]
 
 
 def rle_append_modify(rle, a_r):


### PR DESCRIPTION
rle_append_beginning_modify was not correctly prepending rle fragments with mismatching attributes.