### PR TITLE
vterm: Fixed a crash bug with DECALN command

### DIFF
--- a/urwid/vterm.py
+++ b/urwid/vterm.py
@@ -904,7 +904,7 @@ class TermCanvas(Canvas):
         DEC screen alignment test: Fill screen with E's.
         """
         for row in range(self.height):
-            self.term[row] = self.empty_line('E')
+            self.term[row] = self.empty_line(b'E')
 
     def blank_line(self, row: int) -> None:
         """


### PR DESCRIPTION
##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
vterm.py was crashing upon execution of `DECALN` (ESC # 8) because the code was sending a string to `empty_line` which requires a byte.  This prevented [vttest](https://github.com/ThomasDickey/vttest-snapshots) from running many test cases.

to test this, run terminal.py and execute the following shell command:

`echo -e "\033#8"`

Without this fix, urwid crashes.  With the fix, you'll see a lot of `E`s onscreen, as expected. No crash.