### PR TITLE
Fix Python 3.8 SyntaxWarning: 'str' object is not callable

### DIFF
--- a/urwid/tests/test_canvas.py
+++ b/urwid/tests/test_canvas.py
@@ -138,15 +138,15 @@ class ShardBodyTest(unittest.TestCase):
 class ShardsTrimTest(unittest.TestCase):
     def sttop(self, shards, top, expected):
         result = canvas.shards_trim_top(shards, top)
-        assert result == expected, "got: %r expected: %r" (result, expected)
+        assert result == expected, "got: %r expected: %r" % (result, expected)
 
     def strows(self, shards, rows, expected):
         result = canvas.shards_trim_rows(shards, rows)
-        assert result == expected, "got: %r expected: %r" (result, expected)
+        assert result == expected, "got: %r expected: %r" % (result, expected)
 
     def stsides(self, shards, left, cols, expected):
         result = canvas.shards_trim_sides(shards, left, cols)
-        assert result == expected, "got: %r expected: %r" (result, expected)
+        assert result == expected, "got: %r expected: %r" % (result, expected)
 
 
     def test1(self):
@@ -229,7 +229,7 @@ class ShardsTrimTest(unittest.TestCase):
 class ShardsJoinTest(unittest.TestCase):
     def sjt(self, shard_lists, expected):
         result = canvas.shards_join(shard_lists)
-        assert result == expected, "got: %r expected: %r" (result, expected)
+        assert result == expected, "got: %r expected: %r" % (result, expected)
 
     def test(self):
         shards1 = [(5, [(0,0,10,5,None,"foo"), (0,0,5,8,None,"baz")]),


### PR DESCRIPTION
##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [ ] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:

Fixes these warnings from Python 3.8:

```
/usr/lib/python3/dist-packages/urwid/tests/test_canvas.py:141: SyntaxWarning: 'str' object is not callable; perhaps you missed a comma?
  assert result == expected, "got: %r expected: %r" (result, expected)
/usr/lib/python3/dist-packages/urwid/tests/test_canvas.py:145: SyntaxWarning: 'str' object is not callable; perhaps you missed a comma?
  assert result == expected, "got: %r expected: %r" (result, expected)
/usr/lib/python3/dist-packages/urwid/tests/test_canvas.py:149: SyntaxWarning: 'str' object is not callable; perhaps you missed a comma?
  assert result == expected, "got: %r expected: %r" (result, expected)
/usr/lib/python3/dist-packages/urwid/tests/test_canvas.py:232: SyntaxWarning: 'str' object is not callable; perhaps you missed a comma?
  assert result == expected, "got: %r expected: %r" (result, expected)
```
