### PR TITLE
Remove invalid escape sequence from docstring

### DIFF
--- a/urwid/container.py
+++ b/urwid/container.py
@@ -145,7 +145,7 @@ class GridFlow(WidgetWrap, WidgetContainerMixin, WidgetContainerListContentsMixi
         :param h_sep: blank columns between each cell horizontally
         :param v_sep: blank rows between cells vertically
             (if more than one row is required to display all the cells)
-        :param align: horizontal alignment of cells, one of\:
+        :param align: horizontal alignment of cells, one of:
             'left', 'center', 'right', ('relative', percentage 0=left 100=right)
         """
         self._contents = MonitoredFocusList([


### PR DESCRIPTION
This sequence generates DeprecationWarning under Python-3.7:

```
urwid/container.py:150: DeprecationWarning: invalid escape sequence \:
    """
```

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
