### PR TITLE
Fix assertion failure when string contains SO but not SI

### DIFF
--- a/urwid/util.py
+++ b/urwid/util.py
@@ -156,7 +156,7 @@ def apply_target_encoding( s ):
             sin = sl[0]
             assert isinstance(sin, bytes)
             sout.append(sin)
-            rle_append_modify(cout, (escape.DEC_TAG.encode('ascii'), len(sin)))
+            rle_append_modify(cout, (escape.DEC_TAG, len(sin)))
             continue
         sin, son = sl
         son = son.replace(SI, bytes())


### PR DESCRIPTION
The DEC_TAG cs type should not be escaped when a lone SO is found
and should be used in the same way as when both SO and S1 are
present.
Fixes #322

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [ ] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
See issue #322 
