### PR TITLE
Use comparison with a string instead of "is" test with a literal

### DIFF
--- a/urwid/numedit.py
+++ b/urwid/numedit.py
@@ -242,7 +242,7 @@ class FloatEdit(NumEdit):
                              decimalSeparator))
 
         val = ""
-        if default is not None and default is not "":
+        if default is not None and default != "":
             if not isinstance(default, (int, str, Decimal)):
                 raise ValueError("default: Only 'str', 'int', "
                                  "'long' or Decimal input allowed")


### PR DESCRIPTION
Python 3.8 deprecates `is` test with a literal, which leads to runtime warnings:
```
urwid/numedit.py:245: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if default is not None and default is not "":
```

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
