### PR TITLE
Fix text layout for `align="center", wrap="clip"` when `maxcol` == `line_width - 1`

### DIFF
--- a/urwid/tests/test_text_layout.py
+++ b/urwid/tests/test_text_layout.py
@@ -292,6 +292,23 @@ class CalcTranslateClipTest(CalcTranslateTest, unittest.TestCase):
         [(7, None), (0, 35)],
         [(14, 36, 50), (0, 50)]]
 
+class CalcTranslateClipTest2(CalcTranslateTest, unittest.TestCase):
+    text = "Hello!\nto\nWorld!"
+    mode = 'clip'
+    width = 5  # line width (of first and last lines) minus one
+    result_left = [
+        [(6, 0, 6), (0, 6)],
+        [(2, 7, 9), (0, 9)],
+        [(6, 10, 16), (0, 16)]]
+    result_right = [
+        [(-1, None), (6, 0, 6), (0, 6)],
+        [(3, None), (2, 7, 9), (0, 9)],
+        [(-1, None), (6, 10, 16), (0, 16)]]
+    result_center = [
+        [(6, 0, 6), (0, 6)],
+        [(2, None), (2, 7, 9), (0, 9)],
+        [(6, 10, 16), (0, 16)]]
+
 class CalcTranslateCantDisplayTest(CalcTranslateTest, unittest.TestCase):
     text = b'Hello\xe9\xa2\x96'
     mode = 'space'

--- a/urwid/text_layout.py
+++ b/urwid/text_layout.py
@@ -139,7 +139,8 @@ class StandardTextLayout(TextLayout):
                 out.append([(width-sc, None)] + l)
                 continue
             assert align == 'center'
-            out.append([((width-sc+1) // 2, None)] + l)
+            pad_trim_left = (width-sc+1) // 2
+            out.append([(pad_trim_left, None)] + l if pad_trim_left else l)
         return out
 
     def calculate_text_segments(


### PR DESCRIPTION
##### Checklist
- [ ] I've ensured that similar functionality has not already been implemented
- [ ] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
Fixes: #542


I also realized (and tested) that the bug could be fixed by guarding the append at:
https://github.com/urwid/urwid/blob/350ee5c47ff565d3b0d25b1c3cbddbfb2a0a2a4f/urwid/canvas.py#L1333
with `if s.sc:` but that would only apply to the `Text` widget.