### PR TITLE
CI/CD: Build also macOS arm64/universal2 packages

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -69,6 +69,7 @@ jobs:
           # configure cibuildwheel to build native archs ('auto'), and some
           # emulated ones
           CIBW_ARCHS_LINUX: auto aarch64
+          CIBW_ARCHS_MACOS: x86_64 universal2 arm64
 
       - uses: actions/upload-artifact@v3
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,11 @@ universal = 0
 [tool.setuptools_scm]
 write_to = "urwid/version.py"
 
+[tool.cibuildwheel]
+# Disable building PyPy wheels on all platforms
+# Disable musllinux as not popular platform
+skip = ["pp*", "*-musllinux_*"]
+
 [tool.isort]
 profile = "black"
 line_length = 120


### PR DESCRIPTION
* do not build PyPy and musllinux: let's do it on end-user side as before. These versions are not mainstream and build consume huge amount of resources.

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently