### PR TITLE
Do not call wait_readable with a closed fd in TrioEventLoop

### DIFF
--- a/urwid/_async_kw_event_loop.py
+++ b/urwid/_async_kw_event_loop.py
@@ -227,6 +227,9 @@ class TrioEventLoop(EventLoop):
             callback: the callback to call
         """
         with scope:
-            while True:
+            # We check for the scope being cancelled before calling
+            # wait_readable because if callback cancels the scope, fd might be
+            # closed and calling wait_readable with a closed fd does not work.
+            while not scope.cancel_called:
                 await self._wait_readable(fd)
                 callback()


### PR DESCRIPTION
Fixes #378

##### Checklist
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment

##### Description:

See the linked issue for rationale.
