### PR TITLE
add custom checkbox symbol

### DIFF
--- a/urwid/wimp.py
+++ b/urwid/wimp.py
@@ -114,7 +114,7 @@ class CheckBox(WidgetWrap):
     signals = ["change", 'postchange']
 
     def __init__(self, label, state=False, has_mixed=False,
-             on_state_change=None, user_data=None):
+             on_state_change=None, user_data=None, checked_symbol=None):
         """
         :param label: markup for check box label
         :param state: False, True or "mixed"
@@ -148,6 +148,8 @@ class CheckBox(WidgetWrap):
         self._label = Text("")
         self.has_mixed = has_mixed
         self._state = None
+        if checked_symbol:
+            self.states[True] = SelectableIcon(u"[%s]" % checked_symbol, 1)
         # The old way of listening for a change was to pass the callback
         # in to the constructor.  Just convert it to the new way:
         if on_state_change:


### PR DESCRIPTION
##### Checklist
- [✔] I've ensured that similar functionality has not already been implemented
- [✔] I've ensured that similar functionality has not earlier been proposed and declined
- [✔] I've branched off the `master` or `python-dual-support` branch
- [✔] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

# haven't run tox, but pytest was OK.

##### Description:
Checkbox would now support also
urwid.CheckBox(u"an option", checked_symbol=u'✔')