### PR TITLE
Fix bytes/unicode assert error in draw_screen

### DIFF
--- a/urwid/raw_display.py
+++ b/urwid/raw_display.py
@@ -813,19 +813,19 @@ class Screen(BaseScreen, RealTerminal):
             lasta = lastcs = None
             for (a,cs, run) in row:
                 assert isinstance(run, bytes) # canvases should render with bytes
-                if cs != 'U':
+                if cs != B('U'):
                     run = run.translate(UNPRINTABLE_TRANS_TABLE)
                 if first or lasta != a:
                     o.append(attr_to_escape(a))
                     lasta = a
                 if first or lastcs != cs:
-                    assert cs in [None, "0", "U"], repr(cs)
-                    if lastcs == "U":
+                    assert cs in [None, B("0"), B("U")], repr(cs)
+                    if lastcs == B("U"):
                         o.append( escape.IBMPC_OFF )
 
                     if cs is None:
                         o.append( escape.SI )
-                    elif cs == "U":
+                    elif cs == B("U"):
                         o.append( escape.IBMPC_ON )
                     else:
                         o.append( escape.SO )
@@ -835,10 +835,10 @@ class Screen(BaseScreen, RealTerminal):
             if ins:
                 (inserta, insertcs, inserttext) = ins
                 ias = attr_to_escape(inserta)
-                assert insertcs in [None, "0", "U"], repr(insertcs)
+                assert insertcs in [None, B("0"), B("U")], repr(insertcs)
                 if cs is None:
                     icss = escape.SI
-                elif cs == "U":
+                elif cs == B("U"):
                     icss = escape.IBMPC_ON
                 else:
                     icss = escape.SO
@@ -847,7 +847,7 @@ class Screen(BaseScreen, RealTerminal):
                     escape.INSERT_ON, inserttext,
                     escape.INSERT_OFF ]
 
-                if cs == "U":
+                if cs == B("U"):
                     o.append(escape.IBMPC_OFF)
             if whitespace_at_end:
                 o.append(escape.ERASE_IN_LINE_RIGHT)


### PR DESCRIPTION
When running my application that uses Urwid with Python 3 (https://github.com/bugnano/rnr), I ran into this assert error:

  File "/home/fri/.local/lib/python3.8/site-packages/urwid/raw_display.py", line 822, in draw_screen
    assert cs in [None, "0", "U"], repr(cs)
AssertionError: b'0'

By the assert error it was clear that the error was not in my code but in Urwid, as cs is clearly of type bytes, and the assert compares it against string values.

When modifying this code in order to compare cs against byte values instead of strings, my application stopped crashing.

I don't know if this bug has been reported before, so I don't know if this fixes an already reported bug, or not.
