### PR TITLE
Use == instead of "is" for equality testing

### DIFF
--- a/examples/browse.py
+++ b/examples/browse.py
@@ -323,7 +323,7 @@ def store_initial_cwd(name):
 def starts_expanded(name):
     """Return True if directory is a parent of initial cwd."""
 
-    if name is '/':
+    if name == '/':
         return True
 
     l = name.split(dir_sep())


### PR DESCRIPTION
Identity check (`is`, `is not`) with certain literals (e.g. strings, numbers) is not guaranteed by the language specification to work and issue a warning [starting with Python 3.8](https://docs.python.org/3/whatsnew/3.8.html#changes-in-python-behavior), e.g.:

> examples/browse.py:326: SyntaxWarning: "is" with a literal. Did you mean "=="?

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)