### PR TITLE
Fix documentation of TrioEventLoop.run_async()

### DIFF
--- a/urwid/_async_kw_event_loop.py
+++ b/urwid/_async_kw_event_loop.py
@@ -136,10 +136,15 @@ class TrioEventLoop(EventLoop):
         Trio event loop is already running. Example::
 
             with trio.open_nursery() as nursery:
-                event_loop = urwid.TrioEventLoop(nursery=nursery)
+                event_loop = urwid.TrioEventLoop()
+
+                # [...launch other async tasks in the nursery...]
+
                 loop = urwid.MainLoop(widget, event_loop=event_loop)
                 with loop.start():
                     await event_loop.run_async()
+
+                nursery.cancel_scope.cancel()
         """
 
         idle_callbacks = self._idle_callbacks


### PR DESCRIPTION
##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [X] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:

This PR fixes the documentation of `TrioEventLoop.run_async()`, which incorrectly suggests that the constructor of `TrioEventLoop()` has a `nursery` argument (which it doesn't have).

The new snippet in the docstring now accurately reflects how `TrioEventLoop` should be used in an existing Trio event loop; copied straight from one of my projects.
