### PR TITLE
Fix crash when clicking non-clickable topmost widgets

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,6 +82,7 @@ Contributors
 - `inducer <//github.com/inducer>`_
 - `winbornejw <//github.com/winbornejw>`_
 - `hootnot <//github.com/hootnot>`_
+- `raek <//github.com/raek>`_
 
 
 .. |pypi| image:: http://img.shields.io/pypi/v/urwid.svg

--- a/urwid/main_loop.py
+++ b/urwid/main_loop.py
@@ -504,9 +504,10 @@ class MainLoop(object):
                 continue
             if is_mouse_event(k):
                 event, button, col, row = k
-                if self._topmost_widget.mouse_event(self.screen_size,
-                    event, button, col, row, focus=True ):
-                    k = None
+                if hasattr(self._topmost_widget, "mouse_event"):
+                    if self._topmost_widget.mouse_event(self.screen_size,
+                            event, button, col, row, focus=True):
+                        k = None
             elif self._topmost_widget.selectable():
                 k = self._topmost_widget.keypress(self.screen_size, k)
             if k:


### PR DESCRIPTION
##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment **I only managed to run tox  for py27,py36,py37,pypy**
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature) **no new features**

##### Description:

Handle case where MainLoop._topmost_widget does not implement mouse_event

Code that passes mouse_events to child widgets check if the widget implements the mouse_event() method, but this was not checked in MainLoop.process_input(). This results in a crash. Minimal example:
    
    import urwid
    urwid.MainLoop(urwid.SolidFill("X")).run()
    # ...then click anywhere

