### PR TITLE
Fix #451 : use `set` for widgets storage in dependencies info

### DIFF
--- a/urwid/canvas.py
+++ b/urwid/canvas.py
@@ -61,13 +61,13 @@ class CanvasCache:
     """
     _widgets = {}
     _refs = {}
-    _deps: dict[Widget, list[Widget]] = {}
+    _deps: dict[Widget, set[Widget]] = {}
     hits = 0
     fetches = 0
     cleanups = 0
 
     @classmethod
-    def store(cls, wcls, canvas):
+    def store(cls, wcls, canvas: Canvas) -> None:
         """
         Store a weakref to canvas in the cache.
 
@@ -79,31 +79,32 @@ class CanvasCache:
 
         assert canvas.widget_info, "Can't store canvas without widget_info"
         widget, size, focus = canvas.widget_info
-        def walk_depends(canv):
+
+        def walk_depends(children: list[tuple[int, int, Canvas, int | str | None]]) -> set[Widget]:
             """
             Collect all child widgets for determining who we
             depend on.
             """
             # FIXME: is this recursion necessary?  The cache
             # invalidating might work with only one level.
-            depends = []
-            for x, y, c, pos in canv.children:
+            depends = set()
+            for x, y, c, pos in children:
                 if c.widget_info:
-                    depends.append(c.widget_info[0])
-                elif hasattr(c, 'children'):
-                    depends.extend(walk_depends(c))
+                    depends.add(c.widget_info[0])
+                else:
+                    depends.intersection_update(walk_depends(getattr(c, 'children', ())))
             return depends
 
         # use explicit depends_on if available from the canvas
-        depends_on = getattr(canvas, 'depends_on', None)
-        if depends_on is None and hasattr(canvas, 'children'):
-            depends_on = walk_depends(canvas)
+        depends_on: list[Widget] | set[Widget] | None = getattr(canvas, 'depends_on', None)
+        if depends_on is None:
+            depends_on = walk_depends(getattr(canvas, 'children', ()))
         if depends_on:
             for w in depends_on:
                 if w not in cls._widgets:
                     return
             for w in depends_on:
-                cls._deps.setdefault(w,[]).append(widget)
+                cls._deps.setdefault(w, set()).add(widget)
 
         ref = weakref.ref(canvas, cls.cleanup)
         cls._refs[ref] = (widget, wcls, size, focus)
@@ -147,7 +148,7 @@ class CanvasCache:
             pass
         if widget not in cls._deps:
             return
-        dependants = cls._deps.get(widget, [])
+        dependants = cls._deps.get(widget, set())
         try:
             del cls._deps[widget]
         except KeyError:
@@ -221,7 +222,7 @@ class Canvas:
         """
         if value1 is not None:
             raise self._renamed_error
-        self._widget_info = None
+        self._widget_info: tuple[Widget, tuple[()] | tuple[int] | tuple[int, int], bool] | None = None
         self.coords = {}
         self.shortcuts = {}
 
@@ -619,7 +620,7 @@ class CompositeCanvas(Canvas):
 
         if canv is None:
             self.shards = []
-            self.children = []
+            self.children: list[tuple[int, int, Canvas, int | str | None]] = []
         else:
             if hasattr(canv, "shards"):
                 self.shards = canv.shards
@@ -1153,7 +1154,7 @@ def CanvasCombine(l):
 
     combined_canvas = CompositeCanvas()
     shards = []
-    children = []
+    children: list[tuple[int, int, Canvas, int | str | None]] = []
     row = 0
     focus_index = 0
     n = 0

--- a/urwid/widget.py
+++ b/urwid/widget.py
@@ -46,7 +46,7 @@ from urwid.util import MetaSuper, calc_width, decompose_tagmarkup, is_wide_char,
 if typing.TYPE_CHECKING:
     from typing_extensions import Literal
 
-    from urwid.canvas import TextCanvas
+    from urwid.canvas import Canvas, TextCanvas
 
 
 # define some names for these constants to avoid misspellings in the source
@@ -140,7 +140,7 @@ def cache_widget_render(cls):
     fn = cls.render
 
     @functools.wraps(fn)
-    def cached_render(self, size, focus=False):
+    def cached_render(self, size, focus: bool = False) -> Canvas:
         focus = focus and not ignore_focus
         canv = CanvasCache.fetch(self, cls, size, focus)
         if canv:
@@ -153,6 +153,7 @@ def cache_widget_render(cls):
         canv.finalize(self, size, focus)
         CanvasCache.store(cls, canv)
         return canv
+
     cached_render.original_fn = fn
     return cached_render
 


### PR DESCRIPTION
##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
