### PR TITLE
Optimize `vterm`: adopt data types and add annotations. Fix tests

### DIFF
--- a/urwid/util.py
+++ b/urwid/util.py
@@ -74,7 +74,7 @@ if 'detected_encoding' not in locals():
 else:
     assert 0, "It worked!"
 
-_target_encoding = None
+_target_encoding = 'ascii'
 _use_dec_special = True
 
 


### PR DESCRIPTION
* `TermModes` - make `dataclass` as it's used
* `TermScroller` - deprecate and use `deque` instead
  (faster both side access, automatic size limit control)
* `utf8_buffer` - use `bytearray` as mutual storage for bytes
  (no re-allocation if no crazy size changes)
* `CSI_COMMANDS` - use `namedtuple` types for better type management
* use native string escape sequences instead of hex encoded one
  (easier to read and understand, internally the same)
* not `elif` after `return` (follow actual static checkers rules)

* `_target_encoding = 'ascii'` as default (no re-cast)
* add extra verbose version of tests for scrolling region

Fix #544 

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
