### PR TITLE
fix ProgressBar smoothing on Python 3.x

### DIFF
--- a/urwid/graphics.py
+++ b/urwid/graphics.py
@@ -22,7 +22,7 @@
 
 from __future__ import division, print_function
 
-from urwid.compat import with_metaclass
+from urwid.compat import ord2, with_metaclass
 from urwid.util import decompose_tagmarkup, get_encoding_mode
 from urwid.canvas import CompositeCanvas, CanvasJoin, TextCanvas, \
     CanvasCombine, SolidCanvas
@@ -942,7 +942,7 @@ class ProgressBar(Widget):
             c._attr = [[(self.normal, maxcol)]]
         elif ccol >= maxcol:
             c._attr = [[(self.complete, maxcol)]]
-        elif cs and c._text[0][ccol] == " ":
+        elif cs and ord2(c._text[0][ccol]) == 32:
             t = c._text[0]
             cenc = self.eighths[cs].encode("utf-8")
             c._text[0] = t[:ccol] + cenc + t[ccol + 1:]


### PR DESCRIPTION
##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [ ] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
*(P. S. If this pull requests fixes an existing issue, please specify which one.)*

This PR fixes an issue with the "smoothing" feature of the ProgressBar widget on Python 3.x. Due to a bytes-vs-str problem, smoothing essentially doesn't work on Python 3.x as it is because we are indexing into a bytes object (which returns an integer on Python 3.x) and then compare it with a string (`" "`). Using the `ord2` compatibility function from `urwid.compat` and replacing `" "` with its ASCII code 32 fixes the problem.

The PR would fix issue #317.