### PR TITLE
Fix py34 tests, turn Travis to green again

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,12 +1,9 @@
-.. image:: https://travis-ci.org/urwid/urwid.svg?branch=master
-   :alt: build status
-   :target: https://travis-ci.org/urwid/urwid/
-
-.. image:: https://coveralls.io/repos/github/urwid/urwid/badge.svg
-   :alt: build coverage
-   :target: https://coveralls.io/github/urwid/urwid
-
-`Development version documentation <http://urwid.readthedocs.org/en/latest/>`_
+Urwid
+=====
+|pypi|_
+|docs|_
+|travis|_
+|coveralls|_
 
 .. content-start
 
@@ -88,3 +85,16 @@ Contributors
 - `inducer <//github.com/inducer>`_
 - `winbornejw <//github.com/winbornejw>`_
 - `hootnot <//github.com/hootnot>`_
+
+
+.. |pypi| image:: http://img.shields.io/pypi/v/urwid.svg   :alt: current version on PyPi
+.. _pypi: https://pypi.python.org/pypi/urwid
+
+.. |docs| image:: https://readthedocs.org/projects/urwid/badge/   :alt: docs link
+.. _docs: http://urwid.readthedocs.org/en/latest/
+
+.. |travis| image:: https://travis-ci.org/urwid/urwid.svg?branch=master   :alt: build status
+.. _travis: https://travis-ci.org/urwid/urwid/
+
+.. |coveralls| image:: https://coveralls.io/repos/github/urwid/urwid/badge.svg   :alt: test coverage
+.. _coveralls: https://coveralls.io/github/urwid/urwid

--- a/tox.ini
+++ b/tox.ini
@@ -14,11 +14,11 @@ deps =
     tornado<5.0.0
     coverage
     py27: twisted==16.6.0
-    py34: twisted
     py35: twisted
     py36: twisted
     py37: twisted
     pypy: twisted
+    # NOTE: py34 is tested without Twisted: they had abandoned Py < 3.5.
 commands =
     coverage run ./setup.py test
 

--- a/urwid/tests/test_event_loops.py
+++ b/urwid/tests/test_event_loops.py
@@ -154,6 +154,10 @@ try:
 except ImportError:
     pass
 else:
+    if not hasattr(asyncio, 'ensure_future'):
+        #-- Python < 3.4.4 (e.g. Debian Jessie)
+        asyncio.ensure_future = getattr(asyncio, 'async')
+
     class AsyncioEventLoopTest(unittest.TestCase, EventLoopTestMixin):
         def setUp(self):
             self.evl = urwid.AsyncioEventLoop()


### PR DESCRIPTION
Two little fixes regarding Py3.4. Should turn CI back to green.

Tested manually in debian:8.7 docker container; 3.4 is the only python3 available there.

They said somewhere that Python 3.4 support has been officially ended months ago (March this year) -- so it'd be great to drop it in Urwid altogether. However, Debian Jessie (as well as [latest CentOS](https://pkgs.org/download/python34)) are good enough reasons to keep it just yet.