### PR TITLE
Reconnect the 'modified' signal after setting a new ListBox.body

### DIFF
--- a/urwid/tests/test_listbox.py
+++ b/urwid/tests/test_listbox.py
@@ -802,3 +802,14 @@ class ZeroHeightContentsTest(unittest.TestCase):
         lb.keypress((40,10), 'up')
         self.assertEqual(lb.get_focus()[1], 1)
 
+
+class ListBoxSetBodyTest(unittest.TestCase):
+    def test_signal_connected(self):
+        lb = urwid.ListBox([])
+        lb.body = urwid.SimpleListWalker([])
+        self.assertEqual(
+                lb.body._urwid_signals['modified'][0][1],
+                lb._invalidate,
+                "outdated canvas cache reuse "
+                "after ListWalker's contents modified"
+                )


### PR DESCRIPTION
Ensure that the cached canvas is marked invalidated when a newly set ListBox.body is modified at runtime.

Fixes #428

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
Currently, `ListBox` listens to `modified` events from the `ListWalker` set as its `body` only on initialization. If a new `ListWalker` is assigned to `ListBox.body` later, the signals from it would be ignored. 
