### PR TITLE
Deprecate `__super` hack

### DIFF
--- a/urwid/util.py
+++ b/urwid/util.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import codecs
 import typing
+import warnings
 
 from urwid import escape
 
@@ -445,7 +446,17 @@ class MetaSuper(type):
         super().__init__(name, bases, d)
         if hasattr(cls, f"_{name}__super"):
             raise AttributeError("Class has same name as one of its super classes")
-        setattr(cls, f"_{name}__super", super(cls))
+
+        @property
+        def _super(self):
+            warnings.warn(
+                f"`{name}.__super` is a deprecated hack for old python versions."
+                f"Please use `super()` call explicit.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            return super(cls, self)
+        setattr(cls, f"_{name}__super", _super)
 
 
 def int_scale(val: int, val_range: int, out_range: int):

--- a/urwid/util.py
+++ b/urwid/util.py
@@ -450,8 +450,8 @@ class MetaSuper(type):
         @property
         def _super(self):
             warnings.warn(
-                f"`{name}.__super` is a deprecated hack for old python versions."
-                f"Please use `super()` call explicit.",
+                f"`{name}.__super` was a deprecated feature for old python versions."
+                f"Please use `super()` call instead.",
                 DeprecationWarning,
                 stacklevel=3,
             )


### PR DESCRIPTION
`super()` should be called explicit

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment

Closes: #110