### PR TITLE
CI/CD extend: add automatic labels on internal changes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,12 @@
+"CI/CD":
+  - all:
+      - ".github/workflows/**"
+
+"Maintenance":
+  - all:
+      - ".github/**"
+      - "!.github/workflows/**"
+
+"docs":
+  - all:
+      - "docs/**"

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,15 @@
+name: Set PR labels
+
+on:
+  pull_request_target: {}
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v4
+      with:
+        dot: true

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -4,10 +4,15 @@ on:
   push:
     branches-ignore:
       - 'dependabot/**'
+      - 'gh-pages'
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"  # Canonical versioned tags
       - "[0-9]+.[0-9]+.[0-9]+.post[0-9]+"  # Canonical rebuild tags
   pull_request: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   Test:


### PR DESCRIPTION
* Do not run normal tests on documentation PR
* Cancel running workflow on new changes

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
