### PR TITLE
Extend top and bottom line of LineBox if corner character is empty

### DIFF
--- a/urwid/graphics.py
+++ b/urwid/graphics.py
@@ -159,11 +159,13 @@ class LineBox(WidgetDecoration, WidgetWrap):
                 if title_align == 'center':
                     tline_widgets.append(tline)
             self.tline_widget = Columns(tline_widgets)
-            top = Columns([
-                ('fixed', 1, tlcorner),
-                self.tline_widget,
-                ('fixed', 1, trcorner)
-            ])
+            top_columns = []
+            if tlcorner.text:
+                top_columns.append(('fixed', 1, tlcorner),)
+            top_columns.append(self.tline_widget)
+            if trcorner.text:
+                top_columns.append(('fixed', 1, trcorner),)
+            top = Columns(top_columns)
 
         else:
             self.tline_widget = None
@@ -185,9 +187,14 @@ class LineBox(WidgetDecoration, WidgetWrap):
                 box_columns=[0, 2], focus_column=focus_col)
 
         if bline:
-            bottom = Columns([
-                ('fixed', 1, blcorner), bline, ('fixed', 1, brcorner)
-            ])
+            bottom_columns = []
+            if tlcorner.text:
+                bottom_columns.append(('fixed', 1, blcorner),)
+            bottom_columns.append(bline)
+            if trcorner.text:
+                bottom_columns.append(('fixed', 1, brcorner),)
+            top = Columns(top_columns)
+            bottom = Columns(bottom_columns)
         else:
             bottom = None
 

--- a/urwid/tests/test_graphics.py
+++ b/urwid/tests/test_graphics.py
@@ -40,6 +40,15 @@ class LineBoxTest(unittest.TestCase):
 
         self.assertEqual(l, self.border(*nums))
 
+    def test_no_corners(self):
+        t = urwid.Text("")
+        l = urwid.LineBox(t, tlcorner="", trcorner="", blcorner="", brcorner="", lline="", rline="").render((3,)).text
+
+        # default
+        self.assertEqual(l,
+            self.border(B("\xe2\x94\x80"), B("\xe2\x94\x80"),
+                B("\xe2\x94\x80"), B(" "), B(" "),
+                B("\xe2\x94\x80"), B("\xe2\x94\x80"), B("\xe2\x94\x80")))
 
 class BarGraphTest(unittest.TestCase):
     def bgtest(self, desc, data, top, widths, maxrow, exp ):


### PR DESCRIPTION

##### Checklist
- [ ] I've ensured that similar functionality has not already been implemented
- [ ] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:

When a corner character of a `LineBox` is empty, extend the top line.

Fixes #420 

