### PR TITLE
fix EOF detection for the Terminal widget on Python 3

### DIFF
--- a/urwid/vterm.py
+++ b/urwid/vterm.py
@@ -47,6 +47,7 @@ from urwid.widget import Widget, BOX
 from urwid.display_common import AttrSpec, RealTerminal, _BASIC_COLORS
 from urwid.compat import ord2, chr2, B, bytes, PYTHON3, xrange
 
+EOF = B('')
 ESC = chr(27)
 
 KEY_TRANSLATIONS = {
@@ -1530,19 +1531,19 @@ class Terminal(Widget):
         self.feed()
 
     def feed(self):
-        data = ''
+        data = EOF
 
         try:
             data = os.read(self.master, 4096)
         except OSError as e:
             if e.errno == 5: # End Of File
-                data = ''
+                data = EOF
             elif e.errno == errno.EWOULDBLOCK: # empty buffer
                 return
             else:
                 raise
 
-        if data == '': # EOF on BSD
+        if data == EOF: # EOF on BSD
             self.terminate()
             self._emit('closed')
             return


### PR DESCRIPTION
##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [ ] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:

This PR fixes the detection of the termination of the spawned process of the Terminal widget on Python 3.x. The problem was that process termination resulted in the `os.read()` call to return `b''` on Python 3.x (instead of `''`), which then failed the comparison with `''`. The PR ensures that we use the correct EOF marker (`b''` on Python 3.x, `''` on Python 2.x).
