### PR TITLE
Provide 80x24 fallback for ansi and vt100

### DIFF
--- a/urwid/raw_display.py
+++ b/urwid/raw_display.py
@@ -681,6 +681,10 @@ class Screen(BaseScreen, RealTerminal):
         except OSError:
             # Term size could not be determined
             pass
+        # Provide some lightweight fallbacks in case the TIOCWINSZ doesn't
+        # give sane answers
+        if (x <= 0 or y <= 0) and self.term in ('ansi','vt100'):
+                y, x = 24, 80
         self.maxrow = y
         return x, y
 


### PR DESCRIPTION
Not all terminals will necessarily respond to the TIOCGWINSZ ioctl,
particularly much older ones providing vt100 or ansi terminals, which
will have a fixed 80x24 size.  If they respond with some kind of
non-sensical value here, then at least give the ansi and vt100 terminals
their default so they can draw.

##### Checklist
- [*] I've ensured that similar functionality has not already been implemented
- [ ] I've ensured that similar functionality has not earlier been proposed and declined
- [*] I've branched off the `master` or `python-dual-support` branch
- [*] I've merged fresh upstream into my branch recently
- [*] I've ran `tox` successfully in local environment (my pypy isn't set up, but it's otherwise good)
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:

I've been working with some older machines that present a classic `ansi` or `vt100` terminal, and while `ncurses` worked just fine with them, the `raw_display` from `urwid` did not.  I tracked this down to the use of `TIOCGWINSZ`.  This ioctl wasn't providing meaningful dimensions for these old terminals.  It looked like `urwid` was getting 0x0, while `screen` was getting -1x-1.  These terminal types have a fixed width and height as per their `termcap` descriptions, and they're ubiquitous, so I provided some fallback values should `TIOCGWINSZ` not give workable dimensions.

I tried to see if a patch like this was rejected in the past, but forgive me if I missed it.