### PR TITLE
pass arguments to SelectableIcon() to parent

### DIFF
--- a/urwid/wimp.py
+++ b/urwid/wimp.py
@@ -36,7 +36,7 @@ from urwid.command_map import ACTIVATE
 class SelectableIcon(Text):
     ignore_focus = False
     _selectable = True
-    def __init__(self, text, cursor_position=0):
+    def __init__(self, text, cursor_position=0, *args, **kwargs):
         """
         :param text: markup for this widget; see :class:`Text` for
                      description of text markup
@@ -47,7 +47,7 @@ class SelectableIcon(Text):
         displayed at a fixed location in the text when in focus.
         This widget has no special handling of keyboard or mouse input.
         """
-        self.__super.__init__(text)
+        self.__super.__init__(text, *args, **kwargs)
         self._cursor_position = cursor_position
 
     def render(self, size, focus=False):


### PR DESCRIPTION
`SelectableIcon` subclasses the `Text` widget.
However, it currently isn't possible to pass it `Text` arguments like `wrap`:
`SelectableIcon(text, wrap="ellipsis")`
... because the `SelectableIcon` constructor doesn't pass its arguments along to the `Text` superclass. This commit fixes that.

I'm not sure how or whether to update the docstring, so I haven't changed it. I think it is unwise to simply duplicate all of the possible parameters from the `Text` parent class, because that would violate the DRY principle and introduce the likelihood of their getting out of sync if the `Text` parameters ever change. Feedback welcome.

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
*(P. S. If this pull requests fixes an existing issue, please specify which one.)*

