### PR TITLE
added support for input encoding in Terminal widget

### DIFF
--- a/examples/terminal.py
+++ b/examples/terminal.py
@@ -22,7 +22,8 @@
 import urwid
 
 def main():
-    term = urwid.Terminal(None)
+    urwid.set_encoding('utf8')
+    term = urwid.Terminal(None, encoding='utf-8')
 
     mainframe = urwid.LineBox(
         urwid.Pile([

--- a/urwid/vterm.py
+++ b/urwid/vterm.py
@@ -1325,7 +1325,8 @@ class Terminal(Widget):
 
     signals = ['closed', 'beep', 'leds', 'title']
 
-    def __init__(self, command, env=None, main_loop=None, escape_sequence=None):
+    def __init__(self, command, env=None, main_loop=None, escape_sequence=None,
+                 encoding='ascii'):
         """
         A terminal emulator within a widget.
 
@@ -1343,6 +1344,13 @@ class Terminal(Widget):
 
         'escape_sequence' is the urwid key symbol which should be used to break
         out of the terminal widget. If it's not specified, "ctrl a" is used.
+
+        'encoding' specifies the encoding that is being used when local
+        keypresses in Unicode are encoded into raw bytes. The default encoding
+        is 'ascii' for backwards compatibility with urwid versions <= 2.0.1.
+        Set this to the encoding of your terminal (typically 'utf8') if you
+        want to be able to transmit non-ASCII characters to the spawned process.
+        Applies to Python 3.x only.
         """
         self.__super.__init__()
 
@@ -1360,6 +1368,8 @@ class Terminal(Widget):
             self.command = [self.env.get('SHELL', '/bin/sh')]
         else:
             self.command = command
+
+        self.encoding = encoding
 
         self.keygrab = False
         self.last_key = None
@@ -1624,6 +1634,6 @@ class Terminal(Widget):
             key += "\x0a"
 
         if PYTHON3:
-            key = key.encode('ascii')
+            key = key.encode(self.encoding, 'ignore')
 
         os.write(self.master, key)


### PR DESCRIPTION
##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [ ] I've ran `tox` successfully in local environment
- [X] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
*(P. S. If this pull requests fixes an existing issue, please specify which one.)*

This PR fixes issue #348 by adding an `encoding` argument to the `Terminal` widget and encoding keyboard input with`'ignore'` to ensure that an incorrect encoding will not crash the widget itself.

See also discussion in #348.