### PR TITLE
add pyserial as extra dependency to setup.py.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+#In the module urwid.lcd_display, pyserial is needed as dependency 
+#If you need this module and need pyserial as dependency, please run "pip install urwid[lcd]"

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,9 @@ setup_d = {
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: Implementation :: PyPy",
         ],
+    #if you need pyserial as dependency, please run "pip install urwid[lcd]"
+    'extras_require':{'lcd':['pyserial']}
+
      }
 
 if have_setuptools:


### PR DESCRIPTION
##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
pyserial is used in urwid.lcd_display. So add pyserial as extra dependency to setup.py. fix [#441](https://github.com/urwid/urwid/issues/441)
