### PR TITLE
fix typo

### DIFF
--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -108,7 +108,7 @@ The screenshots above show how these widgets react to being resized.
   allow you to map any display attribute to any other display attribute, but by default they
   will set the display attribute of everything that does not already have a display attribute.
   In this case the text has an attribute, so only the areas around the text
-  used for alignment will be have the new attribute.
+  used for alignment will have the new attribute.
 
 * A second :class:`AttrMap` widget is created to wrap the
   :class:`Filler` widget with attribute ``'bg'``.
@@ -405,6 +405,3 @@ and the widgets that have been created.  The *AdventureGame* class is
 responsible for all the changes that happen through the game and manages
 the topmost widget, but isn't a widget itself.  This is a good pattern to
 follow as your application grows larger.
-
-
-


### PR DESCRIPTION
"will be have" → "will have"

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [n/a] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [n/a] I've ran `tox` successfully in local environment
- [n/a] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
*(P. S. If this pull requests fixes an existing issue, please specify which one.)*