### PR TITLE
Pass SelectableIcon `align` and `wrap` arguments to parent

### DIFF
--- a/urwid/widget/text.py
+++ b/urwid/widget/text.py
@@ -35,7 +35,7 @@ class Text(Widget):
         markup,
         align: Literal["left", "center", "right"] | Align = Align.LEFT,
         wrap: Literal["space", "any", "clip", "ellipsis"] | WrapMode = WrapMode.SPACE,
-        layout=None,
+        layout: text_layout.TextLayout | None = None,
     ) -> None:
         """
         :param markup: content of text widget, one of:

--- a/urwid/widget/wimp.py
+++ b/urwid/widget/wimp.py
@@ -29,7 +29,7 @@ from urwid.text_layout import calc_coords
 from urwid.util import is_mouse_press
 
 from .columns import Columns
-from .constants import Sizing
+from .constants import Align, Sizing, WrapMode
 from .text import Text
 from .widget import WidgetWrap
 
@@ -45,18 +45,28 @@ class SelectableIcon(Text):
     ignore_focus = False
     _selectable = True
 
-    def __init__(self, text, cursor_position=0):
+    def __init__(
+        self,
+        text,
+        cursor_position: int = 0,
+        align: Literal["left", "center", "right"] | Align = Align.LEFT,
+        wrap: Literal["space", "any", "clip", "ellipsis"] | WrapMode = WrapMode.SPACE,
+    ) -> None:
         """
         :param text: markup for this widget; see :class:`Text` for
                      description of text markup
         :param cursor_position: position the cursor will appear in the
                                 text when this widget is in focus
+        :param align: typically ``'left'``, ``'center'`` or ``'right'``
+        :type align: text alignment mode
+        :param wrap: typically ``'space'``, ``'any'``, ``'clip'`` or ``'ellipsis'``
+        :type wrap: text wrapping mode
 
         This is a text widget that is selectable.  A cursor
         displayed at a fixed location in the text when in focus.
         This widget has no special handling of keyboard or mouse input.
         """
-        super().__init__(text)
+        super().__init__(text, align=align, wrap=wrap)
         self._cursor_position = cursor_position
 
     def render(self, size: tuple[int], focus: bool = False) -> TextCanvas | CompositeCanvas:

--- a/urwid/widget/wimp.py
+++ b/urwid/widget/wimp.py
@@ -34,11 +34,13 @@ from .text import Text
 from .widget import WidgetWrap
 
 if typing.TYPE_CHECKING:
-    from collections.abc import MutableSequence
+    from collections.abc import Callable, MutableSequence
 
-    from typing_extensions import Literal
+    from typing_extensions import Literal, Self
 
     from urwid.canvas import TextCanvas
+
+    _T = typing.TypeVar("_T")
 
 
 class SelectableIcon(Text):
@@ -124,7 +126,7 @@ class CheckBox(WidgetWrap):
     def sizing(self):
         return frozenset([Sizing.FLOW])
 
-    states: typing.ClassVar[dict[bool | Literal["mixed"], str]] = {
+    states: typing.ClassVar[dict[bool | Literal["mixed"], SelectableIcon]] = {
         True: SelectableIcon("[X]", 1),
         False: SelectableIcon("[ ]", 1),
         "mixed": SelectableIcon("[#]", 1),
@@ -141,8 +143,8 @@ class CheckBox(WidgetWrap):
         label,
         state: bool | Literal["mixed"] = False,
         has_mixed: bool = False,
-        on_state_change=None,
-        user_data=None,
+        on_state_change: Callable[[Self, bool, _T], typing.Any] | Callable[[Self, bool], typing.Any] | None = None,
+        user_data: _T | None = None,
         checked_symbol: str | None = None,
     ):
         """
@@ -368,7 +370,7 @@ class CheckBox(WidgetWrap):
 
 
 class RadioButton(CheckBox):
-    states: typing.ClassVar[dict[bool | Literal["mixed"], str]] = {
+    states: typing.ClassVar[dict[bool | Literal["mixed"], SelectableIcon]] = {
         True: SelectableIcon("(X)", 1),
         False: SelectableIcon("( )", 1),
         "mixed": SelectableIcon("(#)", 1),
@@ -380,8 +382,8 @@ class RadioButton(CheckBox):
         group: MutableSequence[CheckBox],
         label,
         state: bool | Literal["mixed", "first True"] = "first True",
-        on_state_change=None,
-        user_data=None,
+        on_state_change: Callable[[Self, bool, _T], typing.Any] | Callable[[Self, bool], typing.Any] | None = None,
+        user_data: _T | None = None,
     ) -> None:
         """
         :param group: list for radio buttons in same group
@@ -498,7 +500,12 @@ class Button(WidgetWrap):
 
     signals: typing.ClassVar[list[str]] = ["click"]
 
-    def __init__(self, label, on_press=None, user_data=None) -> None:
+    def __init__(
+        self,
+        label,
+        on_press: Callable[[Self, _T], typing.Any] | Callable[[Self], typing.Any] | None = None,
+        user_data: _T | None = None,
+    ) -> None:
         """
         :param label: markup for button label
         :param on_press: shorthand for connect_signal()

--- a/urwid/widget/wimp.py
+++ b/urwid/widget/wimp.py
@@ -39,6 +39,7 @@ if typing.TYPE_CHECKING:
     from typing_extensions import Literal, Self
 
     from urwid.canvas import TextCanvas
+    from urwid.text_layout import TextLayout
 
     _T = typing.TypeVar("_T")
 
@@ -53,6 +54,7 @@ class SelectableIcon(Text):
         cursor_position: int = 0,
         align: Literal["left", "center", "right"] | Align = Align.LEFT,
         wrap: Literal["space", "any", "clip", "ellipsis"] | WrapMode = WrapMode.SPACE,
+        layout: TextLayout | None = None,
     ) -> None:
         """
         :param text: markup for this widget; see :class:`Text` for
@@ -63,12 +65,14 @@ class SelectableIcon(Text):
         :type align: text alignment mode
         :param wrap: typically ``'space'``, ``'any'``, ``'clip'`` or ``'ellipsis'``
         :type wrap: text wrapping mode
+        :param layout: defaults to a shared :class:`StandardTextLayout` instance
+        :type layout: text layout instance
 
         This is a text widget that is selectable.  A cursor
         displayed at a fixed location in the text when in focus.
         This widget has no special handling of keyboard or mouse input.
         """
-        super().__init__(text, align=align, wrap=wrap)
+        super().__init__(text, align=align, wrap=wrap, layout=layout)
         self._cursor_position = cursor_position
 
     def render(self, size: tuple[int], focus: bool = False) -> TextCanvas | CompositeCanvas:
@@ -508,6 +512,7 @@ class Button(WidgetWrap):
         *,
         align: Literal["left", "center", "right"] | Align = Align.LEFT,
         wrap: Literal["space", "any", "clip", "ellipsis"] | WrapMode = WrapMode.SPACE,
+        layout: TextLayout | None = None,
     ) -> None:
         """
         :param label: markup for button label
@@ -518,6 +523,8 @@ class Button(WidgetWrap):
         :type align: label alignment mode
         :param wrap: typically ``'space'``, ``'any'``, ``'clip'`` or ``'ellipsis'``
         :type wrap: label wrapping mode
+        :param layout: defaults to a shared :class:`StandardTextLayout` instance
+        :type layout: text layout instance
 
         Signals supported: ``'click'``
 
@@ -542,7 +549,7 @@ class Button(WidgetWrap):
         >>> wrapped_button.render((7,), focus=False).text[0].decode('utf-8')
         '< Lo… >'
         """
-        self._label = SelectableIcon(label, 0, align=align, wrap=wrap)
+        self._label = SelectableIcon(label, 0, align=align, wrap=wrap, layout=layout)
         cols = Columns(
             [
                 (Sizing.FIXED, 1, self.button_left),

--- a/urwid/widget/wimp.py
+++ b/urwid/widget/wimp.py
@@ -505,12 +505,19 @@ class Button(WidgetWrap):
         label,
         on_press: Callable[[Self, _T], typing.Any] | Callable[[Self], typing.Any] | None = None,
         user_data: _T | None = None,
+        *,
+        align: Literal["left", "center", "right"] | Align = Align.LEFT,
+        wrap: Literal["space", "any", "clip", "ellipsis"] | WrapMode = WrapMode.SPACE,
     ) -> None:
         """
         :param label: markup for button label
         :param on_press: shorthand for connect_signal()
                          function call for a single callback
         :param user_data: user_data for on_press
+        :param align: typically ``'left'``, ``'center'`` or ``'right'``
+        :type align: label alignment mode
+        :param wrap: typically ``'space'``, ``'any'``, ``'clip'`` or ``'ellipsis'``
+        :type wrap: label wrapping mode
 
         Signals supported: ``'click'``
 
@@ -527,9 +534,15 @@ class Button(WidgetWrap):
         <Button selectable flow widget 'Ok'>
         >>> b = Button("Cancel")
         >>> b.render((15,), focus=True).text # ... = b in Python 3
-        [...'< Cancel      >']
+        [b'< Cancel      >']
+        >>> aligned_button = Button("Test", align=Align.CENTER)
+        >>> aligned_button.render((10,), focus=True).text
+        [b'<  Test  >']
+        >>> wrapped_button = Button("Long label", wrap=WrapMode.ELLIPSIS)
+        >>> wrapped_button.render((7,), focus=False).text[0].decode('utf-8')
+        '< Lo… >'
         """
-        self._label = SelectableIcon("", 0)
+        self._label = SelectableIcon(label, 0, align=align, wrap=wrap)
         cols = Columns(
             [
                 (Sizing.FIXED, 1, self.button_left),
@@ -544,8 +557,6 @@ class Button(WidgetWrap):
         # in to the constructor.  Just convert it to the new way:
         if on_press:
             connect_signal(self, "click", on_press, user_data)
-
-        self.set_label(label)
 
     def _repr_words(self) -> list[str]:
         # include button.label in repr(button)
@@ -564,7 +575,7 @@ class Button(WidgetWrap):
         """
         self._label.set_text(label)
 
-    def get_label(self):
+    def get_label(self) -> str:
         """
         Return label text.
 


### PR DESCRIPTION
##### Checklist
- [ ] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [X] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

Feat #494 #355