### PR TITLE
Fix merging attributes while decomposing tag markup

### DIFF
--- a/urwid/tests/test_util.py
+++ b/urwid/tests/test_util.py
@@ -157,9 +157,9 @@ class TagMarkupTest(unittest.TestCase):
         ("simple one", "simple one", []),
         (('blue',"john"), "john", [('blue',4)]),
         (["a ","litt","le list"], "a little list", []),
-        (["mix",('high',[" it ",('ital',"up a")])," little"],
+        (["mix",[" it",('high',[" up",('ital'," a")])]," little"],
             "mix it up a little",
-            [(None,3),('high',4),('ital',4)]),
+            [(None, 6), ('high', 3), ('ital', 2)]),
         ([u"££", u"x££"], u"££x££", []),
         ([B("\xc2\x80"), B("\xc2\x80")], B("\xc2\x80\xc2\x80"), []),
         ]

--- a/urwid/util.py
+++ b/urwid/util.py
@@ -407,7 +407,7 @@ def _tagmarkup_recurse( tm, attr ):
                 top_attr, top_run = al[0]
                 if last_attr == top_attr:
                     ral[-1] = (top_attr, last_run + top_run)
-                    del al[-1]
+                    del al[0]
             rtl += tl
             ral += al
         return rtl, ral


### PR DESCRIPTION
##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
Previously, nested markup could lead to corrupted output if consecutive
elements from different lists shared the same attributes, due to the
deletion of the wrong element while merging attributes.

Fixes #303.

