### PR TITLE
Fix TypeError in signals module on weak object finalize by GC

### DIFF
--- a/urwid/signals.py
+++ b/urwid/signals.py
@@ -174,10 +174,7 @@ class Signals(object):
         def weakref_callback(weakref):
             o = obj_weak()
             if o:
-                try:
-                    del getattr(o, self._signal_attr, {})[name][key]
-                except KeyError:
-                    pass
+                self.disconnect_by_key(o, name, key)
 
         user_args = self._prepare_user_args(weak_args, user_args, weakref_callback)
         handlers.append((key, callback, user_arg, user_args))
@@ -300,4 +297,3 @@ register_signal = _signals.register
 connect_signal = _signals.connect
 disconnect_signal = _signals.disconnect
 disconnect_signal_by_key = _signals.disconnect_by_key
-

--- a/urwid/tests/test_signals.py
+++ b/urwid/tests/test_signals.py
@@ -1,0 +1,62 @@
+import unittest
+try:
+    from unittest.mock import Mock
+except ImportError:
+    # Python2, rely on PyPi
+    from mock import Mock
+
+from urwid import connect_signal, disconnect_signal, register_signal, emit_signal, Signals, Edit
+
+class SiglnalsTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.EmClass = type("EmClass", (object, ), {})
+        register_signal(cls.EmClass, ["change", "test"])
+
+    def test_connect(self):
+        obj = Mock()
+        handler = Mock()
+        edit = Edit('')
+        key = connect_signal(edit, 'change', handler, user_args=[obj])
+        self.assertIsNotNone(key)
+        edit.set_edit_text('long test text')
+        handler.assert_called_once_with(obj, edit, 'long test text')
+
+        handler.reset_mock()
+        disconnect_signal(edit, 'change', handler, user_args=[obj])
+        edit.set_edit_text('another text')
+        handler.assert_not_called()
+
+    def test_weak_del(self):
+        emitter = SiglnalsTest.EmClass()
+        w1 = Mock()
+        w2 = Mock()
+        w3 = Mock()
+
+        handler1 = Mock()
+        handler2 = Mock()
+
+        k1 = connect_signal(emitter, 'test', handler1, weak_args=[w1], user_args=[42, "abc"])
+        k2 = connect_signal(emitter, 'test', handler2, weak_args=[w2, w3], user_args=[8])
+        self.assertIsNotNone(k2)
+
+        emit_signal(emitter, 'test', "Foo")
+        handler1.assert_called_once_with(w1, 42, "abc",  "Foo")
+        handler2.assert_called_once_with(w2, w3, 8, "Foo")
+
+        handler1.reset_mock()
+        handler2.reset_mock()
+        del w1
+        self.assertEqual(len(getattr(emitter, Signals._signal_attr)['test']), 1)
+        emit_signal(emitter, 'test', "Bar")
+        handler1.assert_not_called()
+        handler2.assert_called_once_with(w2, w3, 8, "Bar")
+
+        handler2.reset_mock()
+        del w3
+        emit_signal(emitter, 'test', "Baz")
+        handler1.assert_not_called()
+        handler2.assert_not_called()
+        self.assertEqual(len(getattr(emitter, Signals._signal_attr)['test']), 0)
+        del w2


### PR DESCRIPTION
##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)


##### Description:
Fixed a bug in signal module with weakref callback and added some tests for signal module.
How to reproduce error:
```python
import urwid
def handler(weak_debug, widget, newtext):
    weak_debug.set_text("Edit widget changed to %s" % newtext)

debug = urwid.Text('')
edit = urwid.Edit('')
key = urwid.connect_signal(edit, 'change', handler, weak_args=[debug])
del debug
```

throws
```
Exception ignored in: <function Signals.connect.<locals>.weakref_callback at 0x7f97bdf44f70>
Traceback (most recent call last):
  File ".../urwid/signals.py", line 178, in weakref_callback
    del getattr(o, self._signal_attr, {})[name][key]
TypeError: list indices must be integers or slices, not Key
```