### PR TITLE
Terminal: use UTF-8 by default.

### DIFF
--- a/urwid/vterm.py
+++ b/urwid/vterm.py
@@ -1361,20 +1361,11 @@ class Terminal(Widget):
         """
         self.__super.__init__()
 
-        if escape_sequence is None:
-            self.escape_sequence = "ctrl a"
-        else:
-            self.escape_sequence = escape_sequence
+        self.escape_sequence = escape_sequence or "ctrl a"
 
-        if env is None:
-            self.env = dict(os.environ)
-        else:
-            self.env = dict(env)
+        self.env = dict(env or os.environ)
 
-        if command is None:
-            self.command = [self.env.get('SHELL', '/bin/sh')]
-        else:
-            self.command = command
+        self.command = command or [self.env.get('SHELL', '/bin/sh')]
 
         self.encoding = encoding
 
@@ -1525,17 +1516,12 @@ class Terminal(Widget):
     def add_watch(self):
         if self.main_loop is None:
             return
-
         self.main_loop.watch_file(self.master, self.feed)
 
     def remove_watch(self):
         if self.main_loop is None:
             return
-
         self.main_loop.remove_watch_file(self.master)
-
-    def selectable(self):
-        return True
 
     def wait_and_feed(self, timeout=1.0):
         while True:

--- a/urwid/vterm.py
+++ b/urwid/vterm.py
@@ -1319,6 +1319,7 @@ class TermCanvas(Canvas):
             return [self.cols()]*self.rows()
         return self.content()
 
+
 class Terminal(Widget):
     _selectable = True
     _sizing = frozenset([BOX])
@@ -1539,14 +1540,14 @@ class Terminal(Widget):
         try:
             data = os.read(self.master, 4096)
         except OSError as e:
-            if e.errno == 5: # End Of File
+            if e.errno == 5: # EIO, child terminated
                 data = EOF
             elif e.errno == errno.EWOULDBLOCK: # empty buffer
                 return
             else:
                 raise
 
-        if data == EOF: # EOF on BSD
+        if data == EOF:
             self.terminate()
             self._emit('closed')
             return

--- a/urwid/vterm.py
+++ b/urwid/vterm.py
@@ -1327,7 +1327,7 @@ class Terminal(Widget):
     signals = ['closed', 'beep', 'leds', 'title']
 
     def __init__(self, command, env=None, main_loop=None, escape_sequence=None,
-                 encoding='ascii'):
+                 encoding='utf-8'):
         """
         A terminal emulator within a widget.
 
@@ -1347,10 +1347,9 @@ class Terminal(Widget):
         out of the terminal widget. If it's not specified, ``ctrl a`` is used.
 
         ``encoding`` specifies the encoding that is being used when local
-        keypresses in Unicode are encoded into raw bytes. The default encoding
-        is ``ascii`` for backwards compatibility with urwid versions <= 2.0.1.
-        Set this to the encoding of your terminal (typically ``utf8``) if you
-        want to be able to transmit non-ASCII characters to the spawned process.
+        keypresses in Unicode are encoded into raw bytes. UTF-8 is used by default.
+        Set this to the encoding of your terminal if you need to transmit
+        characters to the spawned process in non-UTF8 encoding.
         Applies to Python 3.x only.
 
         .. note::

--- a/urwid/vterm.py
+++ b/urwid/vterm.py
@@ -1359,7 +1359,7 @@ class Terminal(Widget):
             ``utf8`` with ``urwid.set_encoding("utf8")``. See
             :ref:`text-encodings` for more details.
         """
-        self.__super.__init__()
+        Widget.__init__(self)
 
         self.escape_sequence = escape_sequence or "ctrl a"
 


### PR DESCRIPTION
As I've commented under #384 — there's no such thing as using `ASCII` instead of `UTF-8` for "backward compatibility reasons". That's just plain nonsense.

Having broken Unicode rendering (#383) by default is unacceptable. We should expect *non-utf8* users to discover and call `urwid.set_encoding(our_unfortunate_codepage)` — not the other way around.

This PR fixes that, by changing the default to `utf-8` and removing the unconvincing wording from the docs.

I'll give it a few days to linger. Perhaps the original author @ntamas shows up and explains where I'm being an idiot?..

A few other `vterm`-related editorials are piggybacked as well.