### PR TITLE
Fix #583: python 3.12 compatibility

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -13,7 +13,7 @@ jobs:
       max-parallel: 6
       matrix:
         os: [ "ubuntu-latest" ]  # , "macos-latest", "windows-latest"   # enable windows after Windows driver will be added
-        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
+        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev" ]
 
     steps:
       - uses: actions/checkout@v3.5.3
@@ -140,7 +140,6 @@ jobs:
           # emulated ones
           CIBW_ARCHS_LINUX: auto aarch64
           CIBW_ARCHS_MACOS: x86_64 universal2 arm64
-          CIBW_SKIP: cp312*  # Issue #583
 
       - uses: actions/upload-artifact@v3
         with:

--- a/source/str_util.c
+++ b/source/str_util.c
@@ -458,13 +458,11 @@ offs -- offset";
 static int Py_IsWideChar(PyObject *text, Py_ssize_t offs)
 {
     const unsigned char *str;
-    Py_UNICODE *ustr;
     Py_ssize_t ret[2], str_len;
 
     if (PyUnicode_Check(text))  //text_py is unicode string
     {
-        ustr = PyUnicode_AS_UNICODE(text);
-        return (Py_GetWidth((long int)ustr[offs]) == 2);
+        return (Py_GetWidth((long int) PyUnicode_ReadChar(text, offs)) == 2);
     }
 
     if (!PyBytes_Check(text)) {
@@ -621,15 +619,13 @@ static Py_ssize_t Py_CalcWidth(PyObject *text, Py_ssize_t start_offs,
     unsigned char * str;
     Py_ssize_t i, ret[2], str_len;
     int screencols;
-    Py_UNICODE *ustr;
 
     if (PyUnicode_Check(text))  //text_py is unicode string
     {
-        ustr = PyUnicode_AS_UNICODE(text);
         screencols = 0;
  
         for(i=start_offs; i<end_offs; i++) 
-            screencols += Py_GetWidth(ustr[i]);
+            screencols += Py_GetWidth((long int) PyUnicode_ReadChar(text, i));
 
         return screencols;
     }
@@ -698,16 +694,14 @@ static int Py_CalcTextPos(PyObject *text, Py_ssize_t start_offs,
     unsigned char * str;
     Py_ssize_t i, dummy[2], str_len;
     int screencols, width;
-    Py_UNICODE *ustr;
 
     if (PyUnicode_Check(text))  //text_py is unicode string
     {
-        ustr = PyUnicode_AS_UNICODE(text);
         screencols = 0;
  
         for(i=start_offs; i<end_offs; i++)
         {
-            width = Py_GetWidth(ustr[i]);
+            width = Py_GetWidth((long int) PyUnicode_ReadChar(text, i));
             
             if (width+screencols > pref_col)
             {

--- a/source/str_util.c
+++ b/source/str_util.c
@@ -21,6 +21,8 @@
 */
 
 #define PY_SSIZE_T_CLEAN
+// Use Limited API for Python 3.7.0 release and newer
+#define Py_LIMITED_API 0x030700f0
 
 #include <Python.h>
 


### PR DESCRIPTION
Replace as pep-0393 recommended:

* `PyUnicode_AS_UNICODE` by `PyUnicode_ReadChar` (use Stable API)

* Enable PR tests on python 3.12

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)