### PR TITLE
Build system: use SCM for version info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -447,3 +447,6 @@ GitHub.sublime-settings
 
 ### GPG template
 secring.*
+
+# Generated version
+/urwid/version.py

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,7 +57,7 @@ def execfile(module, global_vars):
         exec(code, global_vars)
 execfile(VERSION_MODULE, VERSION_VARS)
 # The short X.Y version.
-version = '.'.join([str(x) for x in VERSION_VARS['VERSION'][:2]])
+version = '.'.join(str(x) for x in VERSION_VARS['__version_tuple__'][:2])
 # The full version, including alpha/beta/rc tags.
 release = VERSION_VARS['__version__']
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,8 @@
 # PEP 508 specifications for PEP 518.
 requires = [
     "setuptools >= 61.0.0",
-    "wheel"
+    "setuptools_scm[toml]>=6.2",
+    "wheel",
 ]
 build-backend="setuptools.build_meta"
 
@@ -44,6 +45,9 @@ classifiers = {file = ["classifiers.txt"]}
 
 [tool.distutils.bdist_wheel]
 universal = 0
+
+[tool.setuptools_scm]
+write_to = "urwid/version.py"
 
 [tool.isort]
 profile = "black"

--- a/setup.py
+++ b/setup.py
@@ -21,21 +21,11 @@
 
 from __future__ import annotations
 
-import os
-
 from setuptools import Extension, setup
-
-with open(os.path.join("urwid", "version.py")) as f:
-    globals_ = {}
-    locals_ = {}
-    # Execute safe way: do not expose anything
-    exec(f.read(), globals_, locals_)
-    release = locals_['__version__']
 
 
 setup_d = {
     'name': "urwid",
-    'version': release,
     'ext_modules': [Extension('urwid.str_util', sources=['source/str_util.c'])],
     'url': "https://urwid.org/",
     'test_suite': 'urwid.tests',

--- a/urwid/__init__.py
+++ b/urwid/__init__.py
@@ -102,7 +102,7 @@ from urwid.listbox import ListBox, ListBoxError, ListWalker, ListWalkerError, Si
 from urwid.event_loop import EventLoop, AsyncioEventLoop, ExitMainLoop, MainLoop, SelectEventLoop
 from urwid.monitored_list import MonitoredFocusList, MonitoredList
 from urwid.signals import MetaSignals, Signals, connect_signal, disconnect_signal, emit_signal, register_signal
-from urwid.version import VERSION, __version__
+from urwid.version import __version__, __version_tuple__
 from urwid.widget import (
     ANY,
     BOTTOM,
@@ -212,3 +212,6 @@ try:
     from urwid.event_loop import TrioEventLoop
 except ImportError:
     pass
+
+# Backward compatibility
+VERSION = __version_tuple__

--- a/urwid/version.py
+++ b/urwid/version.py
@@ -1,2 +1,0 @@
-VERSION = (2, 1, 3, 'dev0')
-__version__ = '.'.join([str(x) for x in VERSION])


### PR DESCRIPTION
Use `setuptools-scm` package for version build
For docs build need to enable "install package" on RTD `python -m build` and `pip install` works without changes

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
