### PR TITLE
Fix crash with "ellipsis" clipping for py2

### DIFF
--- a/examples/tour.py
+++ b/examples/tour.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# coding: utf-8
 #
 # Urwid tour.  It slices, it dices..
 #    Copyright (C) 2004-2011  Ian Ward
@@ -53,7 +54,7 @@ def main():
         u"Text will be cut off at the left of this widget.")
     text_center_clip = (u"Center aligned and clipped widgets will have "
         u"text cut off both sides.")
-    text_ellipsis = (u"Text can be clippped using the ellipsis character (…)\n"
+    text_ellipsis = (u"Text can be clipped using the ellipsis character (…)\n"
         u"Extra text is discarded and a … mark is shown."
          u"50-> 55-> 60-> 65-> 70-> 75-> 80-> 85-> 90-> 95-> 100>\n"
     )

--- a/urwid/text_layout.py
+++ b/urwid/text_layout.py
@@ -163,7 +163,7 @@ class StandardTextLayout(TextLayout):
                 if p!=n_end:
                     l += [(sc, p, n_end)]
                 if trimmed:
-                    l += [(1, n_end, u'…'.encode())]
+                    l += [(1, n_end, u'…'.encode("utf-8"))]
                 l += [(pad_right,n_end)]
                 b.append(l)
                 p = n_cr+1


### PR DESCRIPTION
##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
Ellipsis clipping crashed with python2.

Introduced with
https://github.com/urwid/urwid/commit/234989a5df4ecdc176194d4ea8c2e5cf0a335d92#diff-7863b2bac29a97dd8e6d4f0dfa002196
and
https://github.com/urwid/urwid/commit/e8e7cc931cb1ab06ae53271a3389a4046ab16623#diff-7863b2bac29a97dd8e6d4f0dfa002196

##### Steps to reproduce (before this Pull-request)
Add
`# coding: utf-8`
as second line to `examples/tour.py`

In root directory of urwid repo:
```python
PYTHONPATH=. python2 examples/tour.py
```

##### Expected/actual outcome
Expected: line clipped with ellipsis (…)
Actual: `UnicodeEncodeError: 'ascii' codec can't encode character u'\u2026' in position 0: ordinal not in range(128)` as soon as line is too long for the terminal window and should be clipped.