### PR TITLE
Fix GridFlow keypress handling when v_sep is 0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,8 @@ deps =
     py37: trio
     py38: trio
     # NOTE: py34 is tested without Trio; Trio is not supported on Py < 3.5.
+    py27: mock
+    pypy: mock
 commands =
     coverage run ./setup.py test
 

--- a/urwid/container.py
+++ b/urwid/container.py
@@ -370,6 +370,9 @@ class GridFlow(WidgetWrap, WidgetContainerMixin, WidgetContainerListContentsMixi
         if self.v_sep:
             # remove first divider
             del p.contents[:1]
+        else:
+            # Ensure p __selectable is updated
+            p._contents_modified()
 
         return p
 

--- a/urwid/tests/test_container.py
+++ b/urwid/tests/test_container.py
@@ -1,4 +1,10 @@
 import unittest
+try:
+    # Python3 version
+    import unittest.mock as mock
+except ImportError:
+    # Python2, rely on PyPi
+    import mock
 
 from urwid.tests.util import SelectableText
 import urwid
@@ -287,6 +293,17 @@ class GridFlowTest(unittest.TestCase):
     def test_v_sep(self):
         gf = urwid.GridFlow([urwid.Text("test")], 10, 3, 1, "center")
         self.assertEqual(gf.rows((40,), False), 1)
+
+    def test_keypress_v_sep_0(self):
+        """
+        Ensure proper keypress handling when v_sep is 0.
+        https://github.com/urwid/urwid/issues/387
+        """
+        call_back = mock.Mock()
+        button = urwid.Button("test", call_back)
+        gf = urwid.GridFlow([button], 10, 3, v_sep=0, align="center")
+        self.assertEqual(gf.keypress((20,), "enter"), None)
+        call_back.assert_called_with(button)
 
 
 class WidgetSquishTest(unittest.TestCase):


### PR DESCRIPTION
Ensure inner GridFlow's Pile selectable attribute is updated with the
added content, so that keypress events are forwarded properly.

Fixes https://github.com/urwid/urwid/issues/387
