### PR TITLE
README: suggest python3-urwid for debian/ubuntu

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Alternatively if you are on Debian or Ubuntu
 
 .. code:: bash
 
-   apt-get install python-urwid
+   apt-get install python3-urwid
 
 Testing
 =======


### PR DESCRIPTION
All currently supported distro versions provide the python3 version, but the python2 version (`python-urwid`) is not available in recent distributions (after Debian 10 _Buster_/Ubuntu 18.04 _Xenial_).
