### PR TITLE
Typing: Extend wimp typing annotations

### DIFF
--- a/urwid/widget/columns.py
+++ b/urwid/widget/columns.py
@@ -33,7 +33,7 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         self,
         widget_list: Iterable[
             Widget
-            | tuple[Literal["pack", WHSettings.PACK], Widget]
+            | tuple[Literal["pack", WHSettings.PACK] | int, Widget]
             | tuple[Literal["weight", WHSettings.WEIGHT], int, Widget]
         ],
         dividechars: int = 0,

--- a/urwid/widget/pile.py
+++ b/urwid/widget/pile.py
@@ -29,7 +29,15 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
 
     _sizing = frozenset([Sizing.FLOW, Sizing.BOX])
 
-    def __init__(self, widget_list: Iterable[Widget], focus_item: Widget | int | None = None) -> None:
+    def __init__(
+        self,
+        widget_list: Iterable[
+            Widget
+            | tuple[Literal["pack", WHSettings.PACK] | int, Widget]
+            | tuple[Literal["weight", WHSettings.WEIGHT], int, Widget]
+        ],
+        focus_item: Widget | int | None = None,
+    ) -> None:
         """
         :param widget_list: child widgets
         :type widget_list: iterable


### PR DESCRIPTION
Add overload info for constructors of:
* `CheckBox`
* `RadioButton`
* `Button`

Fix info for `Columns` constructor (`GIVEN` size)

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

Partial #406