### PR TITLE
Use non deprecated template

### DIFF
--- a/docs/tools/templates/indexcontent.html
+++ b/docs/tools/templates/indexcontent.html
@@ -1,4 +1,4 @@
-{% extends "!defindex.html" %}
+{% extends "layout.html" %}
 {% block body %}
 <h1>Urwid{% if 'dev' in release %} development version{% endif %}</h1>
 <div style="float: left; width: 500px;">


### PR DESCRIPTION
defindex.html was deprecated a long time ago, see

https://github.com/python/cpython/commit/7970cd483346dfd7723da214fb27399ecc574095

for example.