### PR TITLE
Deprecate legacy property creation

### DIFF
--- a/examples/dialog.py
+++ b/examples/dialog.py
@@ -118,16 +118,16 @@ class InputDialogDisplay(DialogDisplay):
 
         DialogDisplay.__init__(self, text, height, width, body)
 
-        self.frame.set_focus('body')
+        self.frame.focus_position = 'body'
 
     def unhandled_key(self, size, k):
         if k in ('up','page up'):
-            self.frame.set_focus('body')
+            self.frame.focus_position = 'body'
         if k in ('down','page down'):
-            self.frame.set_focus('footer')
+            self.frame.focus_position = 'footer'
         if k == 'enter':
             # pass enter to the "ok" button
-            self.frame.set_focus('footer')
+            self.frame.focus_position = 'footer'
             self.view.keypress( size, k )
 
     def on_exit(self, exitcode):
@@ -148,9 +148,9 @@ class TextDialogDisplay(DialogDisplay):
 
     def unhandled_key(self, size, k):
         if k in ('up','page up','down','page down'):
-            self.frame.set_focus('body')
+            self.frame.focus_position = 'body'
             self.view.keypress( size, k )
-            self.frame.set_focus('footer')
+            self.frame.focus_position = 'footer'
 
 
 class ListDialogDisplay(DialogDisplay):
@@ -178,17 +178,17 @@ class ListDialogDisplay(DialogDisplay):
         lb = urwid.AttrWrap( lb, "selectable" )
         DialogDisplay.__init__(self, text, height, width, lb )
 
-        self.frame.set_focus('body')
+        self.frame.focus_position = 'body'
 
     def unhandled_key(self, size, k):
         if k in ('up','page up'):
-            self.frame.set_focus('body')
+            self.frame.focus_position = 'body'
         if k in ('down','page down'):
-            self.frame.set_focus('footer')
+            self.frame.focus_position = 'footer'
         if k == 'enter':
             # pass enter to the "ok" button
-            self.frame.set_focus('footer')
-            self.buttons.set_focus(0)
+            self.frame.focus_position = 'footer'
+            self.buttons.focus_position = 0
             self.view.keypress( size, k )
 
     def on_exit(self, exitcode):

--- a/urwid/canvas.py
+++ b/urwid/canvas.py
@@ -261,7 +261,7 @@ class Canvas:
     def _text_content(self):
         warnings.warn(
             f"Method `{self.__class__.__name__}._text_content` is deprecated, "
-            f"please use property `{self.__class__.__name__}text`",
+            f"please use property `{self.__class__.__name__}.text`",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/urwid/canvas.py
+++ b/urwid/canvas.py
@@ -23,6 +23,7 @@
 from __future__ import annotations
 
 import typing
+import warnings
 import weakref
 from collections.abc import Sequence
 
@@ -203,10 +204,6 @@ class Canvas:
     _renamed_error = CanvasError("The old Canvas class is now called "
         "TextCanvas. Canvas is now the base class for all canvas "
         "classes.")
-    _old_repr_error = CanvasError("The internal representation of "
-        "canvases is no longer stored as .text, .attr, and .cs "
-        "lists, please see the TextCanvas class for the new "
-        "representation of canvas content.")
 
     def __init__(
         self,
@@ -240,23 +237,35 @@ class Canvas:
             raise self._finalized_error
         self._widget_info = widget, size, focus
 
-    def _get_widget_info(self):
+    @property
+    def widget_info(self):
         return self._widget_info
-    widget_info = property(_get_widget_info)
 
-    def _raise_old_repr_error(self, val=None) -> typing.NoReturn:
-        raise self._old_repr_error
+    def _get_widget_info(self):
+        warnings.warn(
+            f"Method `{self.__class__.__name__}._get_widget_info` is deprecated, "
+            f"please use property `{self.__class__.__name__}widget_info`",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.widget_info
 
-    def _text_content(self):
+    @property
+    def text(self) -> list[bytes]:
         """
         Return the text content of the canvas as a list of strings,
         one for each row.
         """
         return [b''.join([text for (attr, cs, text) in row]) for row in self.content()]
 
-    text = property(_text_content, _raise_old_repr_error)
-    attr = property(_raise_old_repr_error, _raise_old_repr_error)
-    cs = property(_raise_old_repr_error, _raise_old_repr_error)
+    def _text_content(self):
+        warnings.warn(
+            f"Method `{self.__class__.__name__}._text_content` is deprecated, "
+            f"please use property `{self.__class__.__name__}text`",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.text
 
     def content(
         self,

--- a/urwid/canvas.py
+++ b/urwid/canvas.py
@@ -244,7 +244,7 @@ class Canvas:
     def _get_widget_info(self):
         warnings.warn(
             f"Method `{self.__class__.__name__}._get_widget_info` is deprecated, "
-            f"please use property `{self.__class__.__name__}widget_info`",
+            f"please use property `{self.__class__.__name__}.widget_info`",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/urwid/container.py
+++ b/urwid/container.py
@@ -1129,32 +1129,90 @@ class Frame(Widget, WidgetContainerMixin):
         self._footer = footer
         self.focus_part = focus_part
 
-    def get_header(self) -> Widget | None:
+    @property
+    def header(self) -> Widget | None:
         return self._header
 
-    def set_header(self, header: Widget | None):
+    @header.setter
+    def header(self, header: Widget | None):
         self._header = header
         if header is None and self.focus_part == 'header':
             self.focus_part = 'body'
         self._invalidate()
-    header = property(get_header, set_header)
 
-    def get_body(self) -> Widget:
+    def get_header(self) -> Widget | None:
+        warnings.warn(
+            f"method `{self.__class__.__name__}.get_header` is deprecated, "
+            f"standard property `{self.__class__.__name__}.header` should be used instead",
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+        return self.header
+
+    def set_header(self, header: Widget | None):
+        warnings.warn(
+            f"method `{self.__class__.__name__}.set_header` is deprecated, "
+            f"standard property `{self.__class__.__name__}.header` should be used instead",
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+        self.header = header
+
+    @property
+    def body(self) -> Widget:
         return self._body
-    def set_body(self, body: Widget) -> None:
+
+    @body.setter
+    def body(self, body: Widget) -> None:
         self._body = body
         self._invalidate()
-    body = property(get_body, set_body)
 
-    def get_footer(self) -> Widget | None:
+    def get_body(self) -> Widget:
+        warnings.warn(
+            f"method `{self.__class__.__name__}.get_body` is deprecated, "
+            f"standard property {self.__class__.__name__}.body should be used instead",
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+        return self.body
+
+    def set_body(self, body: Widget) -> None:
+        warnings.warn(
+            f"method `{self.__class__.__name__}.set_body` is deprecated, "
+            f"standard property `{self.__class__.__name__}.body` should be used instead",
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+        self.body = body
+
+    @property
+    def footer(self) -> Widget | None:
         return self._footer
 
-    def set_footer(self, footer: Widget | None) -> None:
+    @footer.setter
+    def footer(self, footer: Widget | None) -> None:
         self._footer = footer
         if footer is None and self.focus_part == 'footer':
             self.focus_part = 'body'
         self._invalidate()
-    footer = property(get_footer, set_footer)
+
+    def get_footer(self) -> Widget | None:
+        warnings.warn(
+            f"method `{self.__class__.__name__}.get_footer` is deprecated, "
+            f"standard property `{self.__class__.__name__}.footer` should be used instead",
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+        return self.footer
+
+    def set_footer(self, footer: Widget | None) -> None:
+        warnings.warn(
+            f"method `{self.__class__.__name__}.set_footer` is deprecated, "
+            f"standard property `{self.__class__.__name__}.footer` should be used instead",
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+        self.footer = footer
 
     @property
     def focus_position(self) -> Literal['header', 'footer', 'body']:
@@ -1177,8 +1235,7 @@ class Frame(Widget, WidgetContainerMixin):
         """
         if part not in ('header', 'footer', 'body'):
             raise IndexError(f'Invalid position for Frame: {part}')
-        if (part == 'header' and self._header is None) or (
-                part == 'footer' and self._footer is None):
+        if (part == 'header' and self._header is None) or (part == 'footer' and self._footer is None):
             raise IndexError(f'This Frame has no {part}')
         self.focus_part = part
         self._invalidate()

--- a/urwid/decoration.py
+++ b/urwid/decoration.py
@@ -23,6 +23,7 @@
 from __future__ import annotations
 
 import typing
+import warnings
 from collections.abc import Hashable, Mapping
 
 from urwid.canvas import CompositeCanvas, SolidCanvas
@@ -77,15 +78,35 @@ class WidgetDecoration(Widget):  # "decorator" was already taken
     def _repr_words(self):
         return super()._repr_words() + [repr(self._original_widget)]
 
-    def _get_original_widget(self) -> Widget:
+    @property
+    def original_widget(self) -> Widget:
         return self._original_widget
 
-    def _set_original_widget(self, original_widget):
+    @original_widget.setter
+    def original_widget(self, original_widget: Widget) -> None:
         self._original_widget = original_widget
         self._invalidate()
-    original_widget = property(_get_original_widget, _set_original_widget)
 
-    def _get_base_widget(self):
+    def _get_original_widget(self) -> Widget:
+        warnings.warn(
+            f"Method `{self.__class__.__name__}._get_original_widget` is deprecated, "
+            f"please use property `{self.__class__.__name__}.original_widget`",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.original_widget
+
+    def _set_original_widget(self, original_widget):
+        warnings.warn(
+            f"Method `{self.__class__.__name__}._set_original_widget` is deprecated, "
+            f"please use property `{self.__class__.__name__}.original_widget`",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self.original_widget = original_widget
+
+    @property
+    def base_widget(self) -> Widget:
         """
         Return the widget without decorations.  If there is only one
         Decoration then this is the same as original_widget.
@@ -104,7 +125,14 @@ class WidgetDecoration(Widget):  # "decorator" was already taken
             w = w._original_widget
         return w
 
-    base_widget = property(_get_base_widget)
+    def _get_base_widget(self):
+        warnings.warn(
+            f"Method `{self.__class__.__name__}._get_base_widget` is deprecated, "
+            f"please use property `{self.__class__.__name__}.base_widget`",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.base_widget
 
     def selectable(self) -> bool:
         return self._original_widget.selectable()
@@ -299,10 +327,40 @@ class AttrWrap(AttrMap):
             d['focus_attr'] = self.focus_attr
         return d
 
-    # backwards compatibility, widget used to be stored as w
-    get_w = WidgetDecoration._get_original_widget
-    set_w = WidgetDecoration._set_original_widget
-    w = property(get_w, set_w)
+    @property
+    def w(self) -> Widget:
+        """backwards compatibility, widget used to be stored as w"""
+        warnings.warn(
+            "backwards compatibility, widget used to be stored as w",
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+        return self.original_widget
+
+    @w.setter
+    def w(self, new_widget: Widget) -> None:
+        warnings.warn(
+            "backwards compatibility, widget used to be stored as w",
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+        self.original_widget = new_widget
+
+    def get_w(self):
+        warnings.warn(
+            "backwards compatibility, widget used to be stored as w",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.original_widget
+
+    def set_w(self, new_widget: Widget) -> None:
+        warnings.warn(
+            "backwards compatibility, widget used to be stored as w",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self.original_widget = new_widget
 
     def get_attr(self):
         return self.attr_map[None]
@@ -387,7 +445,23 @@ class BoxAdapter(WidgetDecoration):
         return dict(super()._repr_attrs(), height=self.height)
 
     # originally stored as box_widget, keep for compatibility
-    box_widget = property(WidgetDecoration._get_original_widget, WidgetDecoration._set_original_widget)
+    @property
+    def box_widget(self) -> Widget:
+        warnings.warn(
+            "originally stored as box_widget, keep for compatibility",
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+        return self.original_widget
+
+    @box_widget.setter
+    def box_widget(self, widget: Widget):
+        warnings.warn(
+            "originally stored as box_widget, keep for compatibility",
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+        self.original_widget = widget
 
     def sizing(self):
         return {FLOW}
@@ -571,33 +645,71 @@ class Padding(WidgetDecoration):
             min_width=self.min_width)
         return remove_defaults(attrs, Padding.__init__)
 
-    def _get_align(self) -> Literal['left', 'center', 'right'] | tuple[Literal['relative'], int]:
+    @property
+    def align(self) -> Literal['left', 'center', 'right'] | tuple[Literal['relative'], int]:
         """
         Return the padding alignment setting.
         """
         return simplify_align(self._align_type, self._align_amount)
 
-    def _set_align(self, align: Literal['left', 'center', 'right'] | tuple[Literal['relative'], int]) -> None:
+    @align.setter
+    def align(self, align: Literal['left', 'center', 'right'] | tuple[Literal['relative'], int]) -> None:
         """
         Set the padding alignment.
         """
         self._align_type, self._align_amount = normalize_align(align, PaddingError)
         self._invalidate()
-    align = property(_get_align, _set_align)
 
-    def _get_width(self) -> Literal['clip', 'pack'] | int | tuple[Literal['relative'], int]:
+    def _get_align(self) -> Literal['left', 'center', 'right'] | tuple[Literal['relative'], int]:
+        warnings.warn(
+            f"Method `{self.__class__.__name__}._get_align` is deprecated, "
+            f"please use property `{self.__class__.__name__}.align`",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.align
+
+    def _set_align(self, align: Literal['left', 'center', 'right'] | tuple[Literal['relative'], int]) -> None:
+        warnings.warn(
+            f"Method `{self.__class__.__name__}._set_align` is deprecated, "
+            f"please use property `{self.__class__.__name__}.align`",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self.align = align
+
+    @property
+    def width(self) -> Literal['clip', 'pack'] | int | tuple[Literal['relative'], int]:
         """
         Return the padding width.
         """
         return simplify_width(self._width_type, self._width_amount)
 
-    def _set_width(self, width: Literal['clip', 'pack'] | int | tuple[Literal['relative'], int]) -> None:
+    @width.setter
+    def width(self, width: Literal['clip', 'pack'] | int | tuple[Literal['relative'], int]) -> None:
         """
         Set the padding width.
         """
         self._width_type, self._width_amount = normalize_width(width, PaddingError)
         self._invalidate()
-    width = property(_get_width, _set_width)
+
+    def _get_width(self) -> Literal['clip', 'pack'] | int | tuple[Literal['relative'], int]:
+        warnings.warn(
+            f"Method `{self.__class__.__name__}._get_width` is deprecated, "
+            f"please use property `{self.__class__.__name__}.width`",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.width
+
+    def _set_width(self, width: Literal['clip', 'pack'] | int | tuple[Literal['relative'], int]) -> None:
+        warnings.warn(
+            f"Method `{self.__class__.__name__}._set_width` is deprecated, "
+            f"please use property `{self.__class__.__name__}.width`",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self.width = width
 
     def render(
         self,
@@ -847,10 +959,41 @@ class Filler(WidgetDecoration):
             min_height=self.min_height)
         return remove_defaults(attrs, Filler.__init__)
 
-    # backwards compatibility, widget used to be stored as body
-    get_body = WidgetDecoration._get_original_widget
-    set_body = WidgetDecoration._set_original_widget
-    body = property(get_body, set_body)
+    @property
+    def body(self):
+        """backwards compatibility, widget used to be stored as body"""
+        warnings.warn(
+            "backwards compatibility, widget used to be stored as body",
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+        return self.original_widget
+
+    @body.setter
+    def body(self, new_body):
+        warnings.warn(
+            "backwards compatibility, widget used to be stored as body",
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+        self.original_widget = new_body
+
+    def get_body(self):
+        """backwards compatibility, widget used to be stored as body"""
+        warnings.warn(
+            "backwards compatibility, widget used to be stored as body",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.original_widget
+
+    def set_body(self, new_body):
+        warnings.warn(
+            "backwards compatibility, widget used to be stored as body",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self.original_widget = new_body
 
     def selectable(self) -> bool:
         """Return selectable from body."""

--- a/urwid/display_common.py
+++ b/urwid/display_common.py
@@ -610,7 +610,8 @@ class AttrSpec:
     def strikethrough(self) -> bool:
         return self._value & _STRIKETHROUGH != 0
 
-    def _colors(self) -> int:
+    @property
+    def colors(self) -> int:
         """
         Return the maximum colors required for this object.
 
@@ -625,7 +626,15 @@ class AttrSpec:
         if self._value & (_BG_BASIC_COLOR | _FG_BASIC_COLOR):
             return 16
         return 1
-    colors = property(_colors)
+
+    def _colors(self) -> int:
+        warnings.warn(
+            f"Method `{self.__class__.__name__}._colors` is deprecated, "
+            f"please use property `{self.__class__.__name__}.colors`",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.colors
 
     def __repr__(self) -> str:
         """
@@ -650,7 +659,8 @@ class AttrSpec:
             return _color_desc_true(self.foreground_number)
         return _color_desc_256(self.foreground_number)
 
-    def _foreground(self) -> str:
+    @property
+    def foreground(self) -> str:
         return (
             self._foreground_color()
             + ',bold' * self.bold
@@ -661,7 +671,8 @@ class AttrSpec:
             + ',strikethrough' * self.strikethrough
         )
 
-    def _set_foreground(self, foreground: str) -> None:
+    @foreground.setter
+    def foreground(self, foreground: str) -> None:
         color = None
         flags = 0
         # handle comma-separated foreground
@@ -699,9 +710,26 @@ class AttrSpec:
             color = 0
         self._value = (self._value & ~_FG_MASK) | color | flags
 
-    foreground = property(_foreground, _set_foreground)
+    def _foreground(self) -> str:
+        warnings.warn(
+            f"Method `{self.__class__.__name__}._foreground` is deprecated, "
+            f"please use property `{self.__class__.__name__}.foreground`",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.foreground
 
-    def _background(self) -> str:
+    def _set_foreground(self, foreground: str) -> None:
+        warnings.warn(
+            f"Method `{self.__class__.__name__}._set_foreground` is deprecated, "
+            f"please use property `{self.__class__.__name__}.foreground`",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self.foreground = foreground
+
+    @property
+    def background(self) -> str:
         """Return the background color."""
         if not (self.background_basic or self.background_high or self.background_true):
             return 'default'
@@ -713,7 +741,8 @@ class AttrSpec:
             return _color_desc_true(self.background_number)
         return _color_desc_256(self.background_number)
 
-    def _set_background(self, background: str) -> None:
+    @background.setter
+    def background(self, background: str) -> None:
         flags = 0
         if background in ('', 'default'):
             color = 0
@@ -733,7 +762,23 @@ class AttrSpec:
             raise AttrSpecError(f"Unrecognised color specification in background ({background!r})")
         self._value = (self._value & ~_BG_MASK) | (color << _BG_SHIFT) | flags
 
-    background = property(_background, _set_background)
+    def _background(self) -> str:
+        warnings.warn(
+            f"Method `{self.__class__.__name__}._background` is deprecated, "
+            f"please use property `{self.__class__.__name__}.background`",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.background
+
+    def _set_background(self, background: str) -> None:
+        warnings.warn(
+            f"Method `{self.__class__.__name__}._set_background` is deprecated, "
+            f"please use property `{self.__class__.__name__}.background`",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self.background = background
 
     def get_rgb_values(self):
         """

--- a/urwid/graphics.py
+++ b/urwid/graphics.py
@@ -23,6 +23,7 @@
 from __future__ import annotations
 
 import typing
+import warnings
 
 from urwid.canvas import CanvasCombine, CanvasJoin, CompositeCanvas, SolidCanvas, TextCanvas
 from urwid.container import Columns, Pile
@@ -942,13 +943,26 @@ class ProgressBar(Widget):
         self._invalidate()
     current = property(lambda self: self._current, set_completion)
 
-    def _set_done(self, done):
+    @property
+    def done(self):
+        return self._done
+
+    @done.setter
+    def done(self, done):
         """
         done -- progress amount at 100%
         """
         self._done = done
         self._invalidate()
-    done = property(lambda self: self._done, _set_done)
+
+    def _set_done(self, done):
+        warnings.warn(
+            f"Method `{self.__class__.__name__}._set_done` is deprecated, "
+            f"please use property `{self.__class__.__name__}.done`",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self.done = done
 
     def rows(self, size, focus: bool = False) -> int:
         return 1

--- a/urwid/listbox.py
+++ b/urwid/listbox.py
@@ -23,6 +23,7 @@
 from __future__ import annotations
 
 import typing
+import warnings
 from collections.abc import MutableSequence
 
 from urwid import signals
@@ -118,14 +119,23 @@ class SimpleListWalker(MonitoredList, ListWalker):
         self.focus = 0
         self.wrap_around = wrap_around
 
-    def _get_contents(self):
+    @property
+    def contents(self):
         """
         Return self.
 
         Provides compatibility with old SimpleListWalker class.
         """
         return self
-    contents = property(_get_contents)
+
+    def _get_contents(self):
+        warnings.warn(
+            f"Method `{self.__class__.__name__}._get_contents` is deprecated, "
+            f"please use property`{self.__class__.__name__}.contents`",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.contents
 
     def _modified(self):
         if self.focus >= len(self):
@@ -257,14 +267,14 @@ class ListBox(Widget, WidgetContainerMixin):
     _selectable = True
     _sizing = frozenset([BOX])
 
-    def __init__(self, body):
+    def __init__(self, body: ListWalker):
         """
         :param body: a ListWalker subclass such as
             :class:`SimpleFocusListWalker` that contains
             widgets to be displayed inside the list box
         :type body: ListWalker
         """
-        self._set_body(body)
+        self.body = body
 
         # offset_rows is the number of rows between the top of the view
         # and the top of the focused item
@@ -284,10 +294,16 @@ class ListBox(Widget, WidgetContainerMixin):
         # variable for delayed valign change used by set_focus_valign
         self.set_focus_valign_pending = None
 
-    def _get_body(self):
+    @property
+    def body(self):
+        """
+        a ListWalker subclass such as :class:`SimpleFocusListWalker` that contains
+        widgets to be displayed inside the list box
+        """
         return self._body
 
-    def _set_body(self, body):
+    @body.setter
+    def body(self, body):
         try:
             disconnect_signal(self._body, "modified", self._invalidate)
         except AttributeError:
@@ -306,10 +322,23 @@ class ListBox(Widget, WidgetContainerMixin):
             self.render = nocache_widget_render_instance(self)
         self._invalidate()
 
-    body = property(_get_body, _set_body, doc="""
-    a ListWalker subclass such as :class:`SimpleFocusListWalker` that contains
-    widgets to be displayed inside the list box
-    """)
+    def _get_body(self):
+        warnings.warn(
+            f"Method `{self.__class__.__name__}._get_body` is deprecated, "
+            f"please use property `{self.__class__.__name__}.body`",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.body
+
+    def _set_body(self, body):
+        warnings.warn(
+            f"Method `{self.__class__.__name__}._set_body` is deprecated, "
+            f"please use property `{self.__class__.__name__}.body`",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self.body = body
 
     def calculate_visible(self, size: tuple[int, int], focus: bool = False):
         """
@@ -591,13 +620,14 @@ class ListBox(Widget, WidgetContainerMixin):
         """
         return self._body.get_focus()
 
-    def _get_focus(self):
+    @property
+    def focus(self):
         """
+        the child widget in focus or None when ListBox is empty.
+
         Return the widget in focus according to our :obj:`list walker <ListWalker>`.
         """
         return self._body.get_focus()[0]
-    focus = property(_get_focus,
-                     doc="the child widget in focus or None when ListBox is empty")
 
     def _get_focus_position(self):
         """

--- a/urwid/main_loop.py
+++ b/urwid/main_loop.py
@@ -31,6 +31,7 @@ import signal
 import sys
 import time
 import typing
+import warnings
 from collections.abc import Callable, Iterable
 from functools import wraps
 from itertools import count
@@ -154,25 +155,51 @@ class MainLoop:
 
         self._watch_pipes = {}
 
-    def _set_widget(self, widget):
+    @property
+    def widget(self) -> Widget:
+        """
+       Property for the topmost widget used to draw the screen.
+       This must be a box widget.
+       """
+        return self._widget
+
+    @widget.setter
+    def widget(self, widget: Widget) -> None:
         self._widget = widget
         if self.pop_ups:
             self._topmost_widget.original_widget = self._widget
         else:
             self._topmost_widget = self._widget
-    widget = property(lambda self:self._widget, _set_widget, doc=
-       """
-       Property for the topmost widget used to draw the screen.
-       This must be a box widget.
-       """)
 
-    def _set_pop_ups(self, pop_ups):
+    def _set_widget(self, widget: Widget) -> None:
+        warnings.warn(
+            f"method `{self.__class__.__name__}._set_widget` is deprecated, "
+            f"please use `{self.__class__.__name__}.widget` property",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self.widget = widget
+
+    @property
+    def pop_ups(self):
+        return self._pop_ups
+
+    @pop_ups.setter
+    def pop_ups(self, pop_ups) -> None:
         self._pop_ups = pop_ups
         if pop_ups:
             self._topmost_widget = PopUpTarget(self._widget)
         else:
             self._topmost_widget = self._widget
-    pop_ups = property(lambda self:self._pop_ups, _set_pop_ups)
+
+    def _set_pop_ups(self, pop_ups) -> None:
+        warnings.warn(
+            f"method `{self.__class__.__name__}._set_pop_ups` is deprecated, "
+            f"please use `{self.__class__.__name__}.pop_ups` property",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self.pop_ups = pop_ups
 
     def set_alarm_in(self, sec, callback, user_data=None):
         """
@@ -1039,7 +1066,6 @@ class GLibEventLoop(EventLoop):
             except ExitMainLoop:
                 self._loop.quit()
             except:
-                import sys
                 self._exc_info = sys.exc_info()
                 if self._loop.is_running():
                     self._loop.quit()
@@ -1377,7 +1403,6 @@ class TwistedEventLoop(EventLoop):
                 if self.manage_reactor:
                     self.reactor.stop()
             except:
-                import sys
                 print(sys.exc_info())
                 self._exc_info = sys.exc_info()
                 if self.manage_reactor:

--- a/urwid/tests/test_container.py
+++ b/urwid/tests/test_container.py
@@ -134,6 +134,11 @@ class PileTest(unittest.TestCase):
         p.mouse_event((5,), 'button press', 1, 1, 1, False)
         p.mouse_event((5,), 'button press', 1, 1, 1, True)
 
+    def test_lenght(self):
+        pile = urwid.Pile(urwid.Text(c) for c in "ABC")
+        self.assertEqual(3, len(pile))
+        self.assertEqual(3, len(pile.contents))
+
 
 class ColumnsTest(unittest.TestCase):
     def cwtest(self, desc, l, divide, size, exp, focus_column=0):
@@ -202,8 +207,7 @@ class ColumnsTest(unittest.TestCase):
         c = urwid.Columns( l, divide )
         rval = c.move_cursor_to_coords( size, col, row )
         assert rval == exp, f"{desc} expected {exp!r}, got {rval!r}"
-        assert c.focus_col == f_col, "%s expected focus_col %s got %s"%(
-            desc, f_col, c.focus_col)
+        assert c.focus_position == f_col, f"{desc} expected focus_col {f_col} got {c.focus_position}"
         pc = c.get_pref_col( size )
         assert pc == pref_col, f"{desc} expected pref_col {pref_col}, got {pc}"
 
@@ -252,6 +256,11 @@ class ColumnsTest(unittest.TestCase):
         c.mouse_event((10,), 'foo', 1, 0, 0, True)
         c.get_pref_col((10,))
 
+    def test_lenght(self):
+        columns = urwid.Columns(urwid.Text(c) for c in "ABC")
+        self.assertEqual(3, len(columns))
+        self.assertEqual(3, len(columns.contents))
+
 
 
 class OverlayTest(unittest.TestCase):
@@ -273,6 +282,18 @@ class OverlayTest(unittest.TestCase):
         self.assertEqual(urwid.Overlay(urwid.Filler(urwid.Edit()),
             urwid.SolidFill('B'),
             'right', 1, 'bottom', 1).get_cursor_coords((2,2)), (1,1))
+
+    def test_lenght(self):
+        ovl = urwid.Overlay(
+            urwid.SolidFill('X'),
+            urwid.SolidFill('O'),
+            'center',
+            ("relative", 20),
+            "middle",
+            ("relative", 20),
+        )
+        self.assertEqual(2, len(ovl))
+        self.assertEqual(2, len(ovl.contents))
 
 
 class GridFlowTest(unittest.TestCase):
@@ -297,6 +318,11 @@ class GridFlowTest(unittest.TestCase):
         gf = urwid.GridFlow([button], 10, 3, v_sep=0, align="center")
         self.assertEqual(gf.keypress((20,), "enter"), None)
         call_back.assert_called_with(button)
+
+    def test_lenght(self):
+        grid = urwid.GridFlow((urwid.Text(c) for c in "ABC"), 1, 0, 0, 'left')
+        self.assertEqual(3, len(grid))
+        self.assertEqual(3, len(grid.contents))
 
 
 class WidgetSquishTest(unittest.TestCase):

--- a/urwid/tests/test_container.py
+++ b/urwid/tests/test_container.py
@@ -134,7 +134,7 @@ class PileTest(unittest.TestCase):
         p.mouse_event((5,), 'button press', 1, 1, 1, False)
         p.mouse_event((5,), 'button press', 1, 1, 1, True)
 
-    def test_lenght(self):
+    def test_length(self):
         pile = urwid.Pile(urwid.Text(c) for c in "ABC")
         self.assertEqual(3, len(pile))
         self.assertEqual(3, len(pile.contents))

--- a/urwid/tests/test_container.py
+++ b/urwid/tests/test_container.py
@@ -256,11 +256,10 @@ class ColumnsTest(unittest.TestCase):
         c.mouse_event((10,), 'foo', 1, 0, 0, True)
         c.get_pref_col((10,))
 
-    def test_lenght(self):
+    def test_length(self):
         columns = urwid.Columns(urwid.Text(c) for c in "ABC")
         self.assertEqual(3, len(columns))
         self.assertEqual(3, len(columns.contents))
-
 
 
 class OverlayTest(unittest.TestCase):
@@ -283,7 +282,7 @@ class OverlayTest(unittest.TestCase):
             urwid.SolidFill('B'),
             'right', 1, 'bottom', 1).get_cursor_coords((2,2)), (1,1))
 
-    def test_lenght(self):
+    def test_length(self):
         ovl = urwid.Overlay(
             urwid.SolidFill('X'),
             urwid.SolidFill('O'),
@@ -319,7 +318,7 @@ class GridFlowTest(unittest.TestCase):
         self.assertEqual(gf.keypress((20,), "enter"), None)
         call_back.assert_called_with(button)
 
-    def test_lenght(self):
+    def test_length(self):
         grid = urwid.GridFlow((urwid.Text(c) for c in "ABC"), 1, 0, 0, 'left')
         self.assertEqual(3, len(grid))
         self.assertEqual(3, len(grid.contents))


### PR DESCRIPTION
* Drop long time ago removed methods (never returning methods)
* Move large part of property implementations under `@property`
* Emit `PendingDeprecationWarning` for old compatibility code for public methods used as core for property and methods for compatibility
* Emit `DeprecationWarning` for private methods used in property construction using `property()` call

Due to amount of copy-paste like changes, for containers shared part is moved to the existing base classes Add `__len__` to the list based containers. Related #445 Fix typo in type annotation for `Frame.mouse_event`

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
