### PR TITLE
make tests compatible with Python 3.11

### DIFF
--- a/urwid/tests/test_event_loops.py
+++ b/urwid/tests/test_event_loops.py
@@ -201,15 +201,14 @@ else:
             evl.alarm(0.5, lambda: 1 / 0)  # Simulate error in event loop
             self.assertRaises(ZeroDivisionError, evl.run)
 
-        def test_coroutine_error(self):
+        async def test_coroutine_error(self):
             evl = self.evl
 
-            @asyncio.coroutine
-            def error_coro():
+            async def error_coro():
                 result = 1 / 0 # Simulate error in coroutine
                 yield result
 
-            asyncio.ensure_future(error_coro())
+            asyncio.ensure_future(await error_coro())
             self.assertRaises(ZeroDivisionError, evl.run)
 
 


### PR DESCRIPTION
##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
`@asyncio.coroutine` was deprecated since Python 3.8 and removed in Python 3.11.

