### PR TITLE
Adds 256 color and truecolor support to vterm. Fixes #457

### DIFF
--- a/urwid/vterm.py
+++ b/urwid/vterm.py
@@ -45,7 +45,8 @@ except ImportError:
 
 from urwid import util
 from urwid.canvas import Canvas
-from urwid.display_common import _BASIC_COLORS, AttrSpec, RealTerminal
+from urwid.display_common import (_BASIC_COLORS, AttrSpec, RealTerminal,
+                                  _color_desc_256, _color_desc_true)
 from urwid.escape import ALT_DEC_SPECIAL_CHARS, DEC_SPECIAL_CHARS
 from urwid.widget import BOX, Widget
 from urwid import event_loop
@@ -1036,21 +1037,44 @@ class TermCanvas(Canvas):
 
             y += 1
 
-    def sgi_to_attrspec(self, attrs: Iterable[int], fg: int, bg: int, attributes: set[str]) -> AttrSpec | None:
+    def sgi_to_attrspec(self, attrs: Iterable[int], fg: int, bg: int, attributes: set[str], prev_colors: int) -> AttrSpec | None:
         """
         Parse SGI sequence and return an AttrSpec representing the sequence
         including all earlier sequences specified as 'fg', 'bg' and
         'attributes'.
         """
-        for attr in attrs:
+
+        idx = 0
+        colors = prev_colors
+
+        while idx < len(attrs):
+            attr = attrs[idx]
             if 30 <= attr <= 37:
                 fg = attr - 30
+                colors = max(16, colors)
             elif 40 <= attr <= 47:
                 bg = attr - 40
-            elif attr == 38:
-                # set default foreground color, set underline
-                attributes.add('underline')
-                fg = None
+                colors = max(16, colors)
+            elif attr == 38 or attr == 48:
+                if idx + 2 < len(attrs) and attrs[idx + 1] == 5:
+                    # 8 bit color specification
+                    color = attrs[idx + 2]
+                    colors = max(256, colors)
+                    if attr == 38:
+                        fg = color
+                    else:
+                        bg = color
+                    idx += 2
+                elif idx + 4 < len(attrs) and attrs[idx + 1] == 2:
+                    # 24 bit color specification
+                    color = (attrs[idx + 2] << 16) + \
+                        (attrs[idx + 3] << 8) + attrs[idx + 4]
+                    colors = 2**24
+                    if attr == 38:
+                        fg = color
+                    else:
+                        bg = color
+                    idx += 4
             elif attr == 39:
                 # set default foreground color, remove underline
                 attributes.discard('underline')
@@ -1087,17 +1111,23 @@ class TermCanvas(Canvas):
                 fg = bg = None
                 attributes.clear()
 
-        if 'bold' in attributes and fg is not None:
+            idx += 1
+
+        if 'bold' in attributes and colors == 16 and fg is not None and fg < 8:
             fg += 8
 
-        def _defaulter(color: int | None) -> str:
+        def _defaulter(color: int | None, colors: int) -> str:
             if color is None:
                 return 'default'
-            else:
-                return _BASIC_COLORS[color]
+            # Note: we can't detect 88 color mode
+            if color > 255 or colors == 2**24:
+                return _color_desc_true(color)
+            if color > 15 or colors == 256:
+                return _color_desc_256(color)
+            return _BASIC_COLORS[color]
 
-        fg = _defaulter(fg)
-        bg = _defaulter(bg)
+        fg = _defaulter(fg, colors)
+        bg = _defaulter(bg, colors)
 
         if len(attributes) > 0:
             fg = ','.join([fg] + list(attributes))
@@ -1105,7 +1135,10 @@ class TermCanvas(Canvas):
         if fg == 'default' and bg == 'default':
             return None
         else:
-            return AttrSpec(fg, bg)
+            if colors:
+                return AttrSpec(fg, bg, colors=colors)
+            else:
+                return AttrSpec(fg, bg)
 
     def csi_set_attr(self, attrs):
         """
@@ -1123,14 +1156,14 @@ class TermCanvas(Canvas):
                 fg = None
             else:
                 fg = self.attrspec.foreground_number
-                if fg >= 8:
+                if fg >= 8 and self.attrspec._colors() == 16:
                     fg -= 8
 
             if 'default' in self.attrspec.background:
                 bg = None
             else:
                 bg = self.attrspec.background_number
-                if bg >= 8:
+                if bg >= 8 and self.attrspec._colors() == 16:
                     bg -= 8
 
             for attr in ('bold', 'underline', 'blink', 'standout'):
@@ -1139,7 +1172,9 @@ class TermCanvas(Canvas):
 
                 attributes.add(attr)
 
-        attrspec = self.sgi_to_attrspec(attrs, fg, bg, attributes)
+        attrspec = self.sgi_to_attrspec(attrs, fg, bg, attributes,
+                                        self.attrspec._colors()
+                                        if self.attrspec else 1)
 
         if self.modes.reverse_video:
             self.attrspec = self.reverse_attrspec(attrspec)

--- a/urwid/vterm.py
+++ b/urwid/vterm.py
@@ -1076,8 +1076,7 @@ class TermCanvas(Canvas):
                         bg = color
                     idx += 4
             elif attr == 39:
-                # set default foreground color, remove underline
-                attributes.discard('underline')
+                # set default foreground color
                 fg = None
             elif attr == 49:
                 # set default background color


### PR DESCRIPTION
##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment [Python 3.x only; can't run 2.7 locally]
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
Adds high color support to vterm.py - 88 color, 256 color, truecolor modes.
Monochrome and 16 color mode work as before.

What's missing/needed:
Testing against Python 2.7 - my Ubuntu 22.04 dev box complains when running 2.7, which causes tox to fail.
Add tox tests if it's possible to verify correct color output using tox tests?

Here is palette_test.py running in terminal.py:
![image](https://github.com/urwid/urwid/assets/3261094/5409a8bc-4b4f-435d-b3b3-5bac445c7640)
