### PR TITLE
Fix empty markup handling

### DIFF
--- a/urwid/tests/test_util.py
+++ b/urwid/tests/test_util.py
@@ -227,3 +227,10 @@ class PortabilityTest(unittest.TestCase):
                 f"Locale restore impossible, probably locale not supported by system (libc ignores this error).\n"
                 f"{exc}"
             )
+
+
+class TestEmptyMarkup(unittest.TestCase):
+    def test_001_empty(self):
+        text = urwid.Text('')
+        text.set_text(text.get_text())
+        self.assertEqual("", text.text)

--- a/urwid/util.py
+++ b/urwid/util.py
@@ -382,7 +382,10 @@ def decompose_tagmarkup(tm):
 
     tl, al = _tagmarkup_recurse(tm, None)
     # join as unicode or bytes based on type of first element
-    text = tl[0][:0].join(tl)
+    if tl:
+        text = tl[0][:0].join(tl)
+    else:
+        text = ""
 
     if al and al[-1][0] is None:
         del al[-1]


### PR DESCRIPTION
* not switching to Unicode-only at this moment, so make simple

Fix #408

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
