### PR TITLE
Fix regression: `Pile()` focus_item can be Widget -> need to set prop…

### DIFF
--- a/urwid/container.py
+++ b/urwid/container.py
@@ -1659,7 +1659,7 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
                 focus_item = i
 
         if self.contents and focus_item is not None:
-            self.focus_position = focus_item
+            self.focus = focus_item
 
         self.pref_col = 0
 

--- a/urwid/tests/test_container.py
+++ b/urwid/tests/test_container.py
@@ -395,6 +395,12 @@ class WidgetSquishTest(unittest.TestCase):
         self.fwstest(urwid.Button("hello"))
         self.fwstest(urwid.RadioButton([], "hello"))
 
+    def testFocus(self):
+        expect_focused = urwid.Button("Focused")
+        pile = urwid.Pile((urwid.Button("First"), expect_focused, urwid.Button("Last")), focus_item=expect_focused)
+        self.assertEqual(1, pile.focus_position)
+        self.assertEqual(expect_focused, pile.focus)
+
 
 class CommonContainerTest(unittest.TestCase):
     def test_pile(self):


### PR DESCRIPTION
…erty `focus` in constructor

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [X] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
