### PR TITLE
Fixes Terminal in ListBox

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,6 +94,7 @@ Contributors
 `BkPHcgQL3V <//github.com/BkPHcgQL3V>`_,
 `BlindB0 <//github.com/BlindB0>`_,
 `bukzor <//github.com/bukzor>`_,
+`d0c-s4vage <//github.com/d0c-s4vage>`_,
 `eevee <//github.com/eevee>`_,
 `federicotdn <//github.com/federicotdn>`_,
 `garrison <//github.com/garrison>`_,

--- a/urwid/listbox.py
+++ b/urwid/listbox.py
@@ -324,7 +324,7 @@ class ListBox(Widget, WidgetContainerMixin):
         cursor = None
         if maxrow and focus_widget.selectable() and focus:
             if hasattr(focus_widget,'get_cursor_coords'):
-                cursor=focus_widget.get_cursor_coords((maxcol,))
+                cursor = focus_widget.get_cursor_coords((maxcol,))
 
         if cursor is not None:
             cx, cy = cursor

--- a/urwid/tests/test_vterm.py
+++ b/urwid/tests/test_vterm.py
@@ -245,6 +245,26 @@ class TermTest(unittest.TestCase):
         self.write('\e[?6h\e[10;20r\e[10f1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\e[faa')
         self.expect('\n' * 9 + 'aa\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12')
 
+    def test_scrolling_region_simple_with_focus(self):
+        self.write('\e[10;20r\e[10f1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\e[faa')
+        self.expect('aa' + '\n' * 9 + '2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12', focus=True)
+
+    def test_scrolling_region_reverse_with_focus(self):
+        self.write('\e[2J\e[1;2r\e[5Baaa\r\eM\eM\eMbbb\nXXX')
+        self.expect('\n\nbbb\nXXX\n\naaa', focus=True)
+
+    def test_scrolling_region_move_with_focus(self):
+        self.write('\e[10;20r\e[2J\e[10Bfoo\rbar\rblah\rmooh\r\e[10Aone\r\eM\eMtwo\r\eM\eMthree\r\eM\eMa')
+        self.expect('ahree\n\n\n\n\n\n\n\n\n\nmooh', focus=True)
+
+    def test_scrolling_twice_with_focus(self):
+        self.write('\e[?6h\e[10;20r\e[2;5rtest')
+        self.expect('\ntest', focus=True)
+
+    def test_cursor_scrolling_region_with_focus(self):
+        self.write('\e[?6h\e[10;20r\e[10f1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\e[faa')
+        self.expect('\n' * 9 + 'aa\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12', focus=True)
+
     def test_relative_region_jump(self):
         self.write('\e[21H---\e[10;20r\e[?6h\e[18Htest')
         self.expect('\n' * 19 + 'test\n---')

--- a/urwid/tests/test_vterm.py
+++ b/urwid/tests/test_vterm.py
@@ -25,6 +25,8 @@ import unittest
 
 from itertools import dropwhile
 
+from urwid.listbox import ListBox
+from urwid.decoration import BoxAdapter
 from urwid import vterm
 from urwid import signals
 from urwid.compat import B
@@ -344,3 +346,7 @@ class TermTest(unittest.TestCase):
         self.expect('test2')
         self.expect_signal('caps_lock')
         self.disconnect_signal('leds')
+
+    def test_in_listbox(self):
+        listbox = ListBox([BoxAdapter(self.term, 80)])
+        rendered = listbox.render((80, 24))

--- a/urwid/tests/test_vterm.py
+++ b/urwid/tests/test_vterm.py
@@ -104,9 +104,9 @@ class TermTest(unittest.TestCase):
     def flush(self):
         self.write(chr(0x7f))
 
-    def read(self, raw=False):
+    def read(self, raw=False, focus=False):
         self.term.wait_and_feed()
-        rendered = self.term.render(self.termsize, focus=False)
+        rendered = self.term.render(self.termsize, focus=focus)
         if raw:
             is_empty = lambda c: c == (None, None, B(' '))
             content = list(rendered.content())
@@ -118,10 +118,10 @@ class TermTest(unittest.TestCase):
             lines = [line.rstrip() for line in content]
             return B('\n').join(lines).rstrip()
 
-    def expect(self, what, desc=None, raw=False):
+    def expect(self, what, desc=None, raw=False, focus=False):
         if not isinstance(what, list):
             what = B(what)
-        got = self.read(raw=raw)
+        got = self.read(raw=raw, focus=focus)
         if desc is None:
             desc = ''
         else:
@@ -269,10 +269,10 @@ class TermTest(unittest.TestCase):
 
     def test_cursor_visibility(self):
         self.write('\e[?25linvisible')
-        self.expect('invisible')
+        self.expect('invisible', focus=True)
         self.assertEqual(self.term.term.cursor, None)
         self.write('\rvisible\e[?25h\e[K')
-        self.expect('visible')
+        self.expect('visible', focus=True)
         self.assertNotEqual(self.term.term.cursor, None)
 
     def test_get_utf8_len(self):

--- a/urwid/vterm.py
+++ b/urwid/vterm.py
@@ -153,7 +153,7 @@ class TermModes(object):
         self.reverse_video = False
         self.constrain_scrolling = False
         self.autowrap = True
-        self.visible_cursor = True
+        self.visible_cursor = False
 
         # charset stuff
         self.main_charset = CHARSET_DEFAULT
@@ -1397,8 +1397,7 @@ class Terminal(Widget):
 
         # temporarily set width/height to figure out the new cursor position
         # given the provided width/height
-        orig_width = self.term.width
-        orig_height = self.term.height
+        orig_width, orig_height = self.term.width, self.term.height
 
         self.term.width = size[0]
         self.term.height = size[1]
@@ -1408,8 +1407,7 @@ class Terminal(Widget):
             self.term.term_cursor[1],
         )
 
-        self.term.width = orig_width
-        self.term.height = orig_height
+        self.term.width, self.term.height = orig_width, orig_height
 
         return (x, y)
 

--- a/urwid/vterm.py
+++ b/urwid/vterm.py
@@ -153,7 +153,7 @@ class TermModes(object):
         self.reverse_video = False
         self.constrain_scrolling = False
         self.autowrap = True
-        self.visible_cursor = False
+        self.visible_cursor = True
 
         # charset stuff
         self.main_charset = CHARSET_DEFAULT
@@ -247,6 +247,7 @@ class TermCanvas(Canvas):
         self.width, self.height = width, height
         self.widget = widget
         self.modes = widget.term_modes
+        self.has_focus = False
 
         self.scrollback_buffer = TermScroller()
         self.scrolling_up = 0
@@ -270,7 +271,9 @@ class TermCanvas(Canvas):
 
         self.term_cursor = self.constrain_coords(x, y)
 
-        if self.modes.visible_cursor and self.scrolling_up < self.height - y:
+        if self.has_focus \
+                and self.modes.visible_cursor \
+                and self.scrolling_up < self.height - y:
             self.cursor = (x, y + self.scrolling_up)
         else:
             self.cursor = None
@@ -1519,16 +1522,14 @@ class Terminal(Widget):
 
         self.has_focus = has_focus
 
+        if self.term is not None:
+            self.term.has_focus = has_focus
+            self.term.set_term_cursor()
+
         if has_focus:
-            if self.term is not None:
-                self.term.modes.visible_cursor = True
-                self.term.set_term_cursor()
             self.old_tios = RealTerminal().tty_signal_keys()
             RealTerminal().tty_signal_keys(*(['undefined'] * 5))
         else:
-            if self.term is not None:
-                self.term.modes.visible_cursor = False
-                self.term.set_term_cursor()
             if hasattr(self, "old_tios"):
                 RealTerminal().tty_signal_keys(*self.old_tios)
 

--- a/urwid/widget.py
+++ b/urwid/widget.py
@@ -111,7 +111,6 @@ def validate_size(widget, size, canv):
     """
     if (size and size[1:] != (0,) and size[0] != canv.cols()) or \
         (len(size)>1 and size[1] != canv.rows()):
-        __import__('pdb').set_trace()
         raise WidgetError("Widget %r rendered (%d x %d) canvas"
             " when passed size %r!" % (widget, canv.cols(),
             canv.rows(), size))

--- a/urwid/widget.py
+++ b/urwid/widget.py
@@ -111,6 +111,7 @@ def validate_size(widget, size, canv):
     """
     if (size and size[1:] != (0,) and size[0] != canv.cols()) or \
         (len(size)>1 and size[1] != canv.rows()):
+        __import__('pdb').set_trace()
         raise WidgetError("Widget %r rendered (%d x %d) canvas"
             " when passed size %r!" % (widget, canv.cols(),
             canv.rows(), size))


### PR DESCRIPTION
##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment (see notes below on what broke)
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
*(P. S. If this pull requests fixes an existing issue, please specify which one.)*

fixes #95 

##### Notes

This does break one existing test that tests for cursor visibility, for which I'm not sure what the correct or appropriate fix is.

In order to get `Terminal`s to render correctly (hopefully I did it correctly) in a ListBox, I had to change the TermCanvas's mode's `visibile_cursor` property to default to `False` instead of `True`. This made sense to me because Terminals shouldn't default to having focus. Even if a Terminal is the first item in a ListBox, upon creation it should default to no focus (and no cursor), until it is given focus.

The broken test tests that cursor visibility can be changed with escape sequences:

```python
    def test_cursor_visibility(self):
        self.write('\e[?25linvisible')
        self.expect('invisible')
        self.assertEqual(self.term.term.cursor, None)
        self.write('\rvisible\e[?25h\e[K')
        self.expect('visible')
        self.assertNotEqual(self.term.term.cursor, None)
```

However, this test is performed with the Terminal having `focus=False`, which with my changes means that the cursor will not be visible, even if set by escape sequences. I'm not sure what the correct approach here is.

I've also attached a gif of the listboxes working in a tool that I'm working on. Even if this PR is a bit off in its implementation, I'm hoping it will get me closer to having Terminals fixed in ListBox containers in urwid.

![working_terminals_in_listbox](https://user-images.githubusercontent.com/5090146/70809121-f8286f00-1d75-11ea-8aaa-3ce27e7fe6e1.gif)