### PR TITLE
Resolve #499 and add tests

### DIFF
--- a/urwid/numedit.py
+++ b/urwid/numedit.py
@@ -21,7 +21,7 @@
 
 
 from urwid import Edit
-from decimal import Decimal
+from decimal import Decimal, localcontext
 import re
 
 
@@ -265,22 +265,13 @@ class FloatEdit(NumEdit):
         Return the numeric value of self.edit_text.
         """
         if self.edit_text:
-            # integer part (before .) and fractional part (after .)
-            fmt = "{ip}.{fp}"
-            if self.significance:
-                # in case of preserved significance, construct the
-                # format string to fill with trailing 0
-                fmt = "{{ip}}.{{fp:<0{sig}d}}".format(sig=self.significance)
-
             # get the ip and fp, handles also the case that there is no '.'
             ip, fp = ([v for v in
                       self.edit_text.split(self._decimalSeparator)] + [0])[0:2]
 
-            # in case the fp part surpasses the significance we round it
-            if self.significance and len(str(fp)) > self.significance:
-                fp = float(fp) / 10**(len(str(fp)) - self.significance)
-                fp = int(round(fp))
-
-            return Decimal(fmt.format(ip=ip, fp=int(fp)))
+            with localcontext() as ctx:
+                ctx = (self.significance or len(str(fp)))+1
+                return Decimal(self.edit_text.replace(
+                    self._decimalSeparator, '.')) * 1
 
         return None

--- a/urwid/tests/test_floatedit.py
+++ b/urwid/tests/test_floatedit.py
@@ -1,0 +1,21 @@
+import unittest
+from urwid.numedit import FloatEdit
+from decimal import Decimal, getcontext
+from itertools import product
+class FloatEditNoPreservePrecicionTest(unittest.TestCase):
+    def test(self):
+        for v in ('1.01', '2.5', '300', '4.100', '5.001'):
+            f = FloatEdit(preserveSignificance=False)
+            f.set_edit_text(v)
+            print(f.value(), Decimal(v))
+            assert f.value() == Decimal(v), f'{f.value()} != {Decimal(v)}'
+
+class FloatEditPreservePrecicionTest(unittest.TestCase):
+
+    def test(self):
+        for v, sig, sep in product(('1.010', '2.500', '300.000', '4.100', '5.001'), (1, 2, 3), ('.', ',')):
+            f = FloatEdit(preserveSignificance=True, default='0.' + '0'*sig, decimalSeparator=sep)
+            f.set_edit_text(v.replace('.', sep))
+            getcontext().prec = sig+1
+            print(f.value(), Decimal(v))
+            assert str(f.value()) == str(Decimal(v) * 1), f'{str(f.value())} != {str(Decimal(v)*1)} (significance={sig})'


### PR DESCRIPTION
Resolves #499 - FloatEdit mangles decimals

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [ ] I've ran `tox` successfully in local environment - not familiar with this, sorry

##### Description:
Fixes FloatEdit mangling decimals.

Uses Decimal library instead of manipulating the string representation in urwid.

