### PR TITLE
Fix curses_display python3 ord()

### DIFF
--- a/urwid/curses_display.py
+++ b/urwid/curses_display.py
@@ -32,7 +32,7 @@ from urwid import escape
 
 from urwid.display_common import BaseScreen, RealTerminal, AttrSpec, \
     UNPRINTABLE_TRANS_TABLE
-from urwid.compat import bytes, PYTHON3, text_type, xrange
+from urwid.compat import bytes, PYTHON3, text_type, xrange, ord2
 
 KEY_RESIZE = 410 # curses.KEY_RESIZE (sometimes not defined)
 KEY_MOUSE = 409 # curses.KEY_MOUSE
@@ -368,7 +368,7 @@ class Screen(BaseScreen, RealTerminal):
         l = []
         def append_button( b ):
             b |= mod
-            l.extend([ 27, ord('['), ord('M'), b+32, x+33, y+33 ])
+            l.extend([ 27, ord2('['), ord2('M'), b+32, x+33, y+33 ])
 
         if bstate & curses.BUTTON1_PRESSED and last & 1 == 0:
             append_button( 0 )
@@ -515,7 +515,7 @@ class Screen(BaseScreen, RealTerminal):
                 try:
                     if cs in ("0", "U"):
                         for i in range(len(seg)):
-                            self.s.addch( 0x400000 + seg[i] if PYTHON3 else ord(seg[i]) )
+                            self.s.addch( 0x400000 + ord2(seg[i]) )
                     else:
                         assert cs is None
                         if PYTHON3:

--- a/urwid/curses_display.py
+++ b/urwid/curses_display.py
@@ -515,8 +515,7 @@ class Screen(BaseScreen, RealTerminal):
                 try:
                     if cs in ("0", "U"):
                         for i in range(len(seg)):
-                            self.s.addch( 0x400000 +
-                                ord(seg[i]) )
+                            self.s.addch( 0x400000 + seg[i] if PYTHON3 else ord(seg[i]) )
                     else:
                         assert cs is None
                         if PYTHON3:


### PR DESCRIPTION
##### Checklist
- [v] I've ensured that similar functionality has not already been implemented
- [v] I've ensured that similar functionality has not earlier been proposed and declined
- [v] I've branched off the `master` or `python-dual-support` branch
- [v] I've merged fresh upstream into my branch recently
- [v] I've ran `tox` successfully in local environment
- [v] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
*(P. S. If this pull requests fixes an existing issue, please specify which one.)*
This is actually an issue I faced while using Taurus with oh-my-zsh:
`TypeError: ord() expected string of length 1, but int found`
someone had reported it before:
https://groups.google.com/g/codename-taurus/c/90F2ie0ka0I/m/7iu2mo5yBAAJ
I think this might be a python2 vs python3 issue:
https://stackoverflow.com/questions/50111345/bytes-like-object-is-required-ord-expected-string-of-length-1-but-int-found
https://stackoverflow.com/questions/30076240/ord-expected-string-of-length-1-but-int-found
This change could let Taurus run smoothly with oh-my-zsh
