### PR TITLE
fix AttributeError on mouse click

### DIFF
--- a/examples/calc.py
+++ b/examples/calc.py
@@ -639,6 +639,10 @@ class CalcDisplay:
         """Handle a keystroke."""
 
         self.loop.process_input([key])
+        
+        if isinstance(key, tuple):
+            # ignore mouse events
+            return
 
         if key.upper() in COLUMN_KEYS:
             # column switch


### PR DESCRIPTION
Running `examples/calc.py` I encountered the following error when clicking.

```
  File "calc.py", line 610, in wrap_keypress
    key = self.keypress(key)
  File "calc.py", line 643, in keypress
    if key.upper() in COLUMN_KEYS:
AttributeError: 'tuple' object has no attribute 'upper'
```