### PR TITLE
Vterm now emits 'resize' signal upon terminal resize

### DIFF
--- a/examples/terminal.py
+++ b/examples/terminal.py
@@ -28,9 +28,12 @@ def main():
     urwid.set_encoding('utf8')
     term = urwid.Terminal(None, encoding='utf-8')
 
+    size_widget = urwid.Text('')
+
     mainframe = urwid.LineBox(
         urwid.Pile([
             ('weight', 70, term),
+            ('fixed', 1, urwid.Filler(size_widget)),
             ('fixed', 1, urwid.Filler(urwid.Edit('focus test edit: '))),
         ]),
     )
@@ -45,8 +48,18 @@ def main():
         if key in ('q', 'Q'):
             quit()
 
+    def handle_resize(widget, size):
+        size_widget.set_text(f"Terminal size: [{size[0]}, {size[1]}]")
+
     urwid.connect_signal(term, 'title', set_title)
     urwid.connect_signal(term, 'closed', quit)
+
+    try:
+        urwid.connect_signal(term, 'resize', handle_resize)
+    except NameError:
+        # if using a version of Urwid vterm that doesn't support
+        # resize, don't register the signal handler.
+        pass
 
     loop = urwid.MainLoop(
         mainframe,
@@ -55,6 +68,7 @@ def main():
 
     term.main_loop = loop
     loop.run()
+
 
 if __name__ == '__main__':
     main()

--- a/urwid/vterm.py
+++ b/urwid/vterm.py
@@ -1459,7 +1459,7 @@ class Terminal(Widget):
     _selectable = True
     _sizing = frozenset([BOX])
 
-    signals = ['closed', 'beep', 'leds', 'title']
+    signals = ['closed', 'beep', 'leds', 'title', 'resize']
 
     def __init__(
         self,
@@ -1647,6 +1647,8 @@ class Terminal(Widget):
 
         if process_opened:
             self.add_watch()
+
+        self._emit("resize", (width, height))
 
     def set_title(self, title) -> None:
         self._emit('title', title)


### PR DESCRIPTION


##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [X] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
Vterm now emits 'resize' signal upon terminal resize, with a (height, width) tuple of the new size.

examples/terminal.py has been updated to handle the 'resize' signal, and uses it to display the terminal height x width.  This is useful for testing purposes if you want to test vterm at a particular size.
