### PR TITLE
Drop Python 3.4 support, update Travis CI config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,9 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# IntelliJ IDEA / PyCharm
+.idea/
+
+# Visual Studio Code
+.vscode/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ matrix:
   include:
   - python: 2.7
     env: TOXENV=py27
-  - python: 3.4
-    env: TOXENV=py34
   - python: 3.5
     env: TOXENV=py35
   - python: 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ matrix:
     env: TOXENV=py37
   - python: 3.8
     env: TOXENV=py38
-  - python: pypy3
-    env: TOXENV=pypy3
+  - python: pypy2
+    env: TOXENV=pypy
 before_install:
   - "sudo apt-get update"
   - "sudo apt-get install python-gi python3-gi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ matrix:
   - python: 3.7
     dist: xenial # needed for python 3.7 as of 2019-04-05
     env: TOXENV=py37
+  - python: 3.8
+    dist: xenial # needed for python 3.7 as of 2019-04-05
+    env: TOXENV=py38
   - python: pypy
     env: TOXENV=pypy
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-group: deprecated-2017Q4
 language: python
+dist: bionic
 matrix:
   include:
   - python: 2.7
@@ -9,16 +9,12 @@ matrix:
   - python: 3.6
     env: TOXENV=py36
   - python: 3.7
-    dist: xenial # needed for python 3.7 as of 2019-04-05
     env: TOXENV=py37
   - python: 3.8
-    dist: xenial # needed for python 3.7 as of 2019-04-05
     env: TOXENV=py38
-  - python: pypy
-    env: TOXENV=pypy
+  - python: pypy3
+    env: TOXENV=pypy3
 before_install:
-  - "sudo rm -rf /var/lib/apt/lists/*"
-  - "sudo apt-get clean"
   - "sudo apt-get update"
   - "sudo apt-get install python-gi python3-gi"
 install:

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ It includes many features useful for text console application developers includi
 - Display modules include raw, curses, and experimental LCD and web displays
 - Support for UTF-8, simple 8-bit and CJK encodings
 - 24-bit (true color), 256 color, and 88 color mode support
-- Compatible with Python 2.7, 3.4+ and PyPy
+- Compatible with Python 2.7, 3.5+ and PyPy
 
 Home Page:
   http://urwid.org/
@@ -58,7 +58,6 @@ Supported Python versions
 =========================
 
 - 2.7
-- 3.4
 - 3.5
 - 3.6
 - 3.7

--- a/docs/tools/templates/indexcontent.html
+++ b/docs/tools/templates/indexcontent.html
@@ -37,7 +37,7 @@
 <div class="section" id="requirements">
 <h3>Requirements</h3>
 <ul>
-<li>Python 2.7, 3.4+ or PyPy</li>
+<li>Python 2.7, 3.5+ or PyPy</li>
 <li>Linux, OSX, Cygwin or other unix-like OS</li>
 <li>python-gi for GlibEventLoop (optional)</li>
 <li>Twisted for TwistedEventLoop (optional)</li>

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,6 @@ setup_d = {
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
     py36
     py37
     py38
-    pypy
+    pypy3
 
 [testenv]
 usedevelop = true
@@ -24,7 +24,7 @@ deps =
     py37: trio
     py38: trio
     py27: mock
-    pypy: mock
+    pypy3: mock
 commands =
     coverage run ./setup.py test
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
     py36
     py37
     py38
-    pypy3
+    pypy
 
 [testenv]
 usedevelop = true
@@ -24,7 +24,7 @@ deps =
     py37: trio
     py38: trio
     py27: mock
-    pypy3: mock
+    pypy: mock
 commands =
     coverage run ./setup.py test
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
     py27
-    py34
     py35
     py36
     py37
@@ -20,12 +19,10 @@ deps =
     py37: twisted
     py38: twisted
     pypy: twisted
-    # NOTE: py34 is tested without Twisted: they had abandoned Py < 3.5.
     py35: trio
     py36: trio
     py37: trio
     py38: trio
-    # NOTE: py34 is tested without Trio; Trio is not supported on Py < 3.5.
     py27: mock
     pypy: mock
 commands =


### PR DESCRIPTION
##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:

This PR drop support for Python 3.4, because this version reached its EOL in March, 2019. According to [PyPI stats](https://pypistats.org/packages/urwid) there are ~0.5% users who still on Python 3.4.
