### PR TITLE
Fix: deep TextEnum was improperly resolved

### DIFF
--- a/urwid/__init__.py
+++ b/urwid/__init__.py
@@ -57,6 +57,8 @@ from urwid.font import (
     HalfBlock6x5Font,
     HalfBlock7x7Font,
     HalfBlockHeavy6x5Font,
+    Sextant2x2Font,
+    Sextant3x3Font,
     Thin3x3Font,
     Thin4x3Font,
     Thin6x6Font,

--- a/urwid/font.py
+++ b/urwid/font.py
@@ -129,6 +129,21 @@ class FontRegistry(type):
         """Get font by name if registered."""
         return self.__registered.get(item)
 
+    def __class_getitem__(cls, item: str) -> FontRegistry | None:
+        """Get font by name if registered.
+
+        This method is needed to get access to font from registry class.
+        >>> repr(FontRegistry["a"])
+        'None'
+        >>> font = FontRegistry["Thin 3x3"]()
+        >>> font.height
+        3
+        >>> canvas: TextCanvas = font.render("+")
+        >>> b'\\n'.join(canvas.text).decode('utf-8') == "  \\n ┼\\n  "
+        True
+        """
+        return cls.__registered.get(item)
+
     @property
     def registered(cls) -> Sequence[str]:
         """Registered font names in alphabetical order."""

--- a/urwid/tests/test_doctests.py
+++ b/urwid/tests/test_doctests.py
@@ -38,6 +38,7 @@ def load_tests(loader, tests, ignore):
         urwid.numedit,
         urwid.monitored_list,
         urwid.raw_display,
+        urwid.font,
         'urwid.split_repr',  # override function with same name
         urwid.util,
         urwid.signals,

--- a/urwid/widget/constants.py
+++ b/urwid/widget/constants.py
@@ -51,8 +51,8 @@ class WHSettings(str, enum.Enum):
     GIVEN = "given"
     RELATIVE = "relative"
     WEIGHT = "weight"
-    CLIP = WrapMode.CLIP  # Used as "given" for widgets with fixed width (with clipping part of it)
-    FLOW = Sizing.FLOW  # Used as pack for flow widgets
+    CLIP = "clip"  # Used as "given" for widgets with fixed width (with clipping part of it)
+    FLOW = "flow"  # Used as pack for flow widgets
 
 
 RELATIVE_100 = (WHSettings.RELATIVE, 100)

--- a/urwid/widget/padding.py
+++ b/urwid/widget/padding.py
@@ -81,15 +81,15 @@ class Padding(WidgetDecoration):
         Clipping Mode: (width= ``'clip'``)
         In clipping mode this padding widget will behave as a flow
         widget and self.original_widget will be treated as a fixed
-        widget.  self.original_widget will will be clipped to fit
+        widget.  self.original_widget will be clipped to fit
         the available number of columns.  For example if align is
         ``'left'`` then self.original_widget may be clipped on the right.
 
-        >>> from urwid import Divider, Text
+        >>> from urwid import Divider, Text, BigText, FontRegistry
         >>> size = (7,)
         >>> def pr(w):
         ...     for t in w.render(size).text:
-        ...         print(f"|{t.decode('ascii')}|" )
+        ...         print(f"|{t.decode('utf-8')}|" )
         >>> pr(Padding(Text(u"Head"), ('relative', 20), 'pack'))
         | Head  |
         >>> pr(Padding(Divider(u"-"), left=2, right=1))
@@ -109,6 +109,10 @@ class Padding(WidgetDecoration):
         >>> pr(Padding(Text(u"hi\\nthere"), 'right', 'pack')) # pack text first
         |  hi   |
         |  there|
+        >>> pr(Padding(BigText("1,2,3", FontRegistry['Thin 3x3']()), width="clip"))
+        | ┐  ┌─┐|
+        | │  ┌─┘|
+        | ┴ ,└─ |
         """
         super().__init__(w)
 


### PR DESCRIPTION
* Fix `WHSettings.CLIP` & `WHSettings.FLOW`
* Export `Sextant2x2Font` and `Sextant3x3Font`
* Add `__class_getitem__` to `FontRegistry` for fonts access
* Add related unittests

Fixes: #606

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [X] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
