### PR TITLE
fix #400

### DIFF
--- a/urwid/display_common.py
+++ b/urwid/display_common.py
@@ -795,8 +795,8 @@ class BaseScreen(with_metaclass(signals.MetaSignals, object)):
         :meth:`_start`.
         """
         if not self._started:
+            self._started = True
             self._start(*args, **kwargs)
-        self._started = True
         return StoppingContext(self)
 
     def _start(self):


### PR DESCRIPTION
##### Checklist
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [ ] I've ran `tox` successfully in local environment

##### Description:
This fixes #400 .

The root cause is `_watch_files` being empty at the time `SelectEventLoop._loop()` is called.
That is caused by `get_input_descriptors` returning `[]` if `not self._started`, and `self._started == False`, since `hook_event_loop` is being called by `_start()`, which is called by `start()` **before** `_started` is set to `True` (see patch)

See 426ddd0972518d305f519ab3637b82322cb80b64 for help debugging

A few tests fail in a local environment, when running straight off master, both on 2 and 3. This patch causes no new tests to fail. I realize that's a pretty weak statement, so I hope Travis will help us here.
