### PR TITLE
examples/terminal.py can run against older versions of Urwid again

### DIFF
--- a/examples/terminal.py
+++ b/examples/terminal.py
@@ -57,12 +57,17 @@ def main():
     try:
         urwid.connect_signal(term, 'resize', handle_resize)
     except NameError:
-        # if using a version of Urwid vterm that doesn't support
+        # if using a version of Urwid library where vterm doesn't support
         # resize, don't register the signal handler.
         pass
 
-    # create Screen with bracketed paste mode support enabled
-    bpm_screen = urwid.raw_display.Screen(bracketed_paste_mode=True)
+    try:
+        # create Screen with bracketed paste mode support enabled
+        bpm_screen = urwid.raw_display.Screen(bracketed_paste_mode=True)
+    except TypeError:
+        # if using a version of Urwid library that doesn't support
+        # bracketed paste mode, do without it.
+        bpm_screen = urwid.raw_display.Screen()
 
     loop = urwid.MainLoop(
         mainframe,

--- a/urwid/raw_display.py
+++ b/urwid/raw_display.py
@@ -61,6 +61,10 @@ class Screen(BaseScreen, RealTerminal):
     def __init__(self, input=sys.stdin, output=sys.stdout, bracketed_paste_mode=False):
         """Initialize a screen that directly prints escape codes to an output
         terminal.
+
+        bracketed_paste_mode -- enable bracketed paste mode in the host terminal.
+            If the host terminal supports it, the application will receive `begin paste`
+            and `end paste` keystrokes when the user pastes text.
         """
         super().__init__()
         self._pal_escape = {}


### PR DESCRIPTION
##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [X] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
terminal.py now enables bracketed paste mode and shows columns/rows when run against the latest Urwid library which supports those features. When run against older versions, it will now disable those features rather than throw an exception.

Also, improved documentation for raw_display.Screen.  I am not sure how to test that the new documentation is working correctly, as it doesn't generate the HTML pages on my local system.   The changes should be visible on the new version of [this page](https://urwid.org/reference/display_modules.html#urwid.raw_display.Screen)

