### PR TITLE
Make options a static method where applicable

### DIFF
--- a/urwid/container.py
+++ b/urwid/container.py
@@ -512,7 +512,8 @@ class Overlay(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         self.set_overlay_parameters(align, width, valign, height,
             min_width, min_height, left, right, top, bottom)
 
-    def options(self, align_type, align_amount, width_type, width_amount,
+    @staticmethod
+    def options(align_type, align_amount, width_type, width_amount,
             valign_type, valign_amount, height_type, height_amount,
             min_width=None, min_height=None, left=0, right=0, top=0, bottom=0):
         """
@@ -1346,7 +1347,8 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         .. seealso:: Create new options tuples with the :meth:`options` method
         """)
 
-    def options(self, height_type=WEIGHT, height_amount=1):
+    @staticmethod
+    def options(height_type=WEIGHT, height_amount=1):
         """
         Return a new options tuple for use in a Pile's :attr:`contents` list.
 
@@ -1876,7 +1878,8 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         .. seealso:: Create new options tuples with the :meth:`options` method
         """)
 
-    def options(self, width_type=WEIGHT, width_amount=1, box_widget=False):
+    @staticmethod
+    def options(width_type=WEIGHT, width_amount=1, box_widget=False):
         """
         Return a new options tuple for use in a Pile's .contents list.
 


### PR DESCRIPTION
##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
The `options` method of several container widgets can be made a `staticmethod`, which came in handy in my project. However, this can't be done consistently, as the `GridFlow` widget requires an instance attribute in that method. So I'm not sure if this really is a change one would want to include. Opinions?

