### PR TITLE
Include _resize_pipe_rd in fd_list for _wait_for_input_ready for raw_display

### DIFF
--- a/urwid/raw_display.py
+++ b/urwid/raw_display.py
@@ -538,7 +538,7 @@ class Screen(BaseScreen, RealTerminal):
 
     def _wait_for_input_ready(self, timeout):
         ready = None
-        fd_list = []
+        fd_list = [self._resize_pipe_rd]
         fd = self._input_fileno()
         if fd is not None:
             fd_list.append(fd)


### PR DESCRIPTION


##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:

This addresses https://github.com/inducer/pudb/issues/421 (at least for the raw display). Pudb uses its own [main loop](https://github.com/inducer/pudb/blob/b177c84da93dfcd55ed3c924107ce19001e4de16/pudb/debugger.py#L2537-L2553), and I noticed that it didn't receive events for window resizes, instead receiving those only on the next key press.