### PR TITLE
allow setting align for button

### DIFF
--- a/urwid/__init__.py
+++ b/urwid/__init__.py
@@ -23,12 +23,11 @@
 from __future__ import division, print_function
 
 from urwid.version import VERSION, __version__
-from urwid.widget import (FLOW, BOX, FIXED, LEFT, RIGHT, CENTER, TOP, MIDDLE,
-    BOTTOM, SPACE, ANY, CLIP, PACK, GIVEN, RELATIVE, RELATIVE_100, WEIGHT,
-    WidgetMeta,
-    WidgetError, Widget, FlowWidget, BoxWidget, fixed_size, FixedWidget,
+from urwid.widget import (WidgetMeta, WidgetError, Widget,
+    FlowWidget, BoxWidget, fixed_size, FixedWidget,
     Divider, SolidFill, TextError, Text, EditError, Edit, IntEdit,
-    delegate_to_widget_mixin, WidgetWrapError, WidgetWrap)
+    delegate_to_widget_mixin, WidgetWrapError, WidgetWrap,
+    WidgetSize, WidgetsChildrenSize, WidgetAlignment, TextWrapping)
 from urwid.decoration import (WidgetDecoration, WidgetPlaceholder,
     AttrMapError, AttrMap, AttrWrap, BoxAdapterError, BoxAdapter, PaddingError,
     Padding, FillerError, Filler, WidgetDisable)

--- a/urwid/constants.py
+++ b/urwid/constants.py
@@ -1,0 +1,30 @@
+# define some names for these constants to avoid misspellings in the source
+# and to document the constant strings we are using
+
+# Widget sizing methods
+FLOW = 'flow'
+BOX = 'box'
+FIXED = 'fixed'
+
+# Text alignment modes
+LEFT = 'left'
+RIGHT = 'right'
+CENTER = 'center'
+
+# Filler alignment
+TOP = 'top'
+MIDDLE = 'middle'
+BOTTOM = 'bottom'
+
+# Text wrapping modes
+SPACE = 'space'
+ANY = 'any'
+CLIP = 'clip'
+ELLIPSIS = 'ellipsis'
+
+# Width and Height settings
+PACK = 'pack'
+GIVEN = 'given'
+RELATIVE = 'relative'
+RELATIVE_100 = (RELATIVE, 100)
+WEIGHT = 'weight'

--- a/urwid/constants.py
+++ b/urwid/constants.py
@@ -1,30 +1,44 @@
-# define some names for these constants to avoid misspellings in the source
-# and to document the constant strings we are using
+from enum import Enum, auto
 
-# Widget sizing methods
-FLOW = 'flow'
-BOX = 'box'
-FIXED = 'fixed'
+class WidgetAlignment(Enum):
+    """ Widget's position/gravity """
+    TOP = auto()
+    LEFT = auto()
+    RIGHT = auto()
+    CENTER = auto()
+    MIDDLE = CENTER
+    BOTTOM = auto()
 
-# Text alignment modes
-LEFT = 'left'
-RIGHT = 'right'
-CENTER = 'center'
+class WidgetSize(Enum):
+    """ Widget size is measured in screen cols and rows.
 
-# Filler alignment
-TOP = 'top'
-MIDDLE = 'middle'
-BOTTOM = 'bottom'
+        :data BOX: fixed cols and rows, by container
+        :data FLOW: fixed cols by container, rows decided by widget
+        :data FIXED: widget decides about both cols and rows
+    """
+    BOX = auto()
+    FLOW = auto()
+    FIXED = auto()
 
-# Text wrapping modes
-SPACE = 'space'
-ANY = 'any'
-CLIP = 'clip'
-ELLIPSIS = 'ellipsis'
+class WidgetsChildrenSize(Enum):
+    """ Describes widget children behaviour in container
 
-# Width and Height settings
-PACK = 'pack'
-GIVEN = 'given'
-RELATIVE = 'relative'
-RELATIVE_100 = (RELATIVE, 100)
-WEIGHT = 'weight'
+        :data PACK: child calculates its size
+        :data GIVEN: child gets fixed amount of space
+        :data WEIGHT: child gets space amounting to siblings ratio
+        :data RELATIVE: child gets percent of cols/rows in parent
+        :data FILL_PARENT: child gets all space a container has
+    """
+    PACK = auto()
+    GIVEN = auto()
+    WEIGHT = auto()
+    RELATIVE = auto()
+    FILL_PARENT = (RELATIVE, 100)
+
+class TextWrapping(Enum):
+    SPACE = auto()
+    ANY = auto()
+    CLIP = auto()
+    ELLIPSIS = auto()
+
+# TODO: update "constants.rst"

--- a/urwid/container.py
+++ b/urwid/container.py
@@ -25,8 +25,9 @@ from itertools import chain, repeat
 from urwid.compat import xrange
 
 from urwid.util import is_mouse_press
-from urwid.widget import (Widget, Divider, FLOW, FIXED, PACK, BOX, WidgetWrap,
-    GIVEN, WEIGHT, LEFT, RIGHT, RELATIVE, TOP, BOTTOM, CLIP, RELATIVE_100)
+from urwid.constants import WidgetAlignment, WidgetSize, WidgetsChildrenSize
+from urwid.constants import TextWrapping
+from urwid.widget import (Widget, Divider, WidgetWrap)
 from urwid.decoration import (Padding, Filler, calculate_left_right_padding,
     calculate_top_bottom_filler, normalize_align, normalize_width,
     normalize_valign, normalize_height, simplify_align, simplify_width,
@@ -136,7 +137,7 @@ class GridFlow(WidgetWrap, WidgetContainerMixin, WidgetContainerListContentsMixi
     bottom.
     """
     def sizing(self):
-        return frozenset([FLOW])
+        return frozenset([WidgetSize.FLOW])
 
     def __init__(self, cells, cell_width, h_sep, v_sep, align):
         """
@@ -149,7 +150,7 @@ class GridFlow(WidgetWrap, WidgetContainerMixin, WidgetContainerListContentsMixi
             'left', 'center', 'right', ('relative', percentage 0=left 100=right)
         """
         self._contents = MonitoredFocusList([
-            (w, (GIVEN, cell_width)) for w in cells])
+            (w, (WidgetsChildrenSize.GIVEN, cell_width)) for w in cells])
         self._contents.set_modified_callback(self._invalidate)
         self._contents.set_focus_changed_callback(lambda f: self._invalidate())
         self._contents.set_validate_contents_modified(self._contents_modified)
@@ -170,7 +171,7 @@ class GridFlow(WidgetWrap, WidgetContainerMixin, WidgetContainerListContentsMixi
         for item in new_items:
             try:
                 w, (t, n) = item
-                if t != GIVEN:
+                if t != WidgetsChildrenSize.GIVEN:
                     raise ValueError
             except (TypeError, ValueError):
                 raise GridFlowError("added content invalid %r" % (item,))
@@ -184,7 +185,7 @@ class GridFlow(WidgetWrap, WidgetContainerMixin, WidgetContainerListContentsMixi
     def _set_cells(self, widgets):
         focus_position = self.focus_position
         self.contents = [
-            (new, (GIVEN, self._cell_width)) for new in widgets]
+            (new, (WidgetsChildrenSize.GIVEN, self._cell_width)) for new in widgets]
         if focus_position < len(widgets):
             self.focus_position = focus_position
     cells = property(_get_cells, _set_cells, doc="""
@@ -200,7 +201,7 @@ class GridFlow(WidgetWrap, WidgetContainerMixin, WidgetContainerListContentsMixi
     def _set_cell_width(self, width):
         focus_position = self.focus_position
         self.contents = [
-            (w, (GIVEN, width)) for (w, options) in self.contents]
+            (w, (WidgetsChildrenSize.GIVEN, width)) for (w, options) in self.contents]
         self.focus_position = focus_position
         self._cell_width = width
     cell_width = property(_get_cell_width, _set_cell_width, doc="""
@@ -226,14 +227,14 @@ class GridFlow(WidgetWrap, WidgetContainerMixin, WidgetContainerListContentsMixi
         .. seealso:: Create new options tuples with the :meth:`options` method.
         """)
 
-    def options(self, width_type=GIVEN, width_amount=None):
+    def options(self, width_type=WidgetsChildrenSize.GIVEN, width_amount=None):
         """
         Return a new options tuple for use in a GridFlow's .contents list.
 
         width_type -- 'given' is the only value accepted
         width_amount -- None to use the default cell_width for this GridFlow
         """
-        if width_type != GIVEN:
+        if width_type != WidgetsChildrenSize.GIVEN:
             raise GridFlowError("invalid width_type: %r" % (width_type,))
         if width_amount is None:
             width_amount = self._cell_width
@@ -351,7 +352,7 @@ class GridFlow(WidgetWrap, WidgetContainerMixin, WidgetContainerListContentsMixi
                 pad.first_position = i
                 p.contents.append((pad, p.options()))
 
-            c.contents.append((w, c.options(GIVEN, width_amount)))
+            c.contents.append((w, c.options(WidgetsChildrenSize.GIVEN, width_amount)))
             if ((i == self.focus_position) or
                 (not column_focused and w.selectable())):
                 c.focus_position = len(c.contents) - 1
@@ -453,11 +454,11 @@ class Overlay(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
     Overlay contains two box widgets and renders one on top of the other
     """
     _selectable = True
-    _sizing = frozenset([BOX])
+    _sizing = frozenset([WidgetSize.BOX])
 
     _DEFAULT_BOTTOM_OPTIONS = (
-        LEFT, None, RELATIVE, 100, None, 0, 0,
-        TOP, None, RELATIVE, 100, None, 0, 0)
+        WidgetAlignment.LEFT, None, WidgetsChildrenSize.RELATIVE, 100, None, 0, 0,
+        WidgetAlignment.TOP, None, WidgetsChildrenSize.RELATIVE, 100, None, 0, 0)
 
     def __init__(self, top_w, bottom_w, align, width, valign, height,
             min_width=None, min_height=None, left=0, right=0, top=0, bottom=0):
@@ -544,43 +545,43 @@ class Overlay(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         if isinstance(align, tuple):
             if align[0] == 'fixed left':
                 left = align[1]
-                align = LEFT
+                align = WidgetAlignment.LEFT
             elif align[0] == 'fixed right':
                 right = align[1]
-                align = RIGHT
+                align = WidgetAlignment.RIGHT
         if isinstance(width, tuple):
             if width[0] == 'fixed left':
                 left = width[1]
-                width = RELATIVE_100
+                width = WidgetsChildrenSize.FILL_PARENT
             elif width[0] == 'fixed right':
                 right = width[1]
-                width = RELATIVE_100
+                width = WidgetsChildrenSize.FILL_PARENT
         if isinstance(valign, tuple):
             if valign[0] == 'fixed top':
                 top = valign[1]
-                valign = TOP
+                valign = WidgetAlignment.TOP
             elif valign[0] == 'fixed bottom':
                 bottom = valign[1]
-                valign = BOTTOM
+                valign = WidgetAlignment.BOTTOM
         if isinstance(height, tuple):
             if height[0] == 'fixed bottom':
                 bottom = height[1]
-                height = RELATIVE_100
+                height = WidgetsChildrenSize.FILL_PARENT
             elif height[0] == 'fixed top':
                 top = height[1]
-                height = RELATIVE_100
+                height = WidgetsChildrenSize.FILL_PARENT
 
         if width is None: # more obsolete values accepted
-            width = PACK
+            width = WidgetsChildrenSize.PACK
         if height is None:
-            height = PACK
+            height = WidgetsChildrenSize.PACK
 
         align_type, align_amount = normalize_align(align, OverlayError)
         width_type, width_amount = normalize_width(width, OverlayError)
         valign_type, valign_amount = normalize_valign(valign, OverlayError)
         height_type, height_amount = normalize_height(height, OverlayError)
 
-        if height_type in (GIVEN, PACK):
+        if height_type in (WidgetsChildrenSize.GIVEN, WidgetsChildrenSize.PACK):
             min_height = None
 
         # use container API to set the parameters
@@ -632,7 +633,7 @@ class Overlay(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         return OverlayContents()
     def _contents__getitem__(self, index):
         if index == 0:
-            return (self.bottom_w, self._DEFAULT_BOTTOM_OPTIONS)
+            return (self.bottom_w, self._DEFAULT_WidgetAlignment.BOTTOM_OPTIONS)
         if index == 1:
             return (self.top_w, (
                 self.align_type, self.align_amount,
@@ -649,9 +650,9 @@ class Overlay(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         except (ValueError, TypeError):
             raise OverlayError("added content invalid: %r" % (value,))
         if index == 0:
-            if value_options != self._DEFAULT_BOTTOM_OPTIONS:
+            if value_options != self._DEFAULT_WidgetAlignment.BOTTOM_OPTIONS:
                 raise OverlayError("bottom_options must be set to "
-                    "%r" % (self._DEFAULT_BOTTOM_OPTIONS,))
+                    "%r" % (self._DEFAULT_WidgetAlignment.BOTTOM_OPTIONS,))
             self.bottom_w = value_w
         elif index == 1:
             try:
@@ -728,7 +729,7 @@ class Overlay(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         """Return (padding left, right, filler top, bottom)."""
         (maxcol, maxrow) = size
         height = None
-        if self.width_type == PACK:
+        if self.width_type == WidgetsChildrenSize.PACK:
             width, height = self.top_w.pack((),focus=focus)
             if not height:
                 raise OverlayError("fixed widget must have a height")
@@ -745,15 +746,15 @@ class Overlay(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
             # top_w is a fixed widget
             top, bottom = calculate_top_bottom_filler(maxrow,
                 self.valign_type, self.valign_amount,
-                GIVEN, height, None, self.top, self.bottom)
+                WidgetsChildrenSize.GIVEN, height, None, self.top, self.bottom)
             if maxrow-top-bottom < height:
                 bottom = maxrow-top-height
-        elif self.height_type == PACK:
+        elif self.height_type == WidgetsChildrenSize.PACK:
             # top_w is a flow widget
             height = self.top_w.rows((maxcol,),focus=focus)
             top, bottom =  calculate_top_bottom_filler(maxrow,
                 self.valign_type, self.valign_amount,
-                GIVEN, height, None, self.top, self.bottom)
+                WidgetsChildrenSize.GIVEN, height, None, self.top, self.bottom)
             if height > maxrow: # flow widget rendered too large
                 bottom = maxrow - height
         else:
@@ -765,11 +766,11 @@ class Overlay(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
 
     def top_w_size(self, size, left, right, top, bottom):
         """Return the size to pass to top_w."""
-        if self.width_type == PACK:
+        if self.width_type == WidgetsChildrenSize.PACK:
             # top_w is a fixed widget
             return ()
         maxcol, maxrow = size
-        if self.width_type != PACK and self.height_type == PACK:
+        if self.width_type != WidgetsChildrenSize.PACK and self.height_type == WidgetsChildrenSize.PACK:
             # top_w is a flow widget
             return (maxcol-left-right,)
         return (maxcol-left-right, maxrow-top-bottom)
@@ -826,7 +827,7 @@ class Frame(Widget, WidgetContainerMixin):
     """
 
     _selectable = True
-    _sizing = frozenset([BOX])
+    _sizing = frozenset([WidgetSize.BOX])
 
     def __init__(self, body, header=None, footer=None, focus_part='body'):
         """
@@ -1230,7 +1231,7 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
     """
     A pile of widgets stacked vertically from top to bottom
     """
-    _sizing = frozenset([FLOW, BOX])
+    _sizing = frozenset([WidgetSize.FLOW, WidgetSize.BOX])
 
     def __init__(self, widget_list, focus_item=None):
         """
@@ -1269,17 +1270,17 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         for i, original in enumerate(widget_list):
             w = original
             if not isinstance(w, tuple):
-                self.contents.append((w, (WEIGHT, 1)))
-            elif w[0] in (FLOW, PACK):
+                self.contents.append((w, (WidgetsChildrenSize.WEIGHT, 1)))
+            elif w[0] in (WidgetSize.FLOW, WidgetsChildrenSize.PACK):
                 f, w = w
-                self.contents.append((w, (PACK, None)))
+                self.contents.append((w, (WidgetsChildrenSize.PACK, None)))
             elif len(w) == 2:
                 height, w = w
-                self.contents.append((w, (GIVEN, height)))
-            elif w[0] == FIXED: # backwards compatibility
+                self.contents.append((w, (WidgetsChildrenSize.GIVEN, height)))
+            elif w[0] == WidgetSize.FIXED: # backwards compatibility
                 _ignore, height, w = w
-                self.contents.append((w, (GIVEN, height)))
-            elif w[0] == WEIGHT:
+                self.contents.append((w, (WidgetsChildrenSize.GIVEN, height)))
+            elif w[0] == WidgetsChildrenSize.WEIGHT:
                 f, height, w = w
                 self.contents.append((w, (f, height)))
             else:
@@ -1305,7 +1306,7 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         for item in new_items:
             try:
                 w, (t, n) = item
-                if t not in (PACK, GIVEN, WEIGHT):
+                if t not in (WidgetsChildrenSize.PACK, WidgetsChildrenSize.GIVEN, WidgetsChildrenSize.WEIGHT):
                     raise ValueError
             except (TypeError, ValueError):
                 raise PileError("added content invalid: %r" % (item,))
@@ -1321,7 +1322,7 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         self.contents = [
             (new, options) for (new, (w, options)) in zip(widgets,
                 # need to grow contents list if widgets is longer
-                chain(self.contents, repeat((None, (WEIGHT, 1)))))]
+                chain(self.contents, repeat((None, (WidgetsChildrenSize.WEIGHT, 1)))))]
         if focus_position < len(widgets):
             self.focus_position = focus_position
     widget_list = property(_get_widget_list, _set_widget_list, doc="""
@@ -1334,7 +1335,7 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
     def _get_item_types(self):
         ml = MonitoredList(
             # return the old item type names
-            ({GIVEN: FIXED, PACK: FLOW}.get(f, f), height)
+            ({WidgetsChildrenSize.GIVEN: WidgetSize.FIXED, WidgetsChildrenSize.PACK: WidgetSize.FLOW}.get(f, f), height)
             for w, (f, height) in self.contents)
         def user_modified():
             self._set_item_types(ml)
@@ -1343,7 +1344,7 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
     def _set_item_types(self, item_types):
         focus_position = self.focus_position
         self.contents = [
-            (w, ({FIXED: GIVEN, FLOW: PACK}.get(new_t, new_t), new_height))
+            (w, ({WidgetSize.FIXED: WidgetsChildrenSize.GIVEN, WidgetSize.FLOW: WidgetsChildrenSize.PACK}.get(new_t, new_t), new_height))
             for ((new_t, new_height), (w, options))
             in zip(item_types, self.contents)]
         if focus_position < len(item_types):
@@ -1387,7 +1388,7 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         """)
 
     @staticmethod
-    def options(height_type=WEIGHT, height_amount=1):
+    def options(height_type=WidgetsChildrenSize.WEIGHT, height_amount=1):
         """
         Return a new options tuple for use in a Pile's :attr:`contents` list.
 
@@ -1396,9 +1397,9 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
             ``'fixed'`` or a weight value (number) for ``'weight'``
         """
 
-        if height_type == PACK:
-            return (PACK, None)
-        if height_type not in (GIVEN, WEIGHT):
+        if height_type == WidgetsChildrenSize.PACK:
+            return (WidgetsChildrenSize.PACK, None)
+        if height_type not in (WidgetsChildrenSize.GIVEN, WidgetsChildrenSize.WEIGHT):
             raise PileError('invalid height_type: %r' % (height_type,))
         return (height_type, height_amount)
 
@@ -1482,9 +1483,9 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         """
         maxcol = size[0]
         w, (f, height) = self.contents[i]
-        if f == GIVEN:
+        if f == WidgetsChildrenSize.GIVEN:
             return (maxcol, height)
-        elif f == WEIGHT and len(size) == 2:
+        elif f == WidgetsChildrenSize.WEIGHT and len(size) == 2:
             if not item_rows:
                 item_rows = self.get_item_rows(size, focus)
             return (maxcol, item_rows[i])
@@ -1506,7 +1507,7 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         if remaining is None:
             # pile is a flow widget
             for w, (f, height) in self.contents:
-                if f == GIVEN:
+                if f == WidgetsChildrenSize.GIVEN:
                     l.append(height)
                 else:
                     l.append(w.rows((maxcol,),
@@ -1517,11 +1518,11 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         # do an extra pass to calculate rows for each widget
         wtotal = 0
         for w, (f, height) in self.contents:
-            if f == PACK:
+            if f == WidgetsChildrenSize.PACK:
                 rows = w.rows((maxcol,), focus=focus and self.focus_item == w)
                 l.append(rows)
                 remaining -= rows
-            elif f == GIVEN:
+            elif f == WidgetsChildrenSize.GIVEN:
                 l.append(height)
                 remaining -= height
             elif height:
@@ -1553,9 +1554,9 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         for i, (w, (f, height)) in enumerate(self.contents):
             item_focus = self.focus_item == w
             canv = None
-            if f == GIVEN:
+            if f == WidgetsChildrenSize.GIVEN:
                 canv = w.render((maxcol, height), focus=focus and item_focus)
-            elif f == PACK or len(size)==1:
+            elif f == WidgetsChildrenSize.PACK or len(size)==1:
                 canv = w.render((maxcol,), focus=focus and item_focus)
             else:
                 if item_rows is None:
@@ -1586,8 +1587,8 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         w, (f, height) = self.contents[i]
         item_rows = None
         maxcol = size[0]
-        if f == GIVEN or (f == WEIGHT and len(size) == 2):
-            if f == GIVEN:
+        if f == WidgetsChildrenSize.GIVEN or (f == WidgetsChildrenSize.WEIGHT and len(size) == 2):
+            if f == WidgetsChildrenSize.GIVEN:
                 maxrow = height
             else:
                 if item_rows is None:
@@ -1735,7 +1736,7 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
     """
     Widgets arranged horizontally in columns from left to right
     """
-    _sizing = frozenset([FLOW, BOX])
+    _sizing = frozenset([WidgetSize.FLOW, WidgetSize.BOX])
 
     def __init__(self, widget_list, dividechars=0, focus_column=None,
         min_width=1, box_columns=None):
@@ -1780,23 +1781,22 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         self._contents.set_validate_contents_modified(self._validate_contents_modified)
 
         box_columns = set(box_columns or ())
-
         for i, original in enumerate(widget_list):
             w = original
             if not isinstance(w, tuple):
-                self.contents.append((w, (WEIGHT, 1, i in box_columns)))
-            elif w[0] in (FLOW, PACK): # 'pack' used to be called 'flow'
-                f = PACK
+                self.contents.append((w, (WidgetsChildrenSize.WEIGHT, 1, i in box_columns)))
+            elif w[0] in (WidgetSize.FLOW, WidgetsChildrenSize.PACK): # 'pack' used to be called 'flow'
+                f = WidgetsChildrenSize.PACK
                 _ignored, w = w
                 self.contents.append((w, (f, None, i in box_columns)))
             elif len(w) == 2:
                 width, w = w
-                self.contents.append((w, (GIVEN, width, i in box_columns)))
-            elif w[0] == FIXED: # backwards compatibility
-                f = GIVEN
+                self.contents.append((w, (WidgetsChildrenSize.GIVEN, width, i in box_columns)))
+            elif w[0] == WidgetSize.FIXED: # backwards compatibility
+                f = WidgetsChildrenSize.GIVEN
                 _ignored, width, w = w
-                self.contents.append((w, (GIVEN, width, i in box_columns)))
-            elif w[0] == WEIGHT:
+                self.contents.append((w, (WidgetsChildrenSize.GIVEN, width, i in box_columns)))
+            elif w[0] == WidgetsChildrenSize.WEIGHT:
                 f, width, w = w
                 self.contents.append((w, (f, width, i in box_columns)))
             else:
@@ -1825,7 +1825,7 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         for item in new_items:
             try:
                 w, (t, n, b) = item
-                if t not in (PACK, GIVEN, WEIGHT):
+                if t not in (WidgetsChildrenSize.PACK, WidgetsChildrenSize.GIVEN, WidgetsChildrenSize.WEIGHT):
                     raise ValueError
             except (TypeError, ValueError):
                 raise ColumnsError("added content invalid %r" % (item,))
@@ -1841,7 +1841,7 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         self.contents = [
             (new, options) for (new, (w, options)) in zip(widgets,
                 # need to grow contents list if widgets is longer
-                chain(self.contents, repeat((None, (WEIGHT, 1, False)))))]
+                chain(self.contents, repeat((None, (WidgetsChildrenSize.WEIGHT, 1, False)))))]
         if focus_position < len(widgets):
             self.focus_position = focus_position
     widget_list = property(_get_widget_list, _set_widget_list, doc="""
@@ -1854,7 +1854,7 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
     def _get_column_types(self):
         ml = MonitoredList(
             # return the old column type names
-            ({GIVEN: FIXED, PACK: FLOW}.get(t, t), n)
+            ({WidgetsChildrenSize.GIVEN: WidgetSize.FIXED, WidgetsChildrenSize.PACK: WidgetSize.FLOW}.get(t, t), n)
             for w, (t, n, b) in self.contents)
         def user_modified():
             self._set_column_types(ml)
@@ -1863,7 +1863,8 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
     def _set_column_types(self, column_types):
         focus_position = self.focus_position
         self.contents = [
-            (w, ({FIXED: GIVEN, FLOW: PACK}.get(new_t, new_t), new_n, b))
+            (w, ({WidgetSize.FIXED: WidgetsChildrenSize.GIVEN,
+                  WidgetSize.FLOW: WidgetsChildrenSize.PACK}.get(new_t, new_t), new_n, b))
             for ((new_t, new_n), (w, (t, n, b)))
             in zip(column_types, self.contents)]
         if focus_position < len(column_types):
@@ -1898,7 +1899,7 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         import warnings
         warnings.warn(".has_flow_type is deprecated, "
             "read values from .contents instead.", DeprecationWarning)
-        return PACK in self.column_types
+        return WidgetsChildrenSize.PACK in self.column_types
     def _set_has_pack_type(self, value):
         import warnings
         warnings.warn(".has_flow_type is deprecated, "
@@ -1920,7 +1921,7 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         """)
 
     @staticmethod
-    def options(width_type=WEIGHT, width_amount=1, box_widget=False):
+    def options(width_type=WidgetsChildrenSize.WEIGHT, width_amount=1, box_widget=False):
         """
         Return a new options tuple for use in a Pile's .contents list.
 
@@ -1942,9 +1943,11 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
             widget when the Columns widget itself is treated as a flow widget.
         :type box_widget: bool
         """
-        if width_type == PACK:
+        if width_type == WidgetsChildrenSize.PACK:
             width_amount = None
-        if width_type not in (PACK, GIVEN, WEIGHT):
+        if width_type not in (WidgetsChildrenSize.PACK,
+                              WidgetsChildrenSize.GIVEN,
+                              WidgetsChildrenSize.WEIGHT):
             raise ColumnsError('invalid width_type: %r' % (width_type,))
         return (width_type, width_amount, box_widget)
 
@@ -2044,7 +2047,7 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         # FIXME: get rid of this check and recalculate only when
         # a 'pack' widget has been modified.
         if maxcol == self._cache_maxcol and not any(
-                t == PACK for w, (t, n, b) in self.contents):
+                t == WidgetsChildrenSize.PACK for w, (t, n, b) in self.contents):
             return self._cache_column_widths
 
         widths = []
@@ -2053,9 +2056,9 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         shared = maxcol + self.dividechars
 
         for i, (w, (t, width, b)) in enumerate(self.contents):
-            if t == GIVEN:
+            if t == WidgetsChildrenSize.GIVEN:
                 static_w = width
-            elif t == PACK:
+            elif t == WidgetsChildrenSize.PACK:
                 # FIXME: should be able to pack with a different
                 # maxcol value
                 static_w = w.pack((maxcol,), focus and i == self.focus_position)[0]
@@ -2067,7 +2070,7 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
 
             widths.append(static_w)
             shared -= static_w + self.dividechars
-            if t not in (GIVEN, PACK):
+            if t not in (WidgetsChildrenSize.GIVEN, WidgetsChildrenSize.PACK):
                 weighted.append((width, i))
 
         # drop columns on the left until we fit
@@ -2180,15 +2183,15 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         for i, (width, (w, options)) in enumerate(zip(widths, self.contents)):
             end = x + width
             if w.selectable():
-                if col != RIGHT and (col == LEFT or x > col) and best is None:
+                if col != WidgetAlignment.RIGHT and (col == WidgetAlignment.LEFT or x > col) and best is None:
                     # no other choice
                     best = i, x, end, w, options
                     break
-                if col != RIGHT and x > col and col-best[2] < x-col:
+                if col != WidgetAlignment.RIGHT and x > col and col-best[2] < x-col:
                     # choose one on left
                     break
                 best = i, x, end, w, options
-                if col != RIGHT and col < end:
+                if col != WidgetAlignment.RIGHT and col < end:
                     # choose this one
                     break
             x = end + self.dividechars

--- a/urwid/decoration.py
+++ b/urwid/decoration.py
@@ -22,13 +22,11 @@
 from __future__ import division, print_function
 
 from urwid.util import int_scale
-from urwid.widget import (Widget, WidgetError,
-    BOX, FLOW, LEFT, CENTER, RIGHT, PACK, CLIP, GIVEN, RELATIVE, RELATIVE_100,
-    TOP, MIDDLE, BOTTOM, delegate_to_widget_mixin)
+from urwid.widget import (Widget, WidgetError, delegate_to_widget_mixin)
 from urwid.split_repr import remove_defaults
 from urwid.canvas import CompositeCanvas, SolidCanvas
 from urwid.widget import Divider, Edit, Text, SolidFill # doctests
-
+from urwid.constants import WidgetAlignment, WidgetSize, WidgetsChildrenSize, TextWrapping
 
 class WidgetDecoration(Widget):  # "decorator" was already taken
     """
@@ -356,7 +354,7 @@ class BoxAdapter(WidgetDecoration):
         WidgetDecoration._set_original_widget)
 
     def sizing(self):
-        return set([FLOW])
+        return set([WidgetSize.FLOW])
 
     def rows(self, size, focus=False):
         """
@@ -417,7 +415,8 @@ class PaddingError(Exception):
     pass
 
 class Padding(WidgetDecoration):
-    def __init__(self, w, align=LEFT, width=RELATIVE_100, min_width=None,
+    def __init__(self, w, align=WidgetAlignment.LEFT,
+                 width=WidgetsChildrenSize.FILL_PARENT, min_width=None,
             left=0, right=0):
         """
         :param w: a box, flow or fixed widget to pad on the left and/or right
@@ -489,21 +488,21 @@ class Padding(WidgetDecoration):
             'fixed right'):
             if align[0]=='fixed left':
                 left = align[1]
-                align = LEFT
+                align = WidgetAlignment.LEFT
             else:
                 right = align[1]
-                align = RIGHT
+                align = WidgetAlignment.RIGHT
         if type(width) == tuple and width[0] in ('fixed left',
             'fixed right'):
             if width[0]=='fixed left':
                 left = width[1]
             else:
                 right = width[1]
-            width = RELATIVE_100
+            width = WidgetsChildrenSize.FILL_PARENT
 
         # convert old clipping mode width=None to width='clip'
         if width is None:
-            width = CLIP
+            width = TextWrapping.CLIP
 
         self.left = left
         self.right = right
@@ -514,8 +513,8 @@ class Padding(WidgetDecoration):
         self.min_width = min_width
 
     def sizing(self):
-        if self._width_type == CLIP:
-            return set([FLOW])
+        if self._width_type == TextWrapping.CLIP:
+            return set([WidgetSize.FLOW])
         return self.original_widget.sizing()
 
     def _repr_attrs(self):
@@ -561,7 +560,7 @@ class Padding(WidgetDecoration):
         maxcol = size[0]
         maxcol -= left+right
 
-        if self._width_type == CLIP:
+        if self._width_type == TextWrapping.CLIP:
             canv = self._original_widget.render((), focus)
         else:
             canv = self._original_widget.render((maxcol,)+size[1:], focus)
@@ -582,19 +581,19 @@ class Padding(WidgetDecoration):
 
         Override this method to define custom padding behaviour."""
         maxcol = size[0]
-        if self._width_type == CLIP:
+        if self._width_type == TextWrapping.CLIP:
             width, ignore = self._original_widget.pack((), focus=focus)
             return calculate_left_right_padding(maxcol,
                 self._align_type, self._align_amount,
-                CLIP, width, None, self.left, self.right)
-        if self._width_type == PACK:
+                TextWrapping.CLIP, width, None, self.left, self.right)
+        if self._width_type == WidgetsChildrenSize.PACK:
             maxwidth = max(maxcol - self.left - self.right,
                 self.min_width or 0)
             (width, ignore) = self._original_widget.pack((maxwidth,),
                 focus=focus)
             return calculate_left_right_padding(maxcol,
                 self._align_type, self._align_amount,
-                GIVEN, width, self.min_width,
+                WidgetsChildrenSize.GIVEN, width, self.min_width,
                 self.left, self.right)
         return calculate_left_right_padding(maxcol,
             self._align_type, self._align_amount,
@@ -605,11 +604,11 @@ class Padding(WidgetDecoration):
         """Return the rows needed for self.original_widget."""
         (maxcol,) = size
         left, right = self.padding_values(size, focus)
-        if self._width_type == PACK:
+        if self._width_type == WidgetsChildrenSize.PACK:
             pcols, prows = self._original_widget.pack((maxcol-left-right,),
                 focus)
             return prows
-        if self._width_type == CLIP:
+        if self._width_type == TextWrapping.CLIP:
             fcols, frows = self._original_widget.pack((), focus)
             return frows
         return self._original_widget.rows((maxcol-left-right,), focus=focus)
@@ -684,7 +683,7 @@ class FillerError(Exception):
     pass
 
 class Filler(WidgetDecoration):
-    def __init__(self, body, valign=MIDDLE, height=PACK, min_height=None,
+    def __init__(self, body, valign=WidgetAlignment.MIDDLE, height=WidgetsChildrenSize.PACK, min_height=None,
             top=0, bottom=0):
         """
         :param body: a flow widget or box widget to be filled around (stored
@@ -735,24 +734,24 @@ class Filler(WidgetDecoration):
                     raise FillerError("fixed top height may only be used "
                         "with fixed bottom valign")
                 top = height[1]
-                height = RELATIVE_100
+                height = WidgetsChildrenSize.FILL_PARENT
             elif height[0] == 'fixed bottom':
                 if not isinstance(valign, tuple) or valign[0] != 'fixed top':
                     raise FillerError("fixed bottom height may only be used "
                         "with fixed top valign")
                 bottom = height[1]
-                height = RELATIVE_100
+                height = WidgetsChildrenSize.FILL_PARENT
         if isinstance(valign, tuple):
             if valign[0] == 'fixed top':
                 top = valign[1]
-                valign = TOP
+                valign = WidgetAlignment.TOP
             elif valign[0] == 'fixed bottom':
                 bottom = valign[1]
-                valign = BOTTOM
+                valign = WidgetAlignment.BOTTOM
 
         # convert old flow mode parameter height=None to height='flow'
-        if height is None or height == FLOW:
-            height = PACK
+        if height is None or height == WidgetSize.FLOW:
+            height = WidgetsChildrenSize.PACK
 
         self.top = top
         self.bottom = bottom
@@ -761,7 +760,7 @@ class Filler(WidgetDecoration):
         self.height_type, self.height_amount = normalize_height(height,
             FillerError)
 
-        if self.height_type not in (GIVEN, PACK):
+        if self.height_type not in (WidgetsChildrenSize.GIVEN, WidgetsChildrenSize.PACK):
             self.min_height = min_height
         else:
             self.min_height = None
@@ -795,11 +794,11 @@ class Filler(WidgetDecoration):
         """
         (maxcol, maxrow) = size
 
-        if self.height_type == PACK:
+        if self.height_type == WidgetsChildrenSize.PACK:
             height = self._original_widget.rows((maxcol,),focus=focus)
             return calculate_top_bottom_filler(maxrow,
                 self.valign_type, self.valign_amount,
-                GIVEN, height,
+                WidgetsChildrenSize.GIVEN, height,
                 None, self.top, self.bottom)
 
         return calculate_top_bottom_filler(maxrow,
@@ -813,7 +812,7 @@ class Filler(WidgetDecoration):
         (maxcol, maxrow) = size
         top, bottom = self.filler_values(size, focus)
 
-        if self.height_type == PACK:
+        if self.height_type == WidgetsChildrenSize.PACK:
             canv = self._original_widget.render((maxcol,), focus)
         else:
             canv = self._original_widget.render((maxcol,maxrow-top-bottom),focus)
@@ -833,7 +832,7 @@ class Filler(WidgetDecoration):
     def keypress(self, size, key):
         """Pass keypress to self.original_widget."""
         (maxcol, maxrow) = size
-        if self.height_type == PACK:
+        if self.height_type == WidgetsChildrenSize.PACK:
             return self._original_widget.keypress((maxcol,), key)
 
         top, bottom = self.filler_values((maxcol,maxrow), True)
@@ -846,7 +845,7 @@ class Filler(WidgetDecoration):
             return None
 
         top, bottom = self.filler_values(size, True)
-        if self.height_type == PACK:
+        if self.height_type == WidgetsChildrenSize.PACK:
             coords = self._original_widget.get_cursor_coords((maxcol,))
         else:
             coords = self._original_widget.get_cursor_coords(
@@ -864,7 +863,7 @@ class Filler(WidgetDecoration):
         if not hasattr(self._original_widget, 'get_pref_col'):
             return None
 
-        if self.height_type == PACK:
+        if self.height_type == WidgetsChildrenSize.PACK:
             x = self._original_widget.get_pref_col((maxcol,))
         else:
             top, bottom = self.filler_values(size, True)
@@ -883,7 +882,7 @@ class Filler(WidgetDecoration):
         if row < top or row >= maxcol-bottom:
             return False
 
-        if self.height_type == PACK:
+        if self.height_type == WidgetsChildrenSize.PACK:
             return self._original_widget.move_cursor_to_coords((maxcol,),
                 col, row-top)
         return self._original_widget.move_cursor_to_coords(
@@ -899,7 +898,7 @@ class Filler(WidgetDecoration):
         if row < top or row >= maxrow-bottom:
             return False
 
-        if self.height_type == PACK:
+        if self.height_type == WidgetsChildrenSize.PACK:
             return self._original_widget.mouse_event((maxcol,),
                 event, button, col, row-top, focus)
         return self._original_widget.mouse_event((maxcol, maxrow-top-bottom),
@@ -931,9 +930,9 @@ def normalize_align(align, err):
     Split align into (align_type, align_amount).  Raise exception err
     if align doesn't match a valid alignment.
     """
-    if align in (LEFT, CENTER, RIGHT):
+    if align in (WidgetAlignment.LEFT, WidgetAlignment.CENTER, WidgetAlignment.RIGHT):
         return (align, None)
-    elif type(align) == tuple and len(align) == 2 and align[0] == RELATIVE:
+    elif type(align) == tuple and len(align) == 2 and align[0] == WidgetsChildrenSize.RELATIVE:
         return align
     raise err("align value %r is not one of 'left', 'center', "
         "'right', ('relative', percentage 0=left 100=right)"
@@ -944,7 +943,7 @@ def simplify_align(align_type, align_amount):
     Recombine (align_type, align_amount) into an align value.
     Inverse of normalize_align.
     """
-    if align_type == RELATIVE:
+    if align_type == WidgetsChildrenSize.RELATIVE:
         return (align_type, align_amount)
     return align_type
 
@@ -953,11 +952,11 @@ def normalize_width(width, err):
     Split width into (width_type, width_amount).  Raise exception err
     if width doesn't match a valid alignment.
     """
-    if width in (CLIP, PACK):
+    if width in (TextWrapping.CLIP, WidgetsChildrenSize.PACK):
         return (width, None)
     elif type(width) == int:
-        return (GIVEN, width)
-    elif type(width) == tuple and len(width) == 2 and width[0] == RELATIVE:
+        return (WidgetsChildrenSize.GIVEN, width)
+    elif type(width) == tuple and len(width) == 2 and width[0] == WidgetsChildrenSize.RELATIVE:
         return width
     raise err("width value %r is not one of fixed number of columns, "
         "'pack', ('relative', percentage of total width), 'clip'"
@@ -968,9 +967,9 @@ def simplify_width(width_type, width_amount):
     Recombine (width_type, width_amount) into an width value.
     Inverse of normalize_width.
     """
-    if width_type in (CLIP, PACK):
+    if width_type in (TextWrapping.CLIP, WidgetsChildrenSize.PACK):
         return width_type
-    elif width_type == GIVEN:
+    elif width_type == WidgetsChildrenSize.GIVEN:
         return width_amount
     return (width_type, width_amount)
 
@@ -979,10 +978,10 @@ def normalize_valign(valign, err):
     Split align into (valign_type, valign_amount).  Raise exception err
     if align doesn't match a valid alignment.
     """
-    if valign in (TOP, MIDDLE, BOTTOM):
+    if valign in (WidgetAlignment.TOP, WidgetAlignment.MIDDLE, WidgetAlignment.BOTTOM):
         return (valign, None)
     elif (isinstance(valign, tuple) and len(valign) == 2 and
-            valign[0] == RELATIVE):
+            valign[0] == WidgetsChildrenSize.RELATIVE):
         return valign
     raise err("valign value %r is not one of 'top', 'middle', "
         "'bottom', ('relative', percentage 0=left 100=right)"
@@ -993,7 +992,7 @@ def simplify_valign(valign_type, valign_amount):
     Recombine (valign_type, valign_amount) into an valign value.
     Inverse of normalize_valign.
     """
-    if valign_type == RELATIVE:
+    if valign_type == WidgetsChildrenSize.RELATIVE:
         return (valign_type, valign_amount)
     return valign_type
 
@@ -1002,13 +1001,13 @@ def normalize_height(height, err):
     Split height into (height_type, height_amount).  Raise exception err
     if height isn't valid.
     """
-    if height in (FLOW, PACK):
+    if height in (WidgetSize.FLOW, WidgetsChildrenSize.PACK):
         return (height, None)
     elif (isinstance(height, tuple) and len(height) == 2 and
-            height[0] == RELATIVE):
+            height[0] == WidgetsChildrenSize.RELATIVE):
         return height
     elif isinstance(height, int):
-        return (GIVEN, height)
+        return (WidgetsChildrenSize.GIVEN, height)
     raise err("height value %r is not one of fixed number of columns, "
         "'pack', ('relative', percentage of total height)"
         % (height,))
@@ -1018,9 +1017,9 @@ def simplify_height(height_type, height_amount):
     Recombine (height_type, height_amount) into an height value.
     Inverse of normalize_height.
     """
-    if height_type in (FLOW, PACK):
+    if height_type in (WidgetSize.FLOW, WidgetsChildrenSize.PACK):
         return height_type
-    elif height_type == GIVEN:
+    elif height_type == WidgetsChildrenSize.GIVEN:
         return height_amount
     return (height_type, height_amount)
 
@@ -1058,7 +1057,7 @@ def calculate_top_bottom_filler(maxrow, valign_type, valign_amount, height_type,
     >>> ctbf(20, 'relative', 30, 'relative', 60, 14, 0, 0)
     (2, 4)
     """
-    if height_type == RELATIVE:
+    if height_type == WidgetsChildrenSize.RELATIVE:
         maxheight = max(maxrow - top - bottom, 0)
         height = int_scale(height_amount, 101, maxheight + 1)
         if min_height is not None:
@@ -1066,7 +1065,9 @@ def calculate_top_bottom_filler(maxrow, valign_type, valign_amount, height_type,
     else:
         height = height_amount
 
-    standard_alignments = {TOP:0, MIDDLE:50, BOTTOM:100}
+    standard_alignments = {WidgetAlignment.TOP:0,
+                           WidgetAlignment.MIDDLE:50,
+                           WidgetAlignment.BOTTOM:100}
     valign = standard_alignments.get(valign_type, valign_amount)
 
     # add the remainder of top/bottom to the filler
@@ -1128,7 +1129,7 @@ def calculate_left_right_padding(maxcol, align_type, align_amount,
     >>> clrp(20, 'relative', 30, 'relative', 60, 14, 0, 0)
     (2, 4)
     """
-    if width_type == RELATIVE:
+    if width_type == WidgetsChildrenSize.RELATIVE:
         maxwidth = max(maxcol - left - right, 0)
         width = int_scale(width_amount, 101, maxwidth + 1)
         if min_width is not None:
@@ -1136,7 +1137,9 @@ def calculate_left_right_padding(maxcol, align_type, align_amount,
     else:
         width = width_amount
 
-    standard_alignments = {LEFT:0, CENTER:50, RIGHT:100}
+    standard_alignments = {WidgetAlignment.LEFT:0,
+                           WidgetAlignment.CENTER:50,
+                           WidgetAlignment.RIGHT:100}
     align = standard_alignments.get(align_type, align_amount)
 
     # add the remainder of left/right the padding
@@ -1155,7 +1158,7 @@ def calculate_left_right_padding(maxcol, align_type, align_amount,
         left += shift
 
     # only clip if width_type == 'clip'
-    if width_type != CLIP and (left < 0 or right < 0):
+    if width_type != TextWrapping.CLIP and (left < 0 or right < 0):
         left = max(left, 0)
         right = max(right, 0)
 

--- a/urwid/graphics.py
+++ b/urwid/graphics.py
@@ -26,16 +26,17 @@ from urwid.compat import ord2, with_metaclass
 from urwid.util import decompose_tagmarkup, get_encoding_mode
 from urwid.canvas import CompositeCanvas, CanvasJoin, TextCanvas, \
     CanvasCombine, SolidCanvas
-from urwid.widget import WidgetMeta, Widget, BOX, FIXED, FLOW, \
+from urwid.widget import WidgetMeta, Widget, \
     nocache_widget_render, nocache_widget_render_instance, fixed_size, \
-    WidgetWrap, Divider, SolidFill, Text, CENTER, CLIP
+    WidgetWrap, Divider, SolidFill, Text
 from urwid.container import Pile, Columns
 from urwid.display_common import AttrSpec
 from urwid.decoration import WidgetDecoration
+from urwid.constants import WidgetAlignment, WidgetSize, WidgetsChildrenSize
 
 
 class BigText(Widget):
-    _sizing = frozenset([FIXED])
+    _sizing = frozenset([WidgetSize.FIXED])
 
     def __init__(self, markup, font):
         """
@@ -247,7 +248,7 @@ class BarGraphError(Exception):
     pass
 
 class BarGraph(with_metaclass(BarGraphMeta, Widget)):
-    _sizing = frozenset([BOX])
+    _sizing = frozenset([WidgetSize.BOX])
 
     ignore_focus = True
 
@@ -770,7 +771,7 @@ def calculate_bargraph_display(bardata, top, bar_widths, maxrow):
 
 
 class GraphVScale(Widget):
-    _sizing = frozenset([BOX])
+    _sizing = frozenset([WidgetSize.BOX])
 
     def __init__(self, labels, top):
         """
@@ -848,11 +849,11 @@ def scale_bar_values( bar, top, maxrow ):
 
 
 class ProgressBar(Widget):
-    _sizing = frozenset([FLOW])
+    _sizing = frozenset([WidgetSize.FLOW])
 
     eighths = u' ▏▎▍▌▋▊▉'
 
-    text_align = CENTER
+    text_align = WidgetAlignment.CENTER
 
     def __init__(self, normal, complete, current=0, done=100, satt=None):
         """
@@ -961,7 +962,7 @@ class ProgressBar(Widget):
 
 
 class PythonLogo(Widget):
-    _sizing = frozenset([FIXED])
+    _sizing = frozenset([WidgetSize.FIXED])
 
     def __init__(self):
         """

--- a/urwid/listbox.py
+++ b/urwid/listbox.py
@@ -24,7 +24,9 @@ from __future__ import division, print_function
 from urwid.compat import xrange, with_metaclass
 from urwid.util import is_mouse_press
 from urwid.canvas import SolidCanvas, CanvasCombine
-from urwid.widget import Widget, nocache_widget_render_instance, BOX, GIVEN
+from urwid.widget import Widget, nocache_widget_render_instance
+from urwid.constants import WidgetSize, WidgetsChildrenSize
+
 from urwid.decoration import calculate_top_bottom_filler, normalize_valign
 from urwid import signals
 from urwid.signals import connect_signal
@@ -227,7 +229,7 @@ class ListBox(Widget, WidgetContainerMixin):
     a horizontally stacked list of widgets
     """
     _selectable = True
-    _sizing = frozenset([BOX])
+    _sizing = frozenset([WidgetSize.BOX])
 
     def __init__(self, body):
         """
@@ -628,7 +630,7 @@ class ListBox(Widget, WidgetContainerMixin):
 
         rows = focus_widget.rows((maxcol,), focus)
         rtop, rbot = calculate_top_bottom_filler(maxrow,
-            vt, va, GIVEN, rows, None, 0, 0)
+            vt, va, WidgetsChildrenSize.GIVEN, rows, None, 0, 0)
 
         self.shift_focus((maxcol, maxrow), rtop)
 

--- a/urwid/text_layout.py
+++ b/urwid/text_layout.py
@@ -25,6 +25,8 @@ from __future__ import division, print_function
 from urwid.util import calc_width, calc_text_pos, calc_trim_text, is_wide_char, \
     move_prev_char, move_next_char
 from urwid.compat import bytes, PYTHON3, B, xrange
+from urwid.constants import WidgetAlignment, TextWrapping
+
 
 class TextLayout:
     def supports_align_mode(self, align):
@@ -74,11 +76,9 @@ class StandardTextLayout(TextLayout):
         #self.tab_stops = tab_stops
         #self.tab_stop_every = tab_stop_every
     def supports_align_mode(self, align):
-        """Return True if align is 'left', 'center' or 'right'."""
-        return align in ('left', 'center', 'right')
+        return align in WidgetAlignment
     def supports_wrap_mode(self, wrap):
-        """Return True if wrap is 'any', 'space', 'clip' or 'ellipsis'."""
-        return wrap in ('any', 'space', 'clip', 'ellipsis')
+        return wrap in TextWrapping
     def layout(self, text, width, align, wrap ):
         """Return a layout structure for text."""
         try:
@@ -107,14 +107,14 @@ class StandardTextLayout(TextLayout):
         out = []
         for l in segs:
             sc = line_width(l)
-            if sc == width or align=='left':
+            if sc == width or align==WidgetAlignment.LEFT:
                 out.append(l)
                 continue
 
-            if align == 'right':
+            if align == WidgetAlignment.RIGHT:
                 out.append([(width-sc, None)] + l)
                 continue
-            assert align == 'center'
+            assert align == WidgetAlignment.CENTER
             out.append([((width-sc+1) // 2, None)] + l)
         return out
 
@@ -137,7 +137,7 @@ class StandardTextLayout(TextLayout):
             sp_o = ord(sp_o)
         b = []
         p = 0
-        if wrap in ('clip', 'ellipsis'):
+        if wrap in (TextWrapping.ELLIPSIS, TextWrapping.CLIP):
             # no wrapping to calculate, so it's easy.
             while p<=len(text):
                 n_cr = text.find(nl, p)

--- a/urwid/vterm.py
+++ b/urwid/vterm.py
@@ -43,7 +43,8 @@ except ImportError:
 from urwid import util
 from urwid.escape import DEC_SPECIAL_CHARS, ALT_DEC_SPECIAL_CHARS
 from urwid.canvas import Canvas
-from urwid.widget import Widget, BOX
+from urwid.widget import Widget
+from urwid.constants import WidgetSize
 from urwid.display_common import AttrSpec, RealTerminal, _BASIC_COLORS
 from urwid.compat import ord2, chr2, B, bytes, PYTHON3, xrange
 
@@ -1325,7 +1326,7 @@ class TermCanvas(Canvas):
 
 class Terminal(Widget):
     _selectable = True
-    _sizing = frozenset([BOX])
+    _sizing = frozenset([WidgetSize.BOX])
 
     signals = ['closed', 'beep', 'leds', 'title']
 

--- a/urwid/widget.py
+++ b/urwid/widget.py
@@ -35,39 +35,9 @@ from urwid.command_map import (command_map, CURSOR_LEFT, CURSOR_RIGHT,
     CURSOR_UP, CURSOR_DOWN, CURSOR_MAX_LEFT, CURSOR_MAX_RIGHT)
 from urwid.split_repr import split_repr, remove_defaults, python3_repr
 
-
-# define some names for these constants to avoid misspellings in the source
-# and to document the constant strings we are using
-
-# Widget sizing methods
-
-FLOW = 'flow'
-BOX = 'box'
-FIXED = 'fixed'
-
-# Text alignment modes
-LEFT = 'left'
-RIGHT = 'right'
-CENTER = 'center'
-
-# Filler alignment
-TOP = 'top'
-MIDDLE = 'middle'
-BOTTOM = 'bottom'
-
-# Text wrapping modes
-SPACE = 'space'
-ANY = 'any'
-CLIP = 'clip'
-ELLIPSIS = 'ellipsis'
-
-# Width and Height settings
-PACK = 'pack'
-GIVEN = 'given'
-RELATIVE = 'relative'
-RELATIVE_100 = (RELATIVE, 100)
-WEIGHT = 'weight'
-
+from urwid.constants import FLOW, BOX, FIXED, LEFT, RIGHT, CENTER
+from urwid.constants import TOP, MIDDLE, BOTTOM, SPACE, ANY, CLIP
+from urwid.constants import PACK, GIVEN, RELATIVE, RELATIVE_100, WEIGHT
 
 class WidgetMeta(MetaSuper, signals.MetaSignals):
     """

--- a/urwid/wimp.py
+++ b/urwid/wimp.py
@@ -21,8 +21,7 @@
 
 from __future__ import division, print_function
 
-from urwid.widget import (Text, WidgetWrap, delegate_to_widget_mixin, BOX,
-    FLOW)
+from urwid.widget import (Text, WidgetWrap, delegate_to_widget_mixin)
 from urwid.canvas import CompositeCanvas
 from urwid.signals import connect_signal
 from urwid.container import Columns, Overlay
@@ -32,12 +31,12 @@ from urwid.signals import disconnect_signal # doctests
 from urwid.split_repr import python3_repr
 from urwid.decoration import WidgetDecoration
 from urwid.command_map import ACTIVATE
-from urwid.constants import LEFT
+from urwid.constants import WidgetAlignment, WidgetSize
 
 class SelectableIcon(Text):
     ignore_focus = False
     _selectable = True
-    def __init__(self, text, cursor_position=0, align=LEFT):
+    def __init__(self, text, cursor_position=0, align=WidgetAlignment.LEFT):
         """
         :param text: markup for this widget; see :class:`Text` for
                      description of text markup
@@ -104,7 +103,7 @@ class CheckBoxError(Exception):
 
 class CheckBox(WidgetWrap):
     def sizing(self):
-        return frozenset([FLOW])
+        return frozenset([WidgetSize.FLOW])
 
     states = {
         True: SelectableIcon("[X]", 1),
@@ -446,14 +445,14 @@ class RadioButton(CheckBox):
 
 class Button(WidgetWrap):
     def sizing(self):
-        return frozenset([FLOW])
+        return frozenset([WidgetSize.FLOW])
 
     button_left = Text("<")
     button_right = Text(">")
 
     signals = ["click"]
 
-    def __init__(self, label, on_press=None, user_data=None, align=LEFT):
+    def __init__(self, label, on_press=None, user_data=None, align=WidgetAlignment.LEFT):
         """
         :param label: markup for button label
         :param on_press: shorthand for connect_signal()
@@ -616,7 +615,7 @@ class PopUpLauncher(delegate_to_widget_mixin('_original_widget'),
 class PopUpTarget(WidgetDecoration):
     # FIXME: this whole class is a terrible hack and must be fixed
     # when layout and rendering are separated
-    _sizing = set([BOX])
+    _sizing = set([WidgetSize.BOX])
     _selectable = True
 
     def __init__(self, original_widget):

--- a/urwid/wimp.py
+++ b/urwid/wimp.py
@@ -32,22 +32,25 @@ from urwid.signals import disconnect_signal # doctests
 from urwid.split_repr import python3_repr
 from urwid.decoration import WidgetDecoration
 from urwid.command_map import ACTIVATE
+from urwid.constants import LEFT
 
 class SelectableIcon(Text):
     ignore_focus = False
     _selectable = True
-    def __init__(self, text, cursor_position=0):
+    def __init__(self, text, cursor_position=0, align=LEFT):
         """
         :param text: markup for this widget; see :class:`Text` for
                      description of text markup
         :param cursor_position: position the cursor will appear in the
                                 text when this widget is in focus
+        :param align: markup for this widget; see :class:`Text` for
+                      description of align
 
         This is a text widget that is selectable.  A cursor
         displayed at a fixed location in the text when in focus.
         This widget has no special handling of keyboard or mouse input.
         """
-        self.__super.__init__(text)
+        self.__super.__init__(text, align=align)
         self._cursor_position = cursor_position
 
     def render(self, size, focus=False):
@@ -450,12 +453,13 @@ class Button(WidgetWrap):
 
     signals = ["click"]
 
-    def __init__(self, label, on_press=None, user_data=None):
+    def __init__(self, label, on_press=None, user_data=None, align=LEFT):
         """
         :param label: markup for button label
         :param on_press: shorthand for connect_signal()
                          function call for a single callback
         :param user_data: user_data for on_press
+        :param align: typically (default) ``'left'``, ``'right'``, ``'center'``
 
         Signals supported: ``'click'``
 
@@ -473,8 +477,11 @@ class Button(WidgetWrap):
         >>> b = Button("Cancel")
         >>> b.render((15,), focus=True).text # ... = b in Python 3
         [...'< Cancel      >']
+        >>> b = Button("Cancel", align="center")
+        >>> b.render((15,), focus=True).text # ... = b in Python 3
+        [...'<    Cancel   >']
         """
-        self._label = SelectableIcon("", 0)
+        self._label = SelectableIcon("", 0, align=align)
         cols = Columns([
             ('fixed', 1, self.button_left),
             self._label,


### PR DESCRIPTION
##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [ ] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
Patch
- separates constants from widget.py to a file and
- lets to set horizontal alignment for button:
'<   button   >'
'<    ✔   >']