### PR TITLE
Make Columns and Pile selectable when any child widget is

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,6 +82,7 @@ Contributors
 - `inducer <//github.com/inducer>`_
 - `winbornejw <//github.com/winbornejw>`_
 - `hootnot <//github.com/hootnot>`_
+- `raek <//github.com/raek>`_
 
 
 .. |pypi| image:: http://img.shields.io/pypi/v/urwid.svg

--- a/urwid/main_loop.py
+++ b/urwid/main_loop.py
@@ -504,9 +504,10 @@ class MainLoop(object):
                 continue
             if is_mouse_event(k):
                 event, button, col, row = k
-                if self._topmost_widget.mouse_event(self.screen_size,
-                    event, button, col, row, focus=True ):
-                    k = None
+                if hasattr(self._topmost_widget, "mouse_event"):
+                    if self._topmost_widget.mouse_event(self.screen_size,
+                            event, button, col, row, focus=True):
+                        k = None
             elif self._topmost_widget.selectable():
                 k = self._topmost_widget.keypress(self.screen_size, k)
             if k:


### PR DESCRIPTION
##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
Currently changing the contents of a `Columns` or a `Pile` widget may break the focus. Specifically the `focus_position` is not updated, making it possible to end up with a focused child widget that is not selectable. This propagates to the Container widget, making it not selectable and therefore not responding to keypresses anymore, thus trapping the focus.
This PR changes the selectability of the 2 container widgets to be selectable whenever _any_ child widget is. An alternative fix would be to need explicit user code for such situations, maybe with something like in #154, but I think this solution is the one with the more expected behaviour.

