### PR TITLE
Ignore resetting to invalid locale (Closes: #377)

### DIFF
--- a/urwid/util.py
+++ b/urwid/util.py
@@ -55,7 +55,10 @@ def detect_encoding():
         else:
             raise
     finally:
-        locale.setlocale(locale.LC_ALL, initial)
+        try:
+            locale.setlocale(locale.LC_ALL, initial)
+        except locale.Error:
+            pass
 
 if 'detected_encoding' not in locals():
     detected_encoding = detect_encoding()


### PR DESCRIPTION
##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
~~- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)~~

##### Description:
Resetting the locale was introduced in 5dcf236, before that an invalid
locale was ignored. Restore the old behavior insofar that only valid
locales are restored.
This fixes the unit tests of scottkosty/vit with unset LANG.