### PR TITLE
[BREAKING CHANGE] Fixes: #90 Remove idle emulation from asyncio event loop

### DIFF
--- a/urwid/display_common.py
+++ b/urwid/display_common.py
@@ -487,6 +487,8 @@ class AttrSpecError(Exception):
 
 
 class AttrSpec:
+    __slots__ = ("_value",)
+
     def __init__(self, fg: str, bg: str, colors: Literal[1, 16, 88, 256, 16777216] = 256) -> None:
         """
         fg -- a string containing a comma-separated foreground color
@@ -553,6 +555,13 @@ class AttrSpec:
                 f'foreground/background ({fg!r}/{bg!r}) '
                 f'require more colors than have been specified ({colors:d}).'
             )
+
+    def __hash__(self) -> int:
+        """Safe hashable.
+
+         Instance is mutable -> use ID component.
+         """
+        return hash((self.__class__, self._value, id(self)))
 
     @property
     def foreground_basic(self) -> bool:

--- a/urwid/display_common.py
+++ b/urwid/display_common.py
@@ -580,7 +580,7 @@ class AttrSpec:
         return self.__class__(foreground, background, new_colors)
 
     def __hash__(self) -> int:
-        """Instance is immutable and ashable."""
+        """Instance is immutable and hashable."""
         return hash((self.__class__, self.__value))
 
     @property

--- a/urwid/event_loop/asyncio_loop.py
+++ b/urwid/event_loop/asyncio_loop.py
@@ -144,8 +144,7 @@ class AsyncioEventLoop(EventLoop):
         Returns a handle that may be passed to remove_enter_idle()
         """
         # XXX there's no such thing as "idle" in most event loops; this fakes
-        # it the same way as Twisted, by scheduling the callback to be called
-        # repeatedly
+        # it by adding extra callback to the timer and file watch callbacks.
         self._idle_handle += 1
         self._idle_callbacks[self._idle_handle] = callback
         return self._idle_handle

--- a/urwid/event_loop/tornado_loop.py
+++ b/urwid/event_loop/tornado_loop.py
@@ -47,25 +47,49 @@ class TornadoEventLoop(EventLoop):
     """ This is an Urwid-specific event loop to plug into its MainLoop.
         It acts as an adaptor for Tornado's IOLoop which does all
         heavy lifting except idle-callbacks.
-
-        Notice, since Tornado has no concept of idle callbacks we
-        monkey patch ioloop._impl.poll() function to be able to detect
-        potential idle periods.
     """
-    _idle_emulation_delay = 1.0 / 30  # a short time (in seconds)
 
     def __init__(self, loop: ioloop.IOLoop | None = None) -> None:
         if loop:
             self._loop: ioloop.IOLoop = loop
         else:
-            self._loop = ioloop.IOLoop.instance()
+            self._loop = ioloop.IOLoop.current()  # TODO(Aleksei): Switch to the syncio.EventLoop as tornado >= 6.0 !
 
         self._pending_alarms: dict[object, int] = {}
         self._watch_handles: dict[int, int] = {}  # {<watch_handle> : <file_descriptor>}
         self._max_watch_handle: int = 0
         self._exc: BaseException | None = None
 
+        self._idle_asyncio_handle: object | None = None
+        self._idle_handle: int = 0
+        self._idle_callbacks: dict[int, Callable[[], typing.Any]] = {}
+
+    def _also_call_idle(self, callback: Callable[_Spec, _T]) -> Callable[_Spec, _T]:
+        """
+        Wrap the callback to also call _entering_idle.
+        """
+
+        @functools.wraps(callback)
+        def wrapper(*args: _Spec.args, **kwargs: _Spec.kwargs) -> _T:
+            if not self._idle_asyncio_handle:
+                self._idle_asyncio_handle = self._loop.call_later(0, self._entering_idle)
+            return callback(*args, **kwargs)
+
+        return wrapper
+
+    def _entering_idle(self) -> None:
+        """
+        Call all the registered idle callbacks.
+        """
+        try:
+            for callback in self._idle_callbacks.values():
+                callback()
+        finally:
+            self._idle_asyncio_handle = None
+
     def alarm(self, seconds: float | int, callback:  Callable[[], typing.Any]):
+        @self._also_call_idle
+        @functools.wraps(callback)
         def wrapped() -> None:
             try:
                 del self._pending_alarms[handle]
@@ -77,7 +101,7 @@ class TornadoEventLoop(EventLoop):
         self._pending_alarms[handle] = 1
         return handle
 
-    def remove_alarm(self, handle) -> bool:
+    def remove_alarm(self, handle: object) -> bool:
         self._loop.remove_timeout(handle)
         try:
             del self._pending_alarms[handle]
@@ -87,6 +111,7 @@ class TornadoEventLoop(EventLoop):
             return True
 
     def watch_file(self, fd: int, callback: Callable[[], _T]) -> int:
+        @self._also_call_idle
         def handler(_fd: int, _events: int) -> None:
             self.handle_exit(callback)()
 
@@ -104,7 +129,7 @@ class TornadoEventLoop(EventLoop):
             self._loop.remove_handler(fd)
             return True
 
-    def enter_idle(self, callback: Callable[[], typing.Any]) -> list[object]:
+    def enter_idle(self, callback: Callable[[], typing.Any]) -> int:
         """
         Add a callback for entering idle.
 
@@ -113,25 +138,21 @@ class TornadoEventLoop(EventLoop):
         # XXX there's no such thing as "idle" in most event loops; this fakes
         # it the same way as Twisted, by scheduling the callback to be called
         # repeatedly
-        mutable_handle: list[object] = []
+        self._idle_handle += 1
+        self._idle_callbacks[self._idle_handle] = callback
+        return self._idle_handle
 
-        def faux_idle_callback():
-            callback()
-            mutable_handle[0] = self._loop.call_later(self._idle_emulation_delay, faux_idle_callback)
-
-        mutable_handle.append(self._loop.call_later(self._idle_emulation_delay, faux_idle_callback))
-
-        # asyncio used as backend, real type comes from asyncio_loop.call_later
-        return mutable_handle
-
-    def remove_enter_idle(self, handle) -> bool:
+    def remove_enter_idle(self, handle: int) -> bool:
         """
         Remove an idle callback.
 
         Returns True if the handle was removed.
         """
-        # `handle` is just a list containing the current actual handle
-        return self.remove_alarm(handle[0])
+        try:
+            del self._idle_callbacks[handle]
+        except KeyError:
+            return False
+        return True
 
     def handle_exit(self, f: Callable[_Spec, _T]) -> Callable[_Spec, _T | Literal[False]]:
         @functools.wraps(f)
@@ -139,10 +160,17 @@ class TornadoEventLoop(EventLoop):
             try:
                 return f(*args, **kwargs)
             except ExitMainLoop:
-                self._loop.stop()
+                pass  # handled later
             except Exception as exc:
                 self._exc = exc
-                self._loop.stop()
+
+            if self._idle_asyncio_handle:
+                # clean it up to prevent old callbacks
+                # from messing things up if loop is restarted
+                self._loop.remove_timeout(self._idle_asyncio_handle)
+                self._idle_asyncio_handle = None
+
+            self._loop.stop()
             return False
         return wrapper
 

--- a/urwid/event_loop/tornado_loop.py
+++ b/urwid/event_loop/tornado_loop.py
@@ -136,8 +136,7 @@ class TornadoEventLoop(EventLoop):
         Returns a handle that may be passed to remove_idle()
         """
         # XXX there's no such thing as "idle" in most event loops; this fakes
-        # it the same way as Twisted, by scheduling the callback to be called
-        # repeatedly
+        # it by adding extra callback to the timer and file watch callbacks.
         self._idle_handle += 1
         self._idle_callbacks[self._idle_handle] = callback
         return self._idle_handle

--- a/urwid/tests/test_event_loops.py
+++ b/urwid/tests/test_event_loops.py
@@ -71,12 +71,13 @@ class EventLoopTestMixin:
         if self._expected_idle_handle is not None:
             self.assertEqual(idle_handle, 1)
         evl.run()
+        self.assertTrue("waiting" in out, out)
         self.assertTrue("hello" in out, out)
         self.assertTrue("clean exit" in out, out)
         handle = evl.watch_file(rd, exit_clean)
         del out[:]
         evl.run()
-        self.assertEqual(out, ["clean exit"])
+        self.assertEqual(["clean exit"], out)
         self.assertTrue(evl.remove_watch_file(handle))
         handle = evl.alarm(0, exit_error)
         self.assertRaises(ZeroDivisionError, evl.run)
@@ -208,7 +209,7 @@ class AsyncioEventLoopTest(unittest.TestCase, EventLoopTestMixin):
             result = 1 / 0 # Simulate error in coroutine
             return result
 
-        asyncio.ensure_future(error_coro())
+        asyncio.ensure_future(error_coro(), loop=asyncio.get_event_loop_policy().get_event_loop())
         self.assertRaises(ZeroDivisionError, evl.run)
 
 

--- a/urwid/vterm.py
+++ b/urwid/vterm.py
@@ -48,6 +48,7 @@ from urwid.canvas import Canvas
 from urwid.display_common import _BASIC_COLORS, AttrSpec, RealTerminal
 from urwid.escape import ALT_DEC_SPECIAL_CHARS, DEC_SPECIAL_CHARS
 from urwid.widget import BOX, Widget
+from urwid import event_loop
 
 if typing.TYPE_CHECKING:
     from typing_extensions import Literal
@@ -1366,7 +1367,7 @@ class Terminal(Widget):
         self,
         command: Sequence[str] | None,
         env: Mapping[str, str] | Iterable[Sequence[str]] | None = None,
-        main_loop=None,
+        main_loop: event_loop.EventLoop | None = None,
         escape_sequence: str | None = None,
         encoding: str = 'utf-8',
     ):
@@ -1418,7 +1419,10 @@ class Terminal(Widget):
 
         self.term_modes = TermModes()
 
-        self.main_loop = main_loop
+        if main_loop is not None:
+            self.main_loop = main_loop
+        else:
+            self.main_loop = event_loop.SelectEventLoop()
 
         self.master = None
         self.pid = None

--- a/urwid/vterm.py
+++ b/urwid/vterm.py
@@ -1124,13 +1124,15 @@ class TermCanvas(Canvas):
                 fg = None
             else:
                 fg = self.attrspec.foreground_number
-                if fg >= 8: fg -= 8
+                if fg >= 8:
+                    fg -= 8
 
             if 'default' in self.attrspec.background:
                 bg = None
             else:
                 bg = self.attrspec.background_number
-                if bg >= 8: bg -= 8
+                if bg >= 8:
+                    bg -= 8
 
             for attr in ('bold', 'underline', 'blink', 'standout'):
                 if not getattr(self.attrspec, attr):
@@ -1155,10 +1157,10 @@ class TermCanvas(Canvas):
         attrs = [fg.strip() for fg in attrspec.foreground.split(',')]
         if 'standout' in attrs and undo:
             attrs.remove('standout')
-            attrspec.foreground = ','.join(attrs)
+            attrspec = attrspec.copy_modified(fg=','.join(attrs))
         elif 'standout' not in attrs and not undo:
             attrs.append('standout')
-            attrspec.foreground = ','.join(attrs)
+            attrspec = attrspec.copy_modified(fg=','.join(attrs))
         return attrspec
 
     def reverse_video(self, undo: bool = False) -> None:


### PR DESCRIPTION
Re-implement abandoned PR #418
* Fix "not hashable `AttrSpec`" and it's instance creation price (use `__slots__`) `AttrSpec` instances may be created in huge amount, with slots this process consume less resources.
* `Terminal` is always created with event loop, if not provided -> `SelectEventLoop` is used
* Fixed `TornadoEventLoop` & `AsyncioEventLoop` logic (Tornado IOLoop is asyncio based)

For extra details see original PR.

##### Checklist
- [ ] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [X] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)