### PR TITLE
Use `locale.getpreferredencoding(False)` if possible (most systems) F…

### DIFF
--- a/urwid/tests/test_util.py
+++ b/urwid/tests/test_util.py
@@ -193,6 +193,7 @@ class RleTest(unittest.TestCase):
         self.assertListEqual(rle3, [('A', 10), ('B', 20)])
         self.assertListEqual(rle4, [('A', 10), ('B', 15), ('K', 1)])
 
+
 class PortabilityTest(unittest.TestCase):
     def test_locale(self):
         initial = locale.getlocale()
@@ -201,8 +202,28 @@ class PortabilityTest(unittest.TestCase):
         util.detect_encoding()
         self.assertEqual(locale.getlocale(), (None, None))
 
-        locale.setlocale(locale.LC_ALL, ('en_US', 'UTF-8'))
+        try:
+            locale.setlocale(locale.LC_ALL, ('en_US', 'UTF-8'))
+        except locale.Error as exc:
+            if "unsupported locale setting" not in str(exc):
+                raise
+
+            print(
+                f"Locale change impossible, probably locale not supported by system (libc ignores this error).\n"
+                f"{exc}"
+            )
+            return
+
         util.detect_encoding()
         self.assertEqual(locale.getlocale(), ('en_US', 'UTF-8'))
 
-        locale.setlocale(locale.LC_ALL, initial)
+        try:
+            locale.setlocale(locale.LC_ALL, initial)
+        except locale.Error as exc:
+            if "unsupported locale setting" not in str(exc):
+                raise
+
+            print(
+                f"Locale restore impossible, probably locale not supported by system (libc ignores this error).\n"
+                f"{exc}"
+            )


### PR DESCRIPTION
Fix #436 Fix #479

* Handle impossibility to set locale in tests (docker container scenario)
* `detect_encoding` start from non-destructive behavior (do not change locale) and restore exact locale in destructive

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment

