### PR TITLE
Fix input handling and extra type annotations

### DIFF
--- a/urwid/decoration.py
+++ b/urwid/decoration.py
@@ -414,7 +414,7 @@ class BoxAdapter(WidgetDecoration):
             return None
         return self._original_widget.get_pref_col((maxcol, self.height))
 
-    def keypress(self, size: tuple[int], key):
+    def keypress(self, size: tuple[int], key: str) -> str | None:
         (maxcol,) = size
         return self._original_widget.keypress((maxcol, self.height), key)
 
@@ -667,7 +667,7 @@ class Padding(WidgetDecoration):
             return frows
         return self._original_widget.rows((maxcol-left-right,), focus=focus)
 
-    def keypress(self, size: tuple[int] | tuple[int, int], key):
+    def keypress(self, size: tuple[int] | tuple[int, int], key: str) -> str | None:
         """Pass keypress to self._original_widget."""
         maxcol = size[0]
         left, right = self.padding_values(size, True)
@@ -897,14 +897,14 @@ class Filler(WidgetDecoration):
         canv.pad_trim_top_bottom(top, bottom)
         return canv
 
-    def keypress(self, size: tuple[int, int], key):
+    def keypress(self, size: tuple[int, int], key: str) -> str | None:
         """Pass keypress to self.original_widget."""
         (maxcol, maxrow) = size
         if self.height_type == PACK:
             return self._original_widget.keypress((maxcol,), key)
 
         top, bottom = self.filler_values((maxcol, maxrow), True)
-        return self._original_widget.keypress((maxcol,maxrow-top-bottom), key)
+        return self._original_widget.keypress((maxcol, maxrow-top-bottom), key)
 
     def get_cursor_coords(self, size: tuple[int, int]) -> tuple[int, int] | None:
         """Return cursor coords from self.original_widget if any."""

--- a/urwid/escape.py
+++ b/urwid/escape.py
@@ -363,7 +363,7 @@ _keyconv = {
 }
 
 
-def process_keyqueue(codes: Sequence[int], more_available: bool):
+def process_keyqueue(codes: Sequence[int], more_available: bool) -> tuple[list[str], Sequence[int]]:
     """
     codes -- list of key codes
     more_available -- if True then raise MoreInputRequired when in the
@@ -385,7 +385,7 @@ def process_keyqueue(codes: Sequence[int], more_available: bool):
 
     em = str_util.get_byte_encoding()
 
-    if em == 'wide' and code < 256 and within_double_byte(chr(code), 0, 0):
+    if em == 'wide' and code < 256 and within_double_byte(code.to_bytes(1, "little"), 0, 0):
         if not codes[1:] and more_available:
             raise MoreInputRequired()
         if codes[1:] and codes[1] < 256:
@@ -409,7 +409,7 @@ def process_keyqueue(codes: Sequence[int], more_available: bool):
                 else:
                     return [f"<{code:d}>"], codes[1:]
             k = codes[i+1]
-            if k>256 or k&0xc0 != 0x80:
+            if k > 256 or k & 0xc0 != 0x80:
                 return [f"<{code:d}>"], codes[1:]
 
         s = bytes(codes[:need_more+1])

--- a/urwid/graphics.py
+++ b/urwid/graphics.py
@@ -164,6 +164,7 @@ class LineBox(WidgetDecoration, WidgetWrap):
             lline = SolidFill(lline)
         if rline:
             rline = SolidFill(rline)
+
         tlcorner, trcorner = Text(tlcorner), Text(trcorner)
         blcorner, brcorner = Text(blcorner), Text(brcorner)
 

--- a/urwid/old_str_util.py
+++ b/urwid/old_str_util.py
@@ -317,7 +317,7 @@ def within_double_byte(text: bytes, line_start: int, pos: int) -> Literal[0, 1, 
     assert isinstance(text, bytes)
     v = text[pos]
 
-    if v >= 0x40 and v < 0x7f:
+    if 0x40 <= v < 0x7f:
         # might be second half of big5, uhc or gbk encoding
         if pos == line_start:
             return 0

--- a/urwid/treetools.py
+++ b/urwid/treetools.py
@@ -67,8 +67,7 @@ class TreeWidget(urwid.WidgetWrap):
                 [self.unexpanded_icon, self.expanded_icon][self.expanded]),
                 widget], dividechars=1)
         indent_cols = self.get_indent_cols()
-        return urwid.Padding(widget,
-            width=('relative', 100), left=indent_cols)
+        return urwid.Padding(widget, width=('relative', 100), left=indent_cols)
 
     def update_expanded_icon(self):
         """Update display widget text for parent widgets"""
@@ -138,7 +137,7 @@ class TreeWidget(urwid.WidgetWrap):
                 prevnode = thisnode.get_parent()
             return prevnode.get_widget()
 
-    def keypress(self, size, key):
+    def keypress(self, size, key: str) -> str | None:
         """Handle expand & collapse requests (non-leaf nodes)"""
         if self.is_leaf:
             return key
@@ -154,8 +153,8 @@ class TreeWidget(urwid.WidgetWrap):
         else:
             return key
 
-    def mouse_event(self, size, event, button, col, row, focus):
-        if self.is_leaf or event != 'mouse press' or button!=1:
+    def mouse_event(self, size, event, button: int, col: int, row: int, focus: bool) -> bool:
+        if self.is_leaf or event != 'mouse press' or button !=1:
             return False
 
         if row == 0 and col == self.get_indent_cols():
@@ -416,11 +415,11 @@ class TreeListBox(urwid.ListBox):
     """A ListBox with special handling for navigation and
     collapsing of TreeWidgets"""
 
-    def keypress(self, size, key):
+    def keypress(self, size: tuple[int, int], key: str) -> str | None:
         key = super().keypress(size, key)
         return self.unhandled_input(size, key)
 
-    def unhandled_input(self, size, input):
+    def unhandled_input(self, size: tuple[int, int], input: str) -> str | None:
         """Handle macro-navigation keys"""
         if input == 'left':
             self.move_focus_to_parent(size)
@@ -429,7 +428,7 @@ class TreeListBox(urwid.ListBox):
         else:
             return input
 
-    def collapse_focus_parent(self, size):
+    def collapse_focus_parent(self, size: tuple[int, int]) -> None:
         """Collapse parent directory."""
 
         widget, pos = self.body.get_focus()
@@ -439,7 +438,7 @@ class TreeListBox(urwid.ListBox):
         if pos != ppos:
             self.keypress(size, "-")
 
-    def move_focus_to_parent(self, size):
+    def move_focus_to_parent(self, size: tuple[int, int]) -> None:
         """Move focus to parent of widget in focus."""
 
         widget, pos = self.body.get_focus()
@@ -449,7 +448,7 @@ class TreeListBox(urwid.ListBox):
         if parentpos is None:
             return
 
-        middle, top, bottom = self.calculate_visible( size )
+        middle, top, bottom = self.calculate_visible(size)
 
         row_offset, focus_widget, focus_pos, focus_rows, cursor = middle
         trim_top, fill_above = top
@@ -462,20 +461,20 @@ class TreeListBox(urwid.ListBox):
 
         self.change_focus(size, pos.get_parent())
 
-    def _keypress_max_left(self, size):
+    def _keypress_max_left(self, size: tuple[int, int]) -> None:
         return self.focus_home(size)
 
-    def _keypress_max_right(self, size):
+    def _keypress_max_right(self, size: tuple[int, int]) -> None:
         return self.focus_end(size)
 
-    def focus_home(self, size):
+    def focus_home(self, size: tuple[int, int]) -> None:
         """Move focus to very top."""
 
         widget, pos = self.body.get_focus()
         rootnode = pos.get_root()
         self.change_focus(size, rootnode)
 
-    def focus_end( self, size ):
+    def focus_end(self, size: tuple[int, int]) -> None:
         """Move focus to far bottom."""
 
         maxrow, maxcol = size

--- a/urwid/vterm.py
+++ b/urwid/vterm.py
@@ -1327,8 +1327,14 @@ class Terminal(Widget):
 
     signals = ['closed', 'beep', 'leds', 'title']
 
-    def __init__(self, command, env=None, main_loop=None, escape_sequence=None,
-                 encoding='utf-8'):
+    def __init__(
+        self,
+        command,
+        env=None,
+        main_loop=None,
+        escape_sequence=None,
+        encoding='utf-8',
+    ):
         """
         A terminal emulator within a widget.
 
@@ -1388,7 +1394,7 @@ class Terminal(Widget):
         self.has_focus = False
         self.terminated = False
 
-    def get_cursor_coords(self, size):
+    def get_cursor_coords(self, size: tuple[int, int]) -> tuple[int, int] | None:
         """Return the cursor coordinates for this terminal
         """
         if self.term is None:
@@ -1410,7 +1416,7 @@ class Terminal(Widget):
 
         return (x, y)
 
-    def spawn(self):
+    def spawn(self) -> None:
         env = self.env
         env['TERM'] = 'linux'
 
@@ -1434,7 +1440,7 @@ class Terminal(Widget):
 
         atexit.register(self.terminate)
 
-    def terminate(self):
+    def terminate(self) -> None:
         if self.terminated:
             return
 
@@ -1462,28 +1468,28 @@ class Terminal(Widget):
 
             os.close(self.master)
 
-    def beep(self):
+    def beep(self) -> None:
         self._emit('beep')
 
-    def leds(self, which):
+    def leds(self, which) -> None:
         self._emit('leds', which)
 
-    def respond(self, string):
+    def respond(self, string) -> None:
         """
         Respond to the underlying application with 'string'.
         """
         self.response_buffer.append(string)
 
-    def flush_responses(self):
+    def flush_responses(self) -> None:
         for string in self.response_buffer:
             os.write(self.master, string.encode('ascii'))
         self.response_buffer = []
 
-    def set_termsize(self, width, height):
+    def set_termsize(self, width: int, height: int) -> None:
         winsize = struct.pack("HHHH", height, width, 0, 0)
         fcntl.ioctl(self.master, termios.TIOCSWINSZ, winsize)
 
-    def touch_term(self, width, height):
+    def touch_term(self, width: int, height: int) -> None:
         process_opened = False
 
         if self.pid is None:
@@ -1506,10 +1512,10 @@ class Terminal(Widget):
         if process_opened:
             self.add_watch()
 
-    def set_title(self, title):
+    def set_title(self, title) -> None:
         self._emit('title', title)
 
-    def change_focus(self, has_focus):
+    def change_focus(self, has_focus) -> None:
         """
         Ignore SIGINT if this widget has focus.
         """
@@ -1529,7 +1535,7 @@ class Terminal(Widget):
             if hasattr(self, "old_tios"):
                 RealTerminal().tty_signal_keys(*self.old_tios)
 
-    def render(self, size, focus=False):
+    def render(self, size: tuple[int, int], focus: bool = False):
         if not self.terminated:
             self.change_focus(focus)
 
@@ -1541,17 +1547,17 @@ class Terminal(Widget):
 
         return self.term
 
-    def add_watch(self):
+    def add_watch(self) -> None:
         if self.main_loop is None:
             return
         self.main_loop.watch_file(self.master, self.feed)
 
-    def remove_watch(self):
+    def remove_watch(self) -> None:
         if self.main_loop is None:
             return
         self.main_loop.remove_watch_file(self.master)
 
-    def wait_and_feed(self, timeout=1.0):
+    def wait_and_feed(self, timeout: float = 1.0) -> None:
         while True:
             try:
                 select.select([self.master], [], [], timeout)
@@ -1561,7 +1567,7 @@ class Terminal(Widget):
                     raise
         self.feed()
 
-    def feed(self):
+    def feed(self) -> None:
         data = EOF
 
         try:
@@ -1583,7 +1589,7 @@ class Terminal(Widget):
 
         self.flush_responses()
 
-    def keypress(self, size, key):
+    def keypress(self, size: tuple[int, int], key: str) -> str | None:
         if self.terminated:
             return key
 

--- a/urwid/widget.py
+++ b/urwid/widget.py
@@ -521,7 +521,7 @@ class Widget(metaclass=WidgetMeta):
         """
         return self._sizing
 
-    def pack(self, size, focus=False):
+    def pack(self, size: tuple[[]] | tuple[int] | tuple[int, int], focus: bool = False) -> tuple[int, int]:
         """
         See :meth:`Widget.render` for parameter details.
 
@@ -550,8 +550,7 @@ class Widget(metaclass=WidgetMeta):
         """
         if not size:
             if FIXED in self.sizing():
-                raise NotImplementedError('Fixed widgets must override'
-                    ' Widget.pack()')
+                raise NotImplementedError('Fixed widgets must override Widget.pack()')
             raise WidgetError(f'Cannot pack () size, this is not a fixed widget: {self!r}')
         elif len(size) == 1:
             if FLOW in self.sizing():
@@ -560,7 +559,7 @@ class Widget(metaclass=WidgetMeta):
         return size
 
     @property
-    def base_widget(self):
+    def base_widget(self) -> Widget:
         """
         Read-only property that steps through decoration widgets
         and returns the one at the base.  This default implementation
@@ -569,7 +568,7 @@ class Widget(metaclass=WidgetMeta):
         return self
 
     @property
-    def focus(self):
+    def focus(self) -> Widget | None:
         """
         Read-only property returning the child widget in focus for
         container widgets.  This default implementation
@@ -630,13 +629,13 @@ class FlowWidget(Widget):
             DeprecationWarning,
         )
 
-    def rows(self, size, focus=False):
+    def rows(self, size: int, focus: bool = False) -> int:
         """
         All flow widgets must implement this function.
         """
         raise NotImplementedError()
 
-    def render(self, size, focus=False):
+    def render(self, size: tuple[int], focus: bool = False):
         """
         All widgets must implement this function.
         """
@@ -670,7 +669,7 @@ class BoxWidget(Widget):
             DeprecationWarning,
         )
 
-    def render(self, size, focus=False):
+    def render(self, size: tuple[int, int], focus: bool = False):
         """
         All widgets must implement this function.
         """
@@ -1183,16 +1182,16 @@ class Edit(Text):
     # (this variable is picked up by the MetaSignals metaclass)
     signals = ["change", "postchange"]
 
-    def valid_char(self, ch):
+    def valid_char(self, ch: str) -> bool:
         """
         Filter for text that may be entered into this widget by the user
 
         :param ch: character to be inserted
-        :type ch: bytes or unicode
+        :type ch: str
 
         This implementation returns True for all printable characters.
         """
-        return is_wide_char(ch,0) or (len(ch)==1 and ord(ch) >= 32)
+        return is_wide_char(ch, 0) or (len(ch) == 1 and ord(ch) >= 32)
 
     def __init__(
             self,
@@ -1535,7 +1534,7 @@ class Edit(Text):
         result_pos += len(text)
         return (result_text, result_pos)
 
-    def keypress(self, size: tuple[int], key: str | bytes):
+    def keypress(self, size: tuple[int], key: str) -> str | None:
         """
         Handle editing keystrokes, return others.
 
@@ -1770,9 +1769,9 @@ class IntEdit(Edit):
         """
         Return true for decimal digits.
         """
-        return len(ch)==1 and ch in "0123456789"
+        return len(ch) == 1 and ch in "0123456789"
 
-    def __init__(self,caption="",default=None):
+    def __init__(self, caption="", default: int | str = None) -> None:
         """
         caption -- caption markup
         default -- default edit value
@@ -1780,11 +1779,13 @@ class IntEdit(Edit):
         >>> IntEdit(u"", 42)
         <IntEdit selectable flow widget '42' edit_pos=2>
         """
-        if default is not None: val = str(default)
-        else: val = ""
-        super().__init__(caption,val)
+        if default is not None:
+            val = str(default)
+        else:
+            val = ""
+        super().__init__(caption, val)
 
-    def keypress(self, size, key):
+    def keypress(self, size: tuple[int], key: str) -> str | None:
         """
         Handle editing keystrokes.  Remove leading zeros.
 
@@ -1808,7 +1809,7 @@ class IntEdit(Edit):
 
         return unhandled
 
-    def value(self):
+    def value(self) -> int:
         """
         Return the numeric value of self.edit_text.
 
@@ -1824,7 +1825,7 @@ class IntEdit(Edit):
             return 0
 
 
-def delegate_to_widget_mixin(attribute_name):
+def delegate_to_widget_mixin(attribute_name: str):
     """
     Return a mixin class that delegates all standard widget methods
     to an attribute given by attribute_name.
@@ -1835,10 +1836,11 @@ def delegate_to_widget_mixin(attribute_name):
     # when layout and rendering are separated
 
     get_delegate = attrgetter(attribute_name)
-    class DelegateToWidgetMixin(Widget):
-        no_cache = ["rows"] # crufty metaclass work-around
 
-        def render(self, size, focus=False):
+    class DelegateToWidgetMixin(Widget):
+        no_cache = ["rows"]  # crufty metaclass work-around
+
+        def render(self, size, focus: bool = False) -> CompositeCanvas:
             canv = get_delegate(self).render(size, focus=focus)
             return CompositeCanvas(canv)
 
@@ -1881,12 +1883,12 @@ def delegate_to_widget_mixin(attribute_name):
     return DelegateToWidgetMixin
 
 
-
 class WidgetWrapError(Exception):
     pass
 
+
 class WidgetWrap(delegate_to_widget_mixin('_wrapped_widget'), Widget):
-    def __init__(self, w):
+    def __init__(self, w: Widget):
         """
         w -- widget to wrap, stored as self._w
 
@@ -1932,10 +1934,10 @@ class WidgetWrap(delegate_to_widget_mixin('_wrapped_widget'), Widget):
     w = property(_raise_old_name_error, _raise_old_name_error)
 
 
-
 def _test():
     import doctest
     doctest.testmod()
 
-if __name__=='__main__':
+
+if __name__ == '__main__':
     _test()


### PR DESCRIPTION
* keypress always receive `str`
* fix `CF635Screen`: was missed return parameter in get_input_nonblocking
* fix `LCDScreen`: wrong type used for buffer (pyserial return `bytes`, concatenation to `str` is wrong)

Partial #406
Partial #512
Related #408

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
