### PR TITLE
Buildsystem: use autodetect for packages instead of explicit listing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,10 +30,12 @@ zip-safe = false
 [tool.setuptools.packages.find]
 exclude = [
   "doc",
+  "docs",
+  "examples",
   "test",
+  "bin",
   ".*"
 ]
-include = ["urwid", 'urwid.tests']
 namespaces = false
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
* Fix issues, when new packages created, but not listed explicit

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
