### PR TITLE
fix: update links to examples

### DIFF
--- a/docs/manual/displayattributes.rst
+++ b/docs/manual/displayattributes.rst
@@ -307,7 +307,7 @@ of 24-bit color mode unless properly configured.
 .. seealso::
    The palette_test.py_ example program
 
-.. _palette_test.py: http://excess.org/urwid/browser/examples/palette_test.py
+.. _palette_test.py: https://github.com/urwid/urwid/blob/master/examples/palette_test.py
 
 .. _256-foreground-background:
 
@@ -330,7 +330,7 @@ gray scale entries ``'g0'`` (black from color cube) , ``'g3'``, ``'g7'``, ...
 .. seealso::
    The palette_test.py_ example program
 
-.. _palette_test.py: http://excess.org/urwid/browser/examples/palette_test.py
+.. _palette_test.py: https://github.com/urwid/urwid/blob/master/examples/palette_test.py
 
 .. _88-foreground-background:
 
@@ -352,7 +352,7 @@ gray scale entries ``'g0'`` (black from color cube), ``'g19'``, ``'g35'``, ...
 .. seealso::
    The palette_test.py_ example program
 
-.. _palette_test.py: http://excess.org/urwid/browser/examples/palette_test.py
+.. _palette_test.py: https://github.com/urwid/urwid/blob/master/examples/palette_test.py
 
 
 .. _rgb-palette-setting:

--- a/docs/manual/displaymodules.rst
+++ b/docs/manual/displaymodules.rst
@@ -82,8 +82,8 @@ that need to be resolved before this module is recommended for production use.
 
 The tour.py_ and calc.py_ example programs demonstrate use of this module.
 
-.. _tour.py: http://excess.org/urwid/browser/examples/tour.py
-.. _calc.py: http://excess.org/urwid/browser/examples/calc.py
+.. _tour.py: https://github.com/urwid/urwid/blob/master/examples/tour.py
+.. _calc.py: https://github.com/urwid/urwid/blob/master/examples/calc.py
 
 
 Screenshot Display Module ``html_fragment``
@@ -103,7 +103,7 @@ browser's text size.
 
 The `example screenshots`_ are generated with this display module.
 
-.. _`example screenshots`: http://excess.org/urwid/examples.html
+.. _`example screenshots`: http://urwid.org/examples/index.html
 
 
 LCD Display Module ``lcd_display``
@@ -117,7 +117,7 @@ LCD character display devices and a complete implementation of a
 
 The lcd_cf635.py_ example program demonstrates use of this module.
 
-.. _lcd_cf635.py: http://excess.org/urwid/browser/examples/lcd_cf635.py
+.. _lcd_cf635.py: https://github.com/urwid/urwid/blob/master/examples/lcd_cf635.py
 
 .. seealso:: `Urwid on a Crystalfontz 635 LCD <http://excess.org/article/2010/03/urwid-crystalfontz-635-lcd/>`_
 

--- a/docs/manual/widgets.rst
+++ b/docs/manual/widgets.rst
@@ -436,9 +436,9 @@ using a dictionary indexed by parent directory names. This allows the
 directories to be read only as required. The custom list walker also allows
 directories to be hidden from view when they are "collapsed".
 
-.. _fib.py: http://excess.org/urwid/browser/examples/fib.py
-.. _edit.py: http://excess.org/urwid/browser/examples/edit.py
-.. _browse.py: http://excess.org/urwid/browser/examples/browse.py
+.. _fib.py: https://github.com/urwid/urwid/blob/master/examples/fib.py
+.. _edit.py: https://github.com/urwid/urwid/blob/master/examples/edit.py
+.. _browse.py: https://github.com/urwid/urwid/blob/master/examples/browse.py
 
 
 Setting the Focus


### PR DESCRIPTION
##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently


##### Description:
The original excess.org page doesn't seem to contain any of the examples any more.

