### PR TITLE
Pressing end on a Fix focus_end on a collapsed tree

### DIFF
--- a/urwid/treetools.py
+++ b/urwid/treetools.py
@@ -484,7 +484,8 @@ class TreeListBox(urwid.ListBox):
         rootnode = pos.get_root()
         rootwidget = rootnode.get_widget()
         lastwidget = rootwidget.last_child()
-        lastnode = lastwidget.get_node()
+        if lastwidget:
+            lastnode = lastwidget.get_node()
 
-        self.change_focus(size, lastnode, maxrow-1)
+            self.change_focus(size, lastnode, maxrow-1)
 


### PR DESCRIPTION
When a root node is collapsed and `focus_end` is called,
its inner treenode returns `None` when it is collapsed.

This fixes a `ValueError` by avoiding a change of fucus to the returned `None` item.

Fixes the error mentioned in https://github.com/urwid/urwid/issues/318#issuecomment-674983050

##### Checklist
- [ ] I've ensured that similar functionality has not already been implemented
- [ ] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [ ] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
*(P. S. If this pull requests fixes an existing issue, please specify which one.)*

