### PR TITLE
Fix 256-color mode on some terminals.  Addresses #404.

### DIFF
--- a/urwid/display_common.py
+++ b/urwid/display_common.py
@@ -920,6 +920,8 @@ class BaseScreen(with_metaclass(signals.MetaSignals, object)):
             foreground_high = foreground
         if background_high is None:
             background_high = background
+
+        high_256 = AttrSpec(foreground_high, background_high, 256)
         high_true = AttrSpec(foreground_high, background_high, 2**24)
 
         # 'hX' where X > 15 are different in 88/256 color, use
@@ -938,8 +940,8 @@ class BaseScreen(with_metaclass(signals.MetaSignals, object)):
             high_88 = AttrSpec(foreground_high, background_high, 88)
 
         signals.emit_signal(self, UPDATE_PALETTE_ENTRY,
-                            name, basic, mono, high_88, high_true)
-        self._palette[name] = (basic, mono, high_88, high_true)
+                            name, basic, mono, high_88, high_256, high_true)
+        self._palette[name] = (basic, mono, high_88, high_256, high_true)
 
 
 def _test():

--- a/urwid/raw_display.py
+++ b/urwid/raw_display.py
@@ -101,7 +101,7 @@ class Screen(BaseScreen, RealTerminal):
 
     def _on_update_palette_entry(self, name, *attrspecs):
         # copy the attribute to a dictionary containing the escape seqences
-        a = attrspecs[{16:0,1:1,88:2,256:3,2**24:3}[self.colors]]
+        a = attrspecs[{16:0,1:1,88:2,256:3,2**24:4}[self.colors]]
         self._pal_attrspec[name] = a
         self._pal_escape[name] = self._attrspec_to_escape(a)
 


### PR DESCRIPTION
The initial 24-bit color implementation has problems when the terminal
supports 256 but not 24-bit.  This resulted from a mistake in how
palette entries are registered, and should be fixed with this commit.

##### Checklist
- [ ] I've ensured that similar functionality has not already been implemented
- [ ] I've ensured that similar functionality has not earlier been proposed and declined
- [ ] I've branched off the `master` or `python-dual-support` branch
- [ ] I've merged fresh upstream into my branch recently
- [ ] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
*(P. S. If this pull requests fixes an existing issue, please specify which one.)*

