### PR TITLE
docs: fix simple typo, incompatable -> incompatible

### DIFF
--- a/urwid/numedit.py
+++ b/urwid/numedit.py
@@ -122,7 +122,7 @@ class IntegerEdit(NumEdit):
         >>> e.keypress(size, 'delete')
         >>> e.keypress(size, '0')
         >>> assert e.edit_text == "00FF"
-        >>> # test exception on incompatable value for base
+        >>> # test exception on incompatible value for base
         >>> e, size = IntegerEdit(u"", "10FG", base=16), (10,)
         Traceback (most recent call last):
             ...


### PR DESCRIPTION
There is a small typo in urwid/numedit.py.

Should read `incompatible` rather than `incompatable`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md