### PR TITLE
vterm: Fixed OSC 0,2 to set widget title properly (decode bytestring)

### DIFF
--- a/urwid/tests/test_vterm.py
+++ b/urwid/tests/test_vterm.py
@@ -370,10 +370,10 @@ class TermTest(unittest.TestCase):
         self.connect_signal('title')
         self.write('\\e]666parsed right?\\e\\te\\e]0;test title\007st1')
         self.expect('test1')
-        self.expect_signal(b'test title')
-        self.write('\\e]3;stupid title\\e\\\\e[0G\\e[2Ktest2')
+        self.expect_signal('test title')
+        self.write('\\e];stupid title\\e\\\\e[0G\\e[2Ktest2')
         self.expect('test2')
-        self.expect_signal(b'stupid title')
+        self.expect_signal('stupid title')
         self.disconnect_signal('title')
 
     def test_set_leds(self):

--- a/urwid/vterm.py
+++ b/urwid/vterm.py
@@ -550,10 +550,11 @@ class TermCanvas(Canvas):
         """
         Parse operating system command.
         """
-        if buf.startswith(b';'):  # set window title and icon
-            self.widget.set_title(buf[1:])
-        elif buf.startswith(b'3;'):  # set window title
-            self.widget.set_title(buf[2:])
+        if (buf.startswith(b';')
+                or buf.startswith(b'0;')
+                or buf.startswith(b'2;')):
+            # set window title
+            self.widget.set_title(buf.decode().partition(";")[2])
 
     def parse_escape(self, char: bytes) -> None:
         if self.parsestate == 1:


### PR DESCRIPTION
##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
These are xterm proprietary OSC sequences.
per [https://www.xfree86.org/current/ctlseqs.html](https://www.xfree86.org/current/ctlseqs.html):
0, 2 set window title (and 2 sets icon title, but that's irrelevant)
1 sets icon title, which we don't support
3 sets arbitrary window properties, which we don't support. It shouldn't be setting the title.

The old code was sending the raw bytestring to `widget.set_title` which was bad.  Now it decodes the bytestring before sending.
