### PR TITLE
Fixed KeyError in canvas cleanup method

### DIFF
--- a/urwid/canvas.py
+++ b/urwid/canvas.py
@@ -145,7 +145,10 @@ class CanvasCache(object):
         cls.cleanups += 1 # collect stats
 
         w = cls._refs.get(ref, None)
-        del cls._refs[ref]
+        try:
+            del cls._refs[ref]
+        except KeyError:
+            pass
         if not w:
             return
         widget, wcls, size, focus = w


### PR DESCRIPTION
##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment

##### Description:
After long idle time of an app, the cleanup() method of canvas.py encounters a key-error when the canvas changes:

`  File "[...]/site-packages/urwid/canvas.py", Line 148, in cleanup
    del cls._refs[ref]
KeyError: <weakref at 0x7fb6ce89a3421b, dead>`

Wrapping in try will avoid exception being unhandled and dumped to UI.