### PR TITLE
Refactoring: use `super()` calls if possible

### DIFF
--- a/examples/asyncio_socket_server.py
+++ b/examples/asyncio_socket_server.py
@@ -87,7 +87,7 @@ class AsyncScreen(Screen):
         self.writer = writer
         self.encoding = encoding
 
-        Screen.__init__(self, None, None)
+        super().__init__(None, None)
 
     _pending_task = None
 

--- a/examples/dialog.py
+++ b/examples/dialog.py
@@ -116,7 +116,7 @@ class InputDialogDisplay(DialogDisplay):
         body = urwid.ListBox(urwid.SimpleListWalker([self.edit]))
         body = urwid.AttrWrap(body, 'selectable','focustext')
 
-        DialogDisplay.__init__(self, text, height, width, body)
+        super().__init__(text, height, width, body)
 
         self.frame.focus_position = 'body'
 
@@ -176,7 +176,7 @@ class ListDialogDisplay(DialogDisplay):
 
         lb = urwid.ListBox(urwid.SimpleListWalker(l))
         lb = urwid.AttrWrap( lb, "selectable" )
-        DialogDisplay.__init__(self, text, height, width, lb )
+        super().__init__(text, height, width, lb )
 
         self.frame.focus_position = 'body'
 
@@ -225,7 +225,7 @@ class CheckListDialogDisplay(ListDialogDisplay):
 class MenuItem(urwid.Text):
     """A custom widget for the --menu option"""
     def __init__(self, label):
-        urwid.Text.__init__(self, label)
+        super().__init__(label)
         self.state = False
     def selectable(self):
         return True
@@ -241,9 +241,9 @@ class MenuItem(urwid.Text):
         return False
     def get_state(self):
         return self.state
-    def get_label(self):
-        text, attr = self.get_text()
-        return text
+    def get_label(self) -> str:
+        """Just alias to text."""
+        return self.text
 
 
 def do_checklist(text, height, width, list_height, *items):

--- a/examples/twisted_serve_ssh.py
+++ b/examples/twisted_serve_ssh.py
@@ -177,7 +177,7 @@ class TwistedScreen(Screen):
         # We will need these later
         self.terminalProtocol = terminalProtocol
         self.terminal = terminalProtocol.terminal
-        Screen.__init__(self)
+        super().__init__()
         self.colors = 16
         self._pal_escape = {}
         self.bright_is_bold = True

--- a/urwid/numedit.py
+++ b/urwid/numedit.py
@@ -75,8 +75,7 @@ class NumEdit(Edit):
         >>> e.keypress(size, '1')
         >>> assert e.edit_text == "101"
         """
-        (maxcol,) = size
-        unhandled = Edit.keypress(self, (maxcol,), key)
+        unhandled = super().keypress(size, key)
 
         if not unhandled and self.trimLeadingZeros:
             # trim leading zeros

--- a/urwid/widget/edit.py
+++ b/urwid/widget/edit.py
@@ -588,13 +588,12 @@ class Edit(Text):
         >>> c.cursor
         (5, 0)
         """
-        (maxcol,) = size
         self._shift_view_to_cursor = bool(focus)
 
-        canv: TextCanvas | CompositeCanvas = Text.render(self, (maxcol,))
+        canv: TextCanvas | CompositeCanvas = super().render(size)
         if focus:
             canv = CompositeCanvas(canv)
-            canv.cursor = self.get_cursor_coords((maxcol,))
+            canv.cursor = self.get_cursor_coords(size)
 
         # .. will need to FIXME if I want highlight to work again
         # if self.highlight:
@@ -684,8 +683,7 @@ class IntEdit(Edit):
         >>> print(e.edit_text)
         2
         """
-        (maxcol,) = size
-        unhandled = Edit.keypress(self, (maxcol,), key)
+        unhandled = super().keypress(size, key)
 
         if not unhandled:
             # trim leading zeros


### PR DESCRIPTION
* Stop using `<ParentClass>.<method>.(self, ...)` if only 1 parent / no MRO issues
* Do not expand `size` argument if `maxcol` is not used directly

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
