### PR TITLE
Documentation: add 2.2.1 changelog and fix build

### DIFF
--- a/.github/workflows/documenation.yml
+++ b/.github/workflows/documenation.yml
@@ -1,0 +1,50 @@
+name: Build documentation
+
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+      - 'gh-pages'
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"  # Canonical versioned tags
+      - "[0-9]+.[0-9]+.[0-9]+.post[0-9]+"  # Canonical rebuild tags
+  pull_request:
+    branches-ignore:
+      - 'dependabot/**'
+      - 'gh-pages'
+    paths:
+      - "docs/**"
+      - "README.rst"
+      - "urwid/**"
+      - "setup.py"
+      - "pyproject.toml"
+      - ".github/workflows/**"
+
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # need for setuptools_scm
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+          cache: 'pip'
+      - name: Install Ubuntu dependencies
+        run: |
+          sudo apt-get -qq update
+          sudo apt-get install -y python3-gi gobject-introspection libgirepository1.0-dev
+      - name: Install python dependencies
+        run: |
+          pip install -U -r test_requirements.txt PyGObject
+          pip install -U sphinx
+      - name: Install main package
+        run: pip install -e .
+      - name: Build documentation
+        run: sphinx-build docs build/documentation
+      - uses: actions/upload-artifact@v3
+        with:
+          path: build/documentation
+          name: documentation

--- a/.github/workflows/documenation.yml
+++ b/.github/workflows/documenation.yml
@@ -18,7 +18,7 @@ on:
       - "urwid/**"
       - "setup.py"
       - "pyproject.toml"
-      - ".github/workflows/**"
+      - ".github/workflows/documentation.yml"
 
 jobs:
   Build:

--- a/.gitignore
+++ b/.gitignore
@@ -452,3 +452,6 @@ secring.*
 /urwid/version.py
 # Built packages
 /wheelhouse
+
+### Documentation build
+/build

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,24 @@
 Changelog
 ---------
 
+Urwid 2.2.1
+===========
+
+2023-09-22
+
+Bug fixes 🕷
+
+* Fix: deep TextEnum was improperly resolved by @penguinolog in #609
+
+Documentation 🕮
+
+* Documentation: mention correct python versions by @penguinolog in #608
+
+Refactoring 🛠
+
+* Refactoring: use super() calls if possible by @penguinolog in #611
+* Typing: Extend wimp typing annotations by @penguinolog in #604
+
 Urwid 2.2.0
 ===========
 

--- a/tox.ini
+++ b/tox.ini
@@ -58,3 +58,10 @@ commands = ruff \
     urwid/command_map.py \
     urwid/graphics.py \
     examples
+
+[testenv:docs]
+deps =
+    -r {toxinidir}/test_requirements.txt
+    PyGObject
+    sphinx
+commands = sphinx-build docs/ build/documentation

--- a/urwid/event_loop/asyncio_loop.py
+++ b/urwid/event_loop/asyncio_loop.py
@@ -50,7 +50,8 @@ class AsyncioEventLoop(EventLoop):
         running in background), and wish the screen to be
         redrawn, you must call :meth:`MainLoop.draw_screen` method of the
         main loop manually.
-        A good way to do this::
+
+        A good way to do this:
             asyncio.get_event_loop().call_soon(main_loop.draw_screen)
     """
 


### PR DESCRIPTION
* Fix warning on `AsyncioEventLoop` docstring
* Add `/documentation` directory to `.gitignore`
* Add minimalistic tox target for documentation build

**NOTE: Official support for building Pages with Actions is in public beta at the moment.**
When it will be released officially, switch is expected

##### Checklist
- [ ] I've ensured that similar functionality has not already been implemented
- [ ] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [X] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
