### PR TITLE
Fix incorrect type cast in vterm (`apply_mapping` should return `bytes`)

### DIFF
--- a/examples/calc.py
+++ b/examples/calc.py
@@ -491,9 +491,10 @@ class CellColumn( urwid.WidgetWrap ):
         return self.content[-1].get_result()
 
 
+class HelpColumn(urwid.Widget):
+    _selectable = True
+    _sizing = frozenset([urwid.BOX])
 
-
-class HelpColumn(urwid.BoxWidget):
     help_text = [
         ('title', "Column Calculator"),
         "",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,12 @@ universal = 0
 profile = "black"
 line_length = 120
 
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "-vvvv --doctest-modules -s --cov=urwid"
+doctest_optionflags = ["ELLIPSIS", "IGNORE_EXCEPTION_DETAIL"]
+testpaths = ["urwid"]
+
 [tool.coverage.run]
 omit = ["urwid/tests/*", ".tox/*", "setup.py"]
 branch = true

--- a/urwid/tests/test_event_loops.py
+++ b/urwid/tests/test_event_loops.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import os
 import sys
-import time
 import typing
 import unittest
 
@@ -28,7 +27,6 @@ class EventLoopTestMixin:
         _handle = evl.watch_file(rd, step2)
 
         evl.run()
-        time.sleep(0.1)
         self.assertEqual(out, ["writing", "hi"])
 
     def test_remove_alarm(self):
@@ -89,7 +87,6 @@ class EventLoopTestMixin:
             self.assertEqual(idle_handle, 1)
 
         evl.run()
-        time.sleep(0.1)
         self.assertTrue("waiting" in out, out)
         self.assertTrue("hello" in out, out)
         self.assertTrue("clean exit" in out, out)
@@ -97,7 +94,6 @@ class EventLoopTestMixin:
         del out[:]
 
         evl.run()
-        time.sleep(0.1)
         self.assertEqual(["clean exit"], out)
         self.assertTrue(evl.remove_watch_file(handle))
         _handle = evl.alarm(0, exit_error)
@@ -122,7 +118,7 @@ else:
 
         def test_error(self):
             evl = self.evl
-            evl.alarm(0.5, lambda: 1 / 0)  # Simulate error in event loop
+            evl.alarm(0, lambda: 1 / 0)  # Simulate error in event loop
             self.assertRaises(ZeroDivisionError, evl.run)
 
 
@@ -204,7 +200,6 @@ else:
             _handle = evl.alarm(0.07, test_remove_watch_file)
             self.assertEqual(evl.enter_idle(say_waiting), 1)
             evl.run()
-            time.sleep(0.2)
             self.assertTrue("da" in out, out)
             self.assertTrue("ta" in out, out)
             self.assertTrue("hello" in out, out)
@@ -213,7 +208,7 @@ else:
 
         def test_error(self):
             evl = self.evl
-            evl.alarm(0.5, lambda: 1 / 0)  # Simulate error in event loop
+            evl.alarm(0, lambda: 1 / 0)  # Simulate error in event loop
             self.assertRaises(ZeroDivisionError, evl.run)
 
 
@@ -225,7 +220,7 @@ class AsyncioEventLoopTest(unittest.TestCase, EventLoopTestMixin):
 
     def test_error(self):
         evl = self.evl
-        evl.alarm(0.5, lambda: 1 / 0)  # Simulate error in event loop
+        evl.alarm(0, lambda: 1 / 0)  # Simulate error in event loop
         self.assertRaises(ZeroDivisionError, evl.run)
 
     @unittest.skipIf(
@@ -256,5 +251,5 @@ else:
 
         def test_error(self):
             evl = self.evl
-            evl.alarm(0.5, lambda: 1 / 0)  # Simulate error in event loop
+            evl.alarm(0, lambda: 1 / 0)  # Simulate error in event loop
             self.assertRaises(ZeroDivisionError, evl.run)

--- a/urwid/widget.py
+++ b/urwid/widget.py
@@ -801,12 +801,13 @@ class Divider(Widget):
         return canv
 
 
-class SolidFill(BoxWidget):
+class SolidFill(Widget):
     """
     A box widget that fills an area with a single character
     """
     _selectable = False
     ignore_focus = True
+    _sizing = frozenset([BOX])
 
     def __init__(self, fill_char: str = " ") -> None:
         """

--- a/urwid/wimp.py
+++ b/urwid/wimp.py
@@ -227,17 +227,17 @@ class CheckBox(WidgetWrap):
         do_callback -- False to suppress signal from this change
 
         >>> changes = []
-        >>> def callback_a(cb, state, user_data):
+        >>> def callback_a(user_data, cb, state):
         ...     changes.append("A %r %r" % (state, user_data))
         >>> def callback_b(cb, state):
         ...     changes.append("B %r" % state)
         >>> cb = CheckBox('test', False, False)
-        >>> key1 = connect_signal(cb, 'change', callback_a, "user_a")
+        >>> key1 = connect_signal(cb, 'change', callback_a, user_args=("user_a",))
         >>> key2 = connect_signal(cb, 'change', callback_b)
         >>> cb.set_state(True) # both callbacks will be triggered
         >>> cb.state
         True
-        >>> disconnect_signal(cb, 'change', callback_a, "user_a")
+        >>> disconnect_signal(cb, 'change', callback_a, user_args=("user_a",))
         >>> cb.state = False
         >>> cb.state
         False


### PR DESCRIPTION
Add `time.sleep(0.1)` to the event loop tests:
  in the worst scenario on windows and slow machine
  function in parallel thread/async can wait up to 80 milliseconds (tested)
Add type annotations to the `vterm` and `test_vterm` to simplify error lookup.

Partial: #544
Partial: #512
Partial: #406

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
