### PR TITLE
Unbreak python ./examples/treesample HOME END keys.

### DIFF
--- a/urwid/treetools.py
+++ b/urwid/treetools.py
@@ -418,7 +418,8 @@ class TreeListBox(urwid.ListBox):
     collapsing of TreeWidgets"""
 
     def keypress(self, size, key):
-        key = self.__super.keypress(size, key)
+        if key not in ['home', 'end']:
+            key = self.__super.keypress(size, key)
         return self.unhandled_input(size, key)
 
     def unhandled_input(self, size, input):


### PR DESCRIPTION
TreeWalker does not implement `.positions` and thus default handler in `__super.keypress` fails and tracebacks trying to process HOME and END keybindings.

However, these keys are implemented in the treelistbox (possibly prior to the generic key handler) and imho it should be used.

With this patch treesample works.