### PR TITLE
Updated documentation on Terminal

### DIFF
--- a/urwid/vterm.py
+++ b/urwid/vterm.py
@@ -1328,29 +1328,36 @@ class Terminal(Widget):
     def __init__(self, command, env=None, main_loop=None, escape_sequence=None,
                  encoding='ascii'):
         """
-        A terminal emulator within a widget.
+        A terminal emulator within a widget. BLAH
 
-        'command' is the command to execute inside the terminal, provided as a
+        ``command`` is the command to execute inside the terminal, provided as a
         list of the command followed by its arguments.  If 'command' is None,
         the command is the current user's shell. You can also provide a callable
         instead of a command, which will be executed in the subprocess.
 
-        'env' can be used to pass custom environment variables. If omitted,
+        ``env`` can be used to pass custom environment variables. If omitted,
         os.environ is used.
 
-        'main_loop' should be provided, because the canvas state machine needs
+        ``main_loop`` should be provided, because the canvas state machine needs
         to act on input from the PTY master device. This object must have
         watch_file and remove_watch_file methods.
 
-        'escape_sequence' is the urwid key symbol which should be used to break
-        out of the terminal widget. If it's not specified, "ctrl a" is used.
+        ``escape_sequence`` is the urwid key symbol which should be used to break
+        out of the terminal widget. If it's not specified, ``ctrl a`` is used.
 
-        'encoding' specifies the encoding that is being used when local
+        ``encoding`` specifies the encoding that is being used when local
         keypresses in Unicode are encoded into raw bytes. The default encoding
-        is 'ascii' for backwards compatibility with urwid versions <= 2.0.1.
-        Set this to the encoding of your terminal (typically 'utf8') if you
+        is ``ascii`` for backwards compatibility with urwid versions <= 2.0.1.
+        Set this to the encoding of your terminal (typically ``utf8``) if you
         want to be able to transmit non-ASCII characters to the spawned process.
         Applies to Python 3.x only.
+
+        .. note::
+
+            If you notice your Terminal instance is not printing unicode glyphs
+            correctly, make sure the global encoding for urwid is set to
+            ``utf8`` with ``urwid.set_encoding("utf8")``. See
+            :ref:`text-encodings` for more details.
         """
         self.__super.__init__()
 

--- a/urwid/vterm.py
+++ b/urwid/vterm.py
@@ -1328,7 +1328,7 @@ class Terminal(Widget):
     def __init__(self, command, env=None, main_loop=None, escape_sequence=None,
                  encoding='ascii'):
         """
-        A terminal emulator within a widget. BLAH
+        A terminal emulator within a widget.
 
         ``command`` is the command to execute inside the terminal, provided as a
         list of the command followed by its arguments.  If 'command' is None,


### PR DESCRIPTION
##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:

This PR fixes #383 by adding a note in the documentation about setting the global encoding for urwid to utf8 if Terminals aren't rendering unicode glyphs correctly.