### PR TITLE
Ellipsis

### DIFF
--- a/docs/manual/textlayout.rst
+++ b/docs/manual/textlayout.rst
@@ -9,7 +9,8 @@
 Mapping a text string to screen coordinates within a widget is called text
 layout. The :class:`Text` widget's default layout class supports
 aligning text to the left, center or right, and can wrap text on space
-characters, at any location, or clip text that is off the edge.
+characters, at any location, or clip text that is off the edge, optionally
+inserting an ellipsis character.
 
 ::
 
@@ -59,6 +60,12 @@ characters, at any location, or clip text that is off the edge.
     wrap='clip'
     +----------------+   +------------------------+
     |Showing some dif|   |Showing some different w|
+    |newline         |   |newline                 |
+    +----------------+   +------------------------+
+
+    wrap='ellipsis'
+    +----------------+   +------------------------+
+    |Showing some di…|   |Showing some different …|
     |newline         |   |newline                 |
     +----------------+   +------------------------+
 

--- a/docs/reference/constants.rst
+++ b/docs/reference/constants.rst
@@ -121,7 +121,13 @@ Text Wrapping Modes
    :annotation: = 'clip'
 
    clip before any wide or narrow character that would exceed the available
-   screen columns ad don't display the remaining text on the line
+   screen columns and don't display the remaining text on the line
+
+.. data:: ELLIPSIS
+   :annotation: = 'ellipsis'
+
+   clip if text would exceed the available screen columns, add an ellipsis
+   character at the end
 
 
 Foreground and Background Colors

--- a/examples/tour.py
+++ b/examples/tour.py
@@ -53,6 +53,10 @@ def main():
         u"Text will be cut off at the left of this widget.")
     text_center_clip = (u"Center aligned and clipped widgets will have "
         u"text cut off both sides.")
+    text_ellipsis = (u"Text can be clippped using the ellipsis character (…)\n"
+        u"Extra text is discarded and a … mark is shown."
+         u"50-> 55-> 60-> 65-> 70-> 75-> 80-> 85-> 90-> 95-> 100>\n"
+    )
     text_any = (u"The 'any' wrap mode will wrap on any character.  This "
         u"mode will not collapse space characters at the end of the "
         u"line but it still honors embedded newline characters.\n"
@@ -149,6 +153,8 @@ def main():
         urwid.Text(text_right_clip, align='right', wrap='clip'),
         blank,
         urwid.Text(text_center_clip, align='center', wrap='clip'),
+        blank,
+        urwid.Text(text_ellipsis, wrap='ellipsis'),
         blank,
         urwid.Text(text_any, wrap='any'),
         blank,

--- a/urwid/canvas.py
+++ b/urwid/canvas.py
@@ -1228,7 +1228,8 @@ def apply_text_layout(text, attr, ls, maxcol):
             aw.k = 0
             aw.off = 0
         o = []
-        while aw.off < end_offs:
+        # the loop should run at least once, the '=' part ensures that
+        while aw.off <= end_offs:
             if len(attr)<=aw.k:
                 # run out of attributes
                 o.append((None,end_offs-max(start_offs,aw.off)))

--- a/urwid/text_layout.py
+++ b/urwid/text_layout.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+# -*- coding: utf-8 -*-
 #
 # Urwid Text Layout classes
 #    Copyright (C) 2004-2011  Ian Ward
@@ -162,7 +163,7 @@ class StandardTextLayout(TextLayout):
                 if p!=n_end:
                     l += [(sc, p, n_end)]
                 if trimmed:
-                    l += [(1, n_end, '…'.encode())]
+                    l += [(1, n_end, u'…'.encode())]
                 l += [(pad_right,n_end)]
                 b.append(l)
                 p = n_cr+1

--- a/urwid/widget.py
+++ b/urwid/widget.py
@@ -59,6 +59,7 @@ BOTTOM = 'bottom'
 SPACE = 'space'
 ANY = 'any'
 CLIP = 'clip'
+ELLIPSIS = 'ellipsis'
 
 # Width and Height settings
 PACK = 'pack'
@@ -813,7 +814,7 @@ class Text(Widget):
         :type markup: :ref:`text-markup`
         :param align: typically ``'left'``, ``'center'`` or ``'right'``
         :type align: text alignment mode
-        :param wrap: typically ``'space'``, ``'any'`` or ``'clip'``
+        :param wrap: typically ``'space'``, ``'any'``, ``'clip'`` or ``'ellipsis'``
         :type wrap: text wrapping mode
         :param layout: defaults to a shared :class:`StandardTextLayout` instance
         :type layout: text layout instance
@@ -937,7 +938,7 @@ class Text(Widget):
         Set text wrapping mode. Supported modes depend on text layout
         object in use but defaults to a :class:`StandardTextLayout` instance
 
-        :param mode: typically ``'space'``, ``'any'`` or ``'clip'``
+        :param mode: typically ``'space'``, ``'any'``, ``'clip'`` or ``'ellipsis'``
         :type mode: text wrapping mode
 
         >>> t = Text(u"some words")
@@ -966,7 +967,7 @@ class Text(Widget):
         the same time.
 
         :type align: text alignment mode
-        :param wrap: typically 'space', 'any' or 'clip'
+        :param wrap: typically 'space', 'any', 'clip' or 'ellipsis'
         :type wrap: text wrapping mode
         :param layout: defaults to a shared :class:`StandardTextLayout` instance
         :type layout: text layout instance


### PR DESCRIPTION
##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
Implement a new wrapping mode `ellipsis` for `StandardTextLayout` which works like `clip` but inserts an ellipsis `…` character at the end, if the text has been clipped.
This mode will behave strangely with the `Edit` widget, so I'm not completely sure about this PR. Maybe this should be added as a separate layout class?

