### PR TITLE
Mark `AttrWrap` as `PendingDeprecation`

### DIFF
--- a/examples/calc.py
+++ b/examples/calc.py
@@ -34,6 +34,8 @@ Features:
 
 from __future__ import annotations
 
+import typing
+
 import urwid
 import urwid.raw_display
 import urwid.web_display
@@ -45,26 +47,27 @@ else:
     Screen = urwid.raw_display.Screen
 
 
-def div_or_none(a,b):
+def div_or_none(a, b):
     """Divide a by b.  Return result or None on divide by zero."""
     if b == 0:
         return None
-    return a/b
+    return a / b
+
 
 # operators supported and the functions used to calculate a result
 OPERATORS = {
-    '+': (lambda a, b: a+b),
-    '-': (lambda a, b: a-b),
-    '*': (lambda a, b: a*b),
-    '/': div_or_none,
-    }
+    "+": (lambda a, b: a + b),
+    "-": (lambda a, b: a - b),
+    "*": (lambda a, b: a * b),
+    "/": div_or_none,
+}
 
 # the uppercase versions of keys used to switch columns
-COLUMN_KEYS = list( "?ABCDEF" )
+COLUMN_KEYS = list("?ABCDEF")
 
 # these lists are used to determine when to display errors
-EDIT_KEYS = list(OPERATORS.keys()) + COLUMN_KEYS + ['backspace','delete']
-MOVEMENT_KEYS = ['up','down','left','right','page up','page down']
+EDIT_KEYS = list(OPERATORS.keys()) + COLUMN_KEYS + ["backspace", "delete"]
+MOVEMENT_KEYS = ["up", "down", "left", "right", "page up", "page down"]
 
 # Event text
 E_no_such_column = "Column %s does not exist."
@@ -76,8 +79,11 @@ E_cant_combine = "Cannot combine cells with sub-expressions."
 E_invalid_in_parent_cell = "Cannot enter numbers into parent cell."
 E_invalid_in_help_col = [
     "Help Column is in focus.  Press ",
-    ('key',COLUMN_KEYS[1]),"-",('key',COLUMN_KEYS[-1]),
-    " to select another column."]
+    ("key", COLUMN_KEYS[1]),
+    "-",
+    ("key", COLUMN_KEYS[-1]),
+    " to select another column.",
+]
 
 # Shared layout object
 CALC_LAYOUT = None
@@ -86,33 +92,35 @@ CALC_LAYOUT = None
 class CalcEvent(Exception):
     """Events triggered by user input."""
 
-    attr = 'event'
+    attr = "event"
 
     def __init__(self, message):
         self.message = message
 
     def widget(self):
         """Return a widget containing event information"""
-        text = urwid.Text( self.message, 'center' )
-        return urwid.AttrWrap( text, self.attr )
+        text = urwid.Text(self.message, "center")
+        return urwid.AttrMap(text, self.attr)
+
 
 class ColumnDeleteEvent(CalcEvent):
     """Sent when user wants to delete a column"""
 
-    attr = 'confirm'
+    attr = "confirm"
 
     def __init__(self, letter, from_parent=0):
-        self.message = ["Press ", ('key',"BACKSPACE"),
-            " again to confirm column removal."]
+        self.message = ["Press ", ("key", "BACKSPACE"), " again to confirm column removal."]
         self.letter = letter
+
 
 class UpdateParentEvent(Exception):
     """Sent when parent columns may need to be updated."""
+
     pass
 
 
 class Cell:
-    def __init__(self, op ):
+    def __init__(self, op):
         self.op = op
         self.is_top = op is None
         self.child = None
@@ -132,22 +140,21 @@ class Cell:
             return False
         return True
 
-
     def setup_edit(self):
         """Create the standard edit widget for this cell."""
 
         self.edit = urwid.IntEdit()
         if not self.is_top:
-            self.edit.set_caption( f"{self.op} " )
-        self.edit.set_layout( None, None, CALC_LAYOUT )
+            self.edit.set_caption(f"{self.op} ")
+        self.edit.set_layout(None, None, CALC_LAYOUT)
 
     def get_value(self):
         """Return the numeric value of the cell."""
 
         if self.child is not None:
             return self.child.get_result()
-        else:
-            return int(f"0{self.edit.edit_text}")
+
+        return int(f"0{self.edit.edit_text}")
 
     def get_result(self):
         """Return the numeric result of this cell's operation."""
@@ -161,16 +168,16 @@ class Cell:
     def set_result(self, result):
         """Set the numeric result for this cell."""
 
-        if result == None:
+        if result is None:
             self.result.set_text("")
         else:
-            self.result.set_text( "%d" %result )
+            self.result.set_text("%d" % result)
 
     def become_parent(self, column, letter):
         """Change the edit widget to a parent cell widget."""
 
         self.child = column
-        self.edit = ParentEdit( self.op, letter )
+        self.edit = ParentEdit(self.op, letter)
 
     def remove_child(self):
         """Change the edit widget back to a standard edit widget."""
@@ -178,7 +185,7 @@ class Cell:
         self.child = None
         self.setup_edit()
 
-    def is_empty( self ):
+    def is_empty(self):
         """Return True if the cell is "empty"."""
 
         return self.child is None and self.edit.edit_text == ""
@@ -196,9 +203,9 @@ class ParentEdit(urwid.Edit):
                      function takes no parameters
         """
 
-        urwid.Edit.__init__(self, layout=CALC_LAYOUT)
+        super().__init__(layout=CALC_LAYOUT)
         self.op = op
-        self.set_letter( letter )
+        self.set_letter(letter)
 
     def set_letter(self, letter):
         """Set the letter of the child column for display."""
@@ -214,38 +221,38 @@ class ParentEdit(urwid.Edit):
 
         if key == "backspace":
             raise ColumnDeleteEvent(self.letter, from_parent=True)
-        elif key in list("0123456789"):
+        if key in list("0123456789"):
             raise CalcEvent(E_invalid_in_parent_cell)
-        else:
-            return key
+
+        return key
 
 
 class CellWalker(urwid.ListWalker):
     def __init__(self, content):
         self.content = urwid.MonitoredList(content)
         self.content.modified = self._modified
-        self.focus = (0,0)
+        self.focus = (0, 0)
         # everyone can share the same divider widget
         self.div = urwid.Divider("-")
 
     def get_cell(self, i):
         if i < 0 or i >= len(self.content):
             return None
-        else:
-            return self.content[i]
+
+        return self.content[i]
 
     def _get_at_pos(self, pos):
         i, sub = pos
-        assert sub in (0,1,2)
+        assert sub in (0, 1, 2)  # noqa: S101  # for examples "assert" is acceptable
         if i < 0 or i >= len(self.content):
             return None, None
         if sub == 0:
             edit = self.content[i].edit
-            return urwid.AttrWrap(edit, 'edit', 'editfocus'), pos
-        elif sub == 1:
+            return urwid.AttrMap(edit, "edit", "editfocus"), pos
+        if sub == 1:
             return self.div, pos
-        else:
-            return self.content[i].result, pos
+
+        return self.content[i].result, pos
 
     def get_focus(self):
         return self._get_at_pos(self.focus)
@@ -255,60 +262,57 @@ class CellWalker(urwid.ListWalker):
 
     def get_next(self, start_from):
         i, sub = start_from
-        assert sub in (0,1,2)
+        assert sub in (0, 1, 2)  # noqa: S101  # for examples "assert" is acceptable
         if sub == 0:
-            show_result = self.content[i].show_result(
-                self.get_cell(i+1))
+            show_result = self.content[i].show_result(self.get_cell(i + 1))
             if show_result:
-                return self._get_at_pos( (i, 1) )
-            else:
-                return self._get_at_pos( (i+1, 0) )
-        elif sub == 1:
-            return self._get_at_pos( (i, 2) )
-        else:
-            return self._get_at_pos( (i+1, 0) )
+                return self._get_at_pos((i, 1))
+
+            return self._get_at_pos((i + 1, 0))
+        if sub == 1:
+            return self._get_at_pos((i, 2))
+
+        return self._get_at_pos((i + 1, 0))
 
     def get_prev(self, start_from):
         i, sub = start_from
-        assert sub in (0,1,2)
+        assert sub in (0, 1, 2)  # noqa: S101  # for examples "assert" is acceptable
         if sub == 0:
-            if i == 0: return None, None
-            show_result = self.content[i-1].show_result(
-                self.content[i])
+            if i == 0:
+                return None, None
+            show_result = self.content[i - 1].show_result(self.content[i])
             if show_result:
-                return self._get_at_pos( (i-1, 2) )
-            else:
-                return self._get_at_pos( (i-1, 0) )
-        elif sub == 1:
-            return self._get_at_pos( (i, 0) )
-        else:
-            return self._get_at_pos( (i, 1) )
+                return self._get_at_pos((i - 1, 2))
+
+            return self._get_at_pos((i - 1, 0))
+        if sub == 1:
+            return self._get_at_pos((i, 0))
+
+        return self._get_at_pos((i, 1))
 
 
-class CellColumn( urwid.WidgetWrap ):
+class CellColumn(urwid.WidgetWrap):
     def __init__(self, letter):
         self.walker = CellWalker([Cell(None)])
         self.content = self.walker.content
-        self.listbox = urwid.ListBox( self.walker )
-        self.set_letter( letter )
-        urwid.WidgetWrap.__init__(self, self.frame)
+        self.listbox = urwid.ListBox(self.walker)
+        self.set_letter(letter)
+        super().__init__(self.frame)
 
     def set_letter(self, letter):
         """Set the column header with letter."""
 
         self.letter = letter
-        header = urwid.AttrWrap(
-            urwid.Text( ["Column ",('key',letter)],
-            layout = CALC_LAYOUT), 'colhead' )
-        self.frame = urwid.Frame( self.listbox, header )
+        header = urwid.AttrMap(urwid.Text(["Column ", ("key", letter)], layout=CALC_LAYOUT), "colhead")
+        self.frame = urwid.Frame(self.listbox, header)
 
     def keypress(self, size, key):
-        key = self.frame.keypress( size, key)
+        key = self.frame.keypress(size, key)
         if key is None:
             changed = self.update_results()
             if changed:
                 raise UpdateParentEvent()
-            return
+            return None
 
         f, (i, sub) = self.walker.get_focus()
         if sub != 0:
@@ -319,27 +323,26 @@ class CellColumn( urwid.WidgetWrap ):
             edit = self.walker.get_cell(i).edit
             cursor_pos = edit.edit_pos
             tail = edit.edit_text[cursor_pos:]
-            edit.set_edit_text( edit.edit_text[:cursor_pos] )
+            edit.set_edit_text(edit.edit_text[:cursor_pos])
 
-            new_cell = Cell( key )
-            new_cell.edit.set_edit_text( tail )
-            self.content[i+1:i+1] = [new_cell]
+            new_cell = Cell(key)
+            new_cell.edit.set_edit_text(tail)
+            self.content[i + 1 : i + 1] = [new_cell]
 
             changed = self.update_results()
-            self.move_focus_next( size )
-            self.content[i+1].edit.set_edit_pos(0)
+            self.move_focus_next(size)
+            self.content[i + 1].edit.set_edit_pos(0)
             if changed:
                 raise UpdateParentEvent()
-            return
+            return None
 
-        elif key == 'backspace':
+        if key == "backspace":
             # unhandled backspace, we're at beginning of number
             # append current number to cell above, removing operator
-            above = self.walker.get_cell(i-1)
+            above = self.walker.get_cell(i - 1)
             if above is None:
                 # we're the first cell
-                raise ColumnDeleteEvent( self.letter,
-                    from_parent=False )
+                raise ColumnDeleteEvent(self.letter, from_parent=False)
 
             edit = self.walker.get_cell(i).edit
             # check that we can combine
@@ -352,21 +355,20 @@ class CellColumn( urwid.WidgetWrap ):
             else:
                 # above is normal number cell
                 above_pos = len(above.edit.edit_text)
-                above.edit.set_edit_text( above.edit.edit_text +
-                    edit.edit_text )
+                above.edit.set_edit_text(above.edit.edit_text + edit.edit_text)
 
-            self.move_focus_prev( size )
-            self.content[i-1].edit.set_edit_pos(above_pos)
+            self.move_focus_prev(size)
+            self.content[i - 1].edit.set_edit_pos(above_pos)
             del self.content[i]
             changed = self.update_results()
             if changed:
                 raise UpdateParentEvent()
-            return
+            return None
 
-        elif key == 'delete':
+        if key == "delete":
             # pull text from next cell into current
             cell = self.walker.get_cell(i)
-            below = self.walker.get_cell(i+1)
+            below = self.walker.get_cell(i + 1)
             if cell.child is not None:
                 # this cell is a parent
                 raise CalcEvent(E_cant_combine)
@@ -378,37 +380,34 @@ class CellColumn( urwid.WidgetWrap ):
                 raise CalcEvent(E_cant_combine)
 
             edit = self.walker.get_cell(i).edit
-            edit.set_edit_text( edit.edit_text +
-                below.edit.edit_text )
+            edit.set_edit_text(edit.edit_text + below.edit.edit_text)
 
-            del self.content[i+1]
+            del self.content[i + 1]
             changed = self.update_results()
             if changed:
                 raise UpdateParentEvent()
-            return
+            return None
         return key
-
 
     def move_focus_next(self, size):
         f, (i, sub) = self.walker.get_focus()
-        assert i<len(self.content)-1
+        assert i < len(self.content) - 1  # noqa: S101  # for examples "assert" is acceptable
 
         ni = i
         while ni == i:
-            self.frame.keypress(size, 'down')
+            self.frame.keypress(size, "down")
             nf, (ni, nsub) = self.walker.get_focus()
 
     def move_focus_prev(self, size):
         f, (i, sub) = self.walker.get_focus()
-        assert i>0
+        assert i > 0  # noqa: S101  # for examples "assert" is acceptable
 
         ni = i
         while ni == i:
-            self.frame.keypress(size, 'up')
+            self.frame.keypress(size, "up")
             nf, (ni, nsub) = self.walker.get_focus()
 
-
-    def update_results( self, start_from=None ):
+    def update_results(self, start_from=None):
         """Update column.  Return True if final result changed.
 
         start_from -- Cell to start updating from or None to start from
@@ -419,35 +418,33 @@ class CellColumn( urwid.WidgetWrap ):
             f, (i, sub) = self.walker.get_focus()
         else:
             i = self.content.index(start_from)
-            if i == None: return False
+            if i is None:
+                return False
 
         focus_cell = self.walker.get_cell(i)
 
         if focus_cell.is_top:
             x = focus_cell.get_value()
-            last_op = None
         else:
-            last_cell = self.walker.get_cell(i-1)
+            last_cell = self.walker.get_cell(i - 1)
             x = last_cell.get_result()
 
             if x is not None and focus_cell.op is not None:
-                x = OPERATORS[focus_cell.op]( x,
-                    focus_cell.get_value() )
+                x = OPERATORS[focus_cell.op](x, focus_cell.get_value())
             focus_cell.set_result(x)
 
-        for cell in self.content[i+1:]:
+        for cell in self.content[i + 1 :]:
             if cell.op is None:
                 x = None
             if x is not None:
-                x = OPERATORS[cell.op]( x, cell.get_value() )
+                x = OPERATORS[cell.op](x, cell.get_value())
             if cell.get_result() == x:
                 return False
             cell.set_result(x)
 
         return True
 
-
-    def create_child( self, letter ):
+    def create_child(self, letter):
         """Return (parent cell,child column) or None,None on failure."""
         f, (i, sub) = self.walker.get_focus()
         if sub != 0:
@@ -460,30 +457,29 @@ class CellColumn( urwid.WidgetWrap ):
         if cell.edit.edit_text:
             raise CalcEvent(E_new_col_cell_not_empty)
 
-        child = CellColumn( letter )
-        cell.become_parent( child, letter )
+        child = CellColumn(letter)
+        cell.become_parent(child, letter)
 
         return cell, child
 
-    def is_empty( self ):
+    def is_empty(self):
         """Return True if this column is empty."""
 
-        return len(self.content)==1 and self.content[0].is_empty()
-
+        return len(self.content) == 1 and self.content[0].is_empty()
 
     def get_expression(self):
         """Return the expression as a printable string."""
 
-        l = []
+        lines = []
         for c in self.content:
-            if c.op is not None: # only applies to first cell
-                l.append(c.op)
+            if c.op is not None:  # only applies to first cell
+                lines.append(c.op)
             if c.child is not None:
-                l.append(f"({c.child.get_expression()})")
+                lines.append(f"({c.child.get_expression()})")
             else:
-                l.append("%d"%c.get_value())
+                lines.append(f"{c.get_value():d}")
 
-        return "".join(l)
+        return "".join(lines)
 
     def get_result(self):
         """Return the result of the last cell in the column."""
@@ -493,111 +489,116 @@ class CellColumn( urwid.WidgetWrap ):
 
 class HelpColumn(urwid.Widget):
     _selectable = True
-    _sizing = frozenset([urwid.BOX])
+    _sizing = frozenset((urwid.BOX,))
 
-    help_text = [
-        ('title', "Column Calculator"),
+    help_text = [  # noqa: RUF012  # text layout typing is too complex
+        ("title", "Column Calculator"),
         "",
-        [ "Numbers: ", ('key', "0"), "-", ('key', "9") ],
-        "" ,
-        [ "Operators: ",('key', "+"), ", ", ('key', "-"), ", ",
-            ('key', "*"), " and ", ('key', "/")],
+        ["Numbers: ", ("key", "0"), "-", ("key", "9")],
         "",
-        [ "Editing: ", ('key', "BACKSPACE"), " and ",('key', "DELETE")],
+        ["Operators: ", ("key", "+"), ", ", ("key", "-"), ", ", ("key", "*"), " and ", ("key", "/")],
         "",
-        [ "Movement: ", ('key', "UP"), ", ", ('key', "DOWN"), ", ",
-            ('key', "LEFT"), ", ", ('key', "RIGHT"), ", ",
-            ('key', "PAGE UP"), " and ", ('key', "PAGE DOWN") ],
+        ["Editing: ", ("key", "BACKSPACE"), " and ", ("key", "DELETE")],
         "",
-        [ "Sub-expressions: ", ('key', "("), " and ", ('key', ")") ],
+        [
+            "Movement: ",
+            ("key", "UP"),
+            ", ",
+            ("key", "DOWN"),
+            ", ",
+            ("key", "LEFT"),
+            ", ",
+            ("key", "RIGHT"),
+            ", ",
+            ("key", "PAGE UP"),
+            " and ",
+            ("key", "PAGE DOWN"),
+        ],
         "",
-        [ "Columns: ", ('key', COLUMN_KEYS[0]), " and ",
-            ('key',COLUMN_KEYS[1]), "-",
-            ('key',COLUMN_KEYS[-1]) ],
+        ["Sub-expressions: ", ("key", "("), " and ", ("key", ")")],
         "",
-        [ "Exit: ", ('key', "Q") ],
+        ["Columns: ", ("key", COLUMN_KEYS[0]), " and ", ("key", COLUMN_KEYS[1]), "-", ("key", COLUMN_KEYS[-1])],
+        "",
+        ["Exit: ", ("key", "Q")],
         "",
         "",
-        ["Column Calculator does operations in the order they are ",
+        [
+            "Column Calculator does operations in the order they are ",
             "typed, not by following usual precedence rules.  ",
-            "If you want to calculate ", ('key', "12 - 2 * 3"),
+            "If you want to calculate ",
+            ("key", "12 - 2 * 3"),
             " with the multiplication happening before the ",
             "subtraction you must type ",
-            ('key', "12 - (2 * 3)"), " instead."],
-        ]
+            ("key", "12 - (2 * 3)"),
+            " instead.",
+        ],
+    ]
 
     def __init__(self):
-        self.head = urwid.AttrWrap(
-            urwid.Text(["Help Column ", ('key',"?")],
-                layout = CALC_LAYOUT),
-            'help')
-        self.foot = urwid.AttrWrap(
-            urwid.Text(["[text continues.. press ",
-            ('key',"?"), " then scroll]"]), 'helpnote' )
+        self.head = urwid.AttrMap(urwid.Text(["Help Column ", ("key", "?")], layout=CALC_LAYOUT), "help")
+        self.foot = urwid.AttrMap(urwid.Text(["[text continues.. press ", ("key", "?"), " then scroll]"]), "helpnote")
         self.items = [urwid.Text(x) for x in self.help_text]
         self.listbox = urwid.ListBox(urwid.SimpleListWalker(self.items))
-        self.body = urwid.AttrWrap( self.listbox, 'help' )
-        self.frame = urwid.Frame( self.body, header=self.head)
+        self.body = urwid.AttrMap(self.listbox, "help")
+        self.frame = urwid.Frame(self.body, header=self.head)
 
     def render(self, size, focus=False):
         maxcol, maxrow = size
         head_rows = self.head.rows((maxcol,))
-        if "bottom" in self.listbox.ends_visible(
-            (maxcol, maxrow-head_rows) ):
+        if "bottom" in self.listbox.ends_visible((maxcol, maxrow - head_rows)):
             self.frame.footer = None
         else:
             self.frame.footer = self.foot
 
-        return self.frame.render( (maxcol, maxrow), focus)
+        return self.frame.render((maxcol, maxrow), focus)
 
-    def keypress( self, size, key ):
-        return self.frame.keypress( size, key )
+    def keypress(self, size, key):
+        return self.frame.keypress(size, key)
 
 
 class CalcDisplay:
-    palette = [
-        ('body','white', 'dark blue'),
-        ('edit','yellow', 'dark blue'),
-        ('editfocus','yellow','dark cyan', 'bold'),
-        ('key','dark cyan', 'light gray', ('standout','underline')),
-        ('title', 'white', 'light gray', ('bold','standout')),
-        ('help', 'black', 'light gray', 'standout'),
-        ('helpnote', 'dark green', 'light gray'),
-        ('colhead', 'black', 'light gray', 'standout'),
-        ('event', 'light red', 'black', 'standout'),
-        ('confirm', 'yellow', 'black', 'bold'),
-        ]
+    palette: typing.ClassVar[list[tuple[str, str, str, ...]]] = [
+        ("body", "white", "dark blue"),
+        ("edit", "yellow", "dark blue"),
+        ("editfocus", "yellow", "dark cyan", "bold"),
+        ("key", "dark cyan", "light gray", ("standout", "underline")),
+        ("title", "white", "light gray", ("bold", "standout")),
+        ("help", "black", "light gray", "standout"),
+        ("helpnote", "dark green", "light gray"),
+        ("colhead", "black", "light gray", "standout"),
+        ("event", "light red", "black", "standout"),
+        ("confirm", "yellow", "black", "bold"),
+    ]
 
     def __init__(self):
         self.columns = urwid.Columns([HelpColumn(), CellColumn("A")], 1)
         self.col_list = self.columns.widget_list
         self.columns.focus_position = 1
-        view = urwid.AttrWrap(self.columns, 'body')
-        self.view = urwid.Frame(view) # for showing messages
+        view = urwid.AttrMap(self.columns, "body")
+        self.view = urwid.Frame(view)  # for showing messages
         self.col_link = {}
 
     def main(self):
-        self.loop = urwid.MainLoop(self.view, self.palette, screen=Screen(),
-            input_filter=self.input_filter)
+        self.loop = urwid.MainLoop(self.view, self.palette, screen=Screen(), input_filter=self.input_filter)
         self.loop.run()
 
         # on exit write the formula and the result to the console
         expression, result = self.get_expression_result()
-        print( "Paste this expression into a new Column Calculator session to continue editing:")
-        print( expression)
-        print( "Result:", result)
+        print("Paste this expression into a new Column Calculator session to continue editing:")
+        print(expression)
+        print("Result:", result)
 
-    def input_filter(self, input, raw_input):
-        if 'q' in input or 'Q' in input:
+    def input_filter(self, data, raw_input):
+        if "q" in data or "Q" in data:
             raise urwid.ExitMainLoop()
 
         # handle other keystrokes
-        for k in input:
+        for k in data:
             try:
                 self.wrap_keypress(k)
                 self.event = None
                 self.view.footer = None
-            except CalcEvent as e:
+            except CalcEvent as e:  # noqa: PERF203
                 # display any message
                 self.event = e
                 self.view.footer = e.widget()
@@ -616,23 +617,20 @@ class CalcDisplay:
                 # cannot delete the first column, ignore key
                 return
 
-            if not self.column_empty( e.letter ):
-                # need to get two in a row, so check last event
-                if not isinstance(self.event,ColumnDeleteEvent):
-                    # ask for confirmation
-                    raise e
+            if not self.column_empty(e.letter) and not isinstance(self.event, ColumnDeleteEvent):
+                # need to get two in a row, so check last event ask for confirmation
+                raise
             self.delete_column(e.letter)
 
-        except UpdateParentEvent as e:
+        except UpdateParentEvent:
             self.update_parent_columns()
             return
 
         if key is None:
             return
 
-        if self.columns.focus_position == 0:
-            if key not in ('up','down','page up','page down'):
-                raise CalcEvent(E_invalid_in_help_col)
+        if self.columns.focus_position == 0 and key not in ("up", "down", "page up", "page down"):
+            raise CalcEvent(E_invalid_in_help_col)
 
         if key not in EDIT_KEYS and key not in MOVEMENT_KEYS:
             raise CalcEvent(E_invalid_key % key.upper())
@@ -641,10 +639,10 @@ class CalcDisplay:
         """Handle a keystroke."""
 
         self.loop.process_input([key])
-        
+
         if isinstance(key, tuple):
             # ignore mouse events
-            return
+            return None
 
         if key.upper() in COLUMN_KEYS:
             # column switch
@@ -652,8 +650,8 @@ class CalcDisplay:
             if i >= len(self.columns):
                 raise CalcEvent(E_no_such_column % key.upper())
             self.columns.focus_position = i
-            return
-        elif key == "(":
+            return None
+        if key == "(":
             # open a new column
             if len(self.columns) >= len(COLUMN_KEYS):
                 raise CalcEvent(E_no_more_columns)
@@ -663,43 +661,45 @@ class CalcDisplay:
                 return key
             col = self.columns.contents[i][0]
             new_letter = COLUMN_KEYS[len(self.columns)]
-            parent, child = col.create_child(new_letter )
+            parent, child = col.create_child(new_letter)
             if child is None:
                 # something invalid in focus
                 return key
             self.col_list.append(child)
-            self.set_link( parent, col, child )
-            self.columns.focus_position = len(self.columns)-1
+            self.set_link(parent, col, child)
+            self.columns.focus_position = len(self.columns) - 1
+            return None
 
-        elif key == ")":
+        if key == ")":
             i = self.columns.focus_position
             if i == 0:
                 # makes no sense in help column
                 return key
             col = self.columns.contents[i][0]
-            parent, pcol = self.get_parent( col )
+            parent, pcol = self.get_parent(col)
             if parent is None:
                 # column has no parent
                 raise CalcEvent(E_no_parent_column)
 
-            new_i = self.col_list.index( pcol )
+            new_i = self.col_list.index(pcol)
             self.columns.focus_position = new_i
-        else:
-            return key
+            return None
 
-    def set_link( self, parent, pcol, child ):
+        return key
+
+    def set_link(self, parent, pcol, child):
         """Store the link between a parent cell and child column.
 
         parent -- parent Cell object
         pcol -- CellColumn where parent resides
         child -- child CellColumn object"""
 
-        self.col_link[ child ] = parent, pcol
+        self.col_link[child] = parent, pcol
 
-    def get_parent( self, child ):
+    def get_parent(self, child):
         """Return the parent and parent column for a given column."""
 
-        return self.col_link.get( child, (None,None) )
+        return self.col_link.get(child, (None, None))
 
     def column_empty(self, letter):
         """Return True if the column passed is empty."""
@@ -708,14 +708,13 @@ class CalcDisplay:
         col = self.columns.contents[i][0]
         return col.is_empty()
 
-
     def delete_column(self, letter):
         """Delete the column with the given letter."""
 
         i = COLUMN_KEYS.index(letter)
         col = self.columns.contents[i][0]
 
-        parent, pcol = self.get_parent( col )
+        parent, pcol = self.get_parent(col)
 
         f = self.columns.focus_position
         if f == i:
@@ -731,11 +730,11 @@ class CalcDisplay:
         keep_right_cols = []
         remove_cols = [col]
         for rcol in self.col_list[i:]:
-            parent, pcol = self.get_parent( rcol )
+            parent, pcol = self.get_parent(rcol)
             if pcol in remove_cols:
-                remove_cols.append( rcol )
+                remove_cols.append(rcol)
             else:
-                keep_right_cols.append( rcol )
+                keep_right_cols.append(rcol)
         for rc in remove_cols:
             # remove the links
             del self.col_link[rc]
@@ -746,10 +745,10 @@ class CalcDisplay:
         for j in range(i, len(self.columns)):
             col = self.columns.contents[j][0]
             # fix the column heading
-            col.set_letter( COLUMN_KEYS[j] )
-            parent, pcol = self.get_parent( col )
+            col.set_letter(COLUMN_KEYS[j])
+            parent, pcol = self.get_parent(col)
             # fix the parent cell
-            parent.edit.set_letter( COLUMN_KEYS[j] )
+            parent.edit.set_letter(COLUMN_KEYS[j])
 
     def update_parent_columns(self):
         "Update the parent columns of the current focus column."
@@ -761,7 +760,7 @@ class CalcDisplay:
             if pcol is None:
                 return
 
-            changed = pcol.update_results( start_from = parent )
+            changed = pcol.update_results(start_from=parent)
             if not changed:
                 return
             col = pcol
@@ -778,40 +777,39 @@ class CalcNumLayout(urwid.TextLayout):
     TextLayout class for bottom-right aligned numbers with a space on
     the last line for the cursor.
     """
-    def layout( self, text, width, align, wrap ):
+
+    def layout(self, text, width, align, wrap):
         """
         Return layout structure for calculator number display.
         """
-        lt = len(text) + 1 # extra space for cursor
-        r = (lt) % width # remaining segment not full width wide
-        linestarts = range( r, lt, width )
-        l = []
+        lt = len(text) + 1  # extra space for cursor
+        remaining = lt % width  # remaining segment not full width wide
+        linestarts = range(remaining, lt, width)
+        layout = []
         if linestarts:
-            if r:
+            if remaining:
                 # right-align the remaining segment on 1st line
-                l.append( [(width-r,None),(r, 0, r)] )
+                layout.append([(width - remaining, None), (remaining, 0, remaining)])
             # fill all but the last line
             for x in linestarts[:-1]:
-                l.append( [(width, x, x+width)] )
+                layout.append([(width, x, x + width)])  # noqa: PERF401
             s = linestarts[-1]
             # add the last line with a cursor hint
-            l.append( [(width-1, s, lt-1), (0, lt-1)] )
-        elif lt-1:
+            layout.append([(width - 1, s, lt - 1), (0, lt - 1)])
+        elif lt - 1:
             # all fits on one line, so right align the text
             # with a cursor hint at the end
-            l.append( [(width-lt,None),(lt-1,0,lt-1), (0,lt-1)] )
+            layout.append([(width - lt, None), (lt - 1, 0, lt - 1), (0, lt - 1)])
         else:
             # nothing on the line, right align a cursor hint
-            l.append( [(width-1,None),(0,0)] )
+            layout.append([(width - 1, None), (0, 0)])
 
-        return l
-
-
+        return layout
 
 
 def main():
     """Launch Column Calculator."""
-    global CALC_LAYOUT
+    global CALC_LAYOUT  # noqa: PLW0603
     CALC_LAYOUT = CalcNumLayout()
 
     urwid.web_display.set_preferences("Column Calculator")
@@ -821,5 +819,6 @@ def main():
 
     CalcDisplay().main()
 
-if '__main__'==__name__ or urwid.web_display.is_web_request():
+
+if __name__ == "__main__" or urwid.web_display.is_web_request():
     main()

--- a/examples/edit.py
+++ b/examples/edit.py
@@ -33,6 +33,7 @@ edit.py <filename>
 from __future__ import annotations
 
 import sys
+import typing
 
 import urwid
 
@@ -41,7 +42,7 @@ class LineWalker(urwid.ListWalker):
     """ListWalker-compatible class for lazily reading file contents."""
 
     def __init__(self, name):
-        self.file = open(name)
+        self.file = open(name)  # noqa: SIM115  # do not overcomplicate example
         self.lines = []
         self.focus = 0
 
@@ -63,7 +64,7 @@ class LineWalker(urwid.ListWalker):
 
         next_line = self.file.readline()
 
-        if not next_line or next_line[-1:] != '\n':
+        if not next_line or next_line[-1:] != "\n":
             # no newline on last line of file
             self.file = None
         else:
@@ -78,7 +79,6 @@ class LineWalker(urwid.ListWalker):
         self.lines.append(edit)
 
         return next_line
-
 
     def _get_at_pos(self, pos):
         """Return a widget for the line number passed."""
@@ -95,7 +95,7 @@ class LineWalker(urwid.ListWalker):
             # file is closed, so there are no more lines
             return None, None
 
-        assert pos == len(self.lines), "out of order request?"
+        assert pos == len(self.lines), "out of order request?"  # noqa: S101  # "assert" is ok in examples
 
         self.read_next_line()
 
@@ -106,11 +106,11 @@ class LineWalker(urwid.ListWalker):
 
         focus = self.lines[self.focus]
         pos = focus.edit_pos
-        edit = urwid.Edit("",focus.edit_text[pos:], allow_tab=True)
+        edit = urwid.Edit("", focus.edit_text[pos:], allow_tab=True)
         edit.original_text = ""
         focus.set_edit_text(focus.edit_text[:pos])
         edit.set_edit_pos(0)
-        self.lines.insert(self.focus+1, edit)
+        self.lines.insert(self.focus + 1, edit)
 
     def combine_focus_with_prev(self):
         """Combine the focus edit widget with the one above."""
@@ -136,34 +136,36 @@ class LineWalker(urwid.ListWalker):
 
         focus = self.lines[self.focus]
         focus.set_edit_text(focus.edit_text + below.edit_text)
-        del self.lines[self.focus+1]
+        del self.lines[self.focus + 1]
 
 
 class EditDisplay:
-    palette = [
-        ('body','default', 'default'),
-        ('foot','dark cyan', 'dark blue', 'bold'),
-        ('key','light cyan', 'dark blue', 'underline'),
-        ]
+    palette: typing.ClassVar[list[tuple[str, str, str, ...]]] = [
+        ("body", "default", "default"),
+        ("foot", "dark cyan", "dark blue", "bold"),
+        ("key", "light cyan", "dark blue", "underline"),
+    ]
 
-    footer_text = ('foot', [
-        "Text Editor    ",
-        ('key', "F5"), " save  ",
-        ('key', "F8"), " quit",
-        ])
+    footer_text = (
+        "foot",
+        [
+            "Text Editor    ",
+            ("key", "F5"),
+            " save  ",
+            ("key", "F8"),
+            " quit",
+        ],
+    )
 
     def __init__(self, name):
         self.save_name = name
         self.walker = LineWalker(name)
         self.listbox = urwid.ListBox(self.walker)
-        self.footer = urwid.AttrWrap(urwid.Text(self.footer_text),
-            "foot")
-        self.view = urwid.Frame(urwid.AttrWrap(self.listbox, 'body'),
-            footer=self.footer)
+        self.footer = urwid.AttrMap(urwid.Text(self.footer_text), "foot")
+        self.view = urwid.Frame(urwid.AttrMap(self.listbox, "body"), footer=self.footer)
 
     def main(self):
-        self.loop = urwid.MainLoop(self.view, self.palette,
-            unhandled_input=self.unhandled_keypress)
+        self.loop = urwid.MainLoop(self.view, self.palette, unhandled_input=self.unhandled_keypress)
         self.loop.run()
 
     def unhandled_keypress(self, k):
@@ -188,70 +190,69 @@ class EditDisplay:
             w, pos = self.walker.get_focus()
             w, pos = self.walker.get_next(pos)
             if w:
-                self.listbox.set_focus(pos, 'above')
+                self.listbox.set_focus(pos, "above")
                 self.loop.process_input(["home"])
         elif k == "left":
             w, pos = self.walker.get_focus()
             w, pos = self.walker.get_prev(pos)
             if w:
-                self.listbox.set_focus(pos, 'below')
+                self.listbox.set_focus(pos, "below")
                 self.loop.process_input(["end"])
         else:
-            return
+            return None
         return True
-
 
     def save_file(self):
         """Write the file out to disk."""
 
-        l = []
+        lines = []
         walk = self.walker
         for edit in walk.lines:
             # collect the text already stored in edit widgets
             if edit.original_text.expandtabs() == edit.edit_text:
-                l.append(edit.original_text)
+                lines.append(edit.original_text)
             else:
-                l.append(re_tab(edit.edit_text))
+                lines.append(re_tab(edit.edit_text))
 
         # then the rest
         while walk.file is not None:
-            l.append(walk.read_next_line())
+            lines.append(walk.read_next_line())
 
         # write back to disk
-        outfile = open(self.save_name, "w")
+        with open(self.save_name, "w") as outfile:
 
-        prefix = ""
-        for line in l:
-            outfile.write(prefix + line)
-            prefix = "\n"
+            prefix = ""
+            for line in lines:
+                outfile.write(prefix + line)
+                prefix = "\n"
+
 
 def re_tab(s):
     """Return a tabbed string from an expanded one."""
-    l = []
+    line = []
     p = 0
     for i in range(8, len(s), 8):
-        if s[i-2:i] == "  ":
+        if s[i - 2 : i] == "  ":
             # collapse two or more spaces into a tab
-            l.append(f"{s[p:i].rstrip()}\t")
+            line.append(f"{s[p:i].rstrip()}\t")
             p = i
 
     if p == 0:
         return s
-    else:
-        l.append(s[p:])
-        return "".join(l)
 
+    line.append(s[p:])
+    return "".join(line)
 
 
 def main():
     try:
         name = sys.argv[1]
-        assert open(name, "a")
-    except:
+        assert open(name, "a")  # noqa: SIM115,S101  # do not overcomplicate example
+    except (FileNotFoundError, OSError):
         sys.stderr.write(__doc__)
         return
     EditDisplay(name).main()
 
 
-if __name__=="__main__":
+if __name__ == "__main__":
     main()

--- a/examples/fib.py
+++ b/examples/fib.py
@@ -37,13 +37,14 @@ class FibonacciWalker(urwid.ListWalker):
 
     positions returned are (value at position-1, value at position) tuples.
     """
+
     def __init__(self):
-        self.focus = (0,1)
+        self.focus = (0, 1)
         self.numeric_layout = NumericLayout()
 
     def _get_at_pos(self, pos):
         """Return a widget and the position passed."""
-        return urwid.Text("%d"%pos[1], layout=self.numeric_layout), pos
+        return urwid.Text("%d" % pos[1], layout=self.numeric_layout), pos
 
     def get_focus(self):
         return self._get_at_pos(self.focus)
@@ -54,37 +55,49 @@ class FibonacciWalker(urwid.ListWalker):
 
     def get_next(self, start_from):
         a, b = start_from
-        focus = b, a+b
+        focus = b, a + b
         return self._get_at_pos(focus)
 
     def get_prev(self, start_from):
         a, b = start_from
-        focus = b-a, a
+        focus = b - a, a
         return self._get_at_pos(focus)
+
 
 def main():
     palette = [
-        ('body','black','dark cyan', 'standout'),
-        ('foot','light gray', 'black'),
-        ('key','light cyan', 'black', 'underline'),
-        ('title', 'white', 'black',),
-        ]
+        ("body", "black", "dark cyan", "standout"),
+        ("foot", "light gray", "black"),
+        ("key", "light cyan", "black", "underline"),
+        (
+            "title",
+            "white",
+            "black",
+        ),
+    ]
 
     footer_text = [
-        ('title', "Fibonacci Set Viewer"), "    ",
-        ('key', "UP"), ", ", ('key', "DOWN"), ", ",
-        ('key', "PAGE UP"), " and ", ('key', "PAGE DOWN"),
+        ("title", "Fibonacci Set Viewer"),
+        "    ",
+        ("key", "UP"),
+        ", ",
+        ("key", "DOWN"),
+        ", ",
+        ("key", "PAGE UP"),
+        " and ",
+        ("key", "PAGE DOWN"),
         " move view  ",
-        ('key', "Q"), " exits",
-        ]
+        ("key", "Q"),
+        " exits",
+    ]
 
-    def exit_on_q(input):
-        if input in ('q', 'Q'):
+    def exit_on_q(key):
+        if key in ("q", "Q"):
             raise urwid.ExitMainLoop()
 
     listbox = urwid.ListBox(FibonacciWalker())
-    footer = urwid.AttrMap(urwid.Text(footer_text), 'foot')
-    view = urwid.Frame(urwid.AttrWrap(listbox, 'body'), footer=footer)
+    footer = urwid.AttrMap(urwid.Text(footer_text), "foot")
+    view = urwid.Frame(urwid.AttrMap(listbox, "body"), footer=footer)
     loop = urwid.MainLoop(view, palette, unhandled_input=exit_on_q)
     loop.run()
 
@@ -93,23 +106,24 @@ class NumericLayout(urwid.TextLayout):
     """
     TextLayout class for bottom-right aligned numbers
     """
-    def layout( self, text, width, align, wrap ):
+
+    def layout(self, text, width, align, wrap):
         """
         Return layout structure for right justified numbers.
         """
         lt = len(text)
-        r = lt % width # remaining segment not full width wide
+        r = lt % width  # remaining segment not full width wide
         if r:
-            linestarts = range( r, lt, width )
+            linestarts = range(r, lt, width)
             return [
                 # right-align the remaining segment on 1st line
-                [(width-r,None),(r, 0, r)]
+                [(width - r, None), (r, 0, r)]
                 # fill the rest of the lines
-                ] + [[(width, x, x+width)] for x in linestarts]
-        else:
-            linestarts = range( 0, lt, width )
-            return [[(width, x, x+width)] for x in linestarts]
+            ] + [[(width, x, x + width)] for x in linestarts]
+
+        linestarts = range(0, lt, width)
+        return [[(width, x, x + width)] for x in linestarts]
 
 
-if __name__=="__main__":
+if __name__ == "__main__":
     main()

--- a/examples/graph.py
+++ b/examples/graph.py
@@ -29,17 +29,20 @@ from __future__ import annotations
 
 import math
 import time
+import typing
 
 import urwid
 
 UPDATE_INTERVAL = 0.2
 
-def sin100( x ):
+
+def sin100(x):
     """
     A sin function that returns values between 0 and 100 and repeats
     after x == 100.
     """
-    return 50 + 50 * math.sin( x * math.pi / 50 )
+    return 50 + 50 * math.sin(x * math.pi / 50)
+
 
 class GraphModel:
     """
@@ -50,14 +53,13 @@ class GraphModel:
     data_max_value = 100
 
     def __init__(self):
-        data = [ ('Saw', list(range(0,100,2))*2),
-            ('Square', [0]*30 + [100]*30),
-            ('Sine 1', [sin100(x) for x in range(100)] ),
-            ('Sine 2', [(sin100(x) + sin100(x*2))/2
-                for x in range(100)] ),
-            ('Sine 3', [(sin100(x) + sin100(x*3))/2
-                for x in range(100)] ),
-            ]
+        data = [
+            ("Saw", list(range(0, 100, 2)) * 2),
+            ("Square", [0] * 30 + [100] * 30),
+            ("Sine 1", [sin100(x) for x in range(100)]),
+            ("Sine 2", [(sin100(x) + sin100(x * 2)) / 2 for x in range(100)]),
+            ("Sine 3", [(sin100(x) + sin100(x * 3)) / 2 for x in range(100)]),
+        ]
         self.modes = []
         self.data = {}
         for m, d in data:
@@ -76,15 +78,15 @@ class GraphModel:
         for items returned, and the offset at which the data
         repeats.
         """
-        l = []
+        lines = []
         d = self.data[self.current_mode]
         while r:
             offset = offset % len(d)
-            segment = d[offset:offset+r]
+            segment = d[offset : offset + r]
             r -= len(segment)
             offset += len(segment)
-            l += segment
-        return l, self.data_max_value, len(d)
+            lines += segment
+        return lines, self.data_max_value, len(d)
 
 
 class GraphView(urwid.WidgetWrap):
@@ -92,24 +94,25 @@ class GraphView(urwid.WidgetWrap):
     A class responsible for providing the application's interface and
     graph display.
     """
-    palette = [
-        ('body',         'black',      'light gray', 'standout'),
-        ('header',       'white',      'dark red',   'bold'),
-        ('screen edge',  'light blue', 'dark cyan'),
-        ('main shadow',  'dark gray',  'black'),
-        ('line',         'black',      'light gray', 'standout'),
-        ('bg background','light gray', 'black'),
-        ('bg 1',         'black',      'dark blue', 'standout'),
-        ('bg 1 smooth',  'dark blue',  'black'),
-        ('bg 2',         'black',      'dark cyan', 'standout'),
-        ('bg 2 smooth',  'dark cyan',  'black'),
-        ('button normal','light gray', 'dark blue', 'standout'),
-        ('button select','white',      'dark green'),
-        ('line',         'black',      'light gray', 'standout'),
-        ('pg normal',    'white',      'black', 'standout'),
-        ('pg complete',  'white',      'dark magenta'),
-        ('pg smooth',     'dark magenta','black')
-        ]
+
+    palette: typing.ClassVar[tuple[str, str, str, ...]] = [
+        ("body", "black", "light gray", "standout"),
+        ("header", "white", "dark red", "bold"),
+        ("screen edge", "light blue", "dark cyan"),
+        ("main shadow", "dark gray", "black"),
+        ("line", "black", "light gray", "standout"),
+        ("bg background", "light gray", "black"),
+        ("bg 1", "black", "dark blue", "standout"),
+        ("bg 1 smooth", "dark blue", "black"),
+        ("bg 2", "black", "dark cyan", "standout"),
+        ("bg 2 smooth", "dark cyan", "black"),
+        ("button normal", "light gray", "dark blue", "standout"),
+        ("button select", "white", "dark green"),
+        ("line", "black", "light gray", "standout"),
+        ("pg normal", "white", "black", "standout"),
+        ("pg complete", "white", "dark magenta"),
+        ("pg smooth", "dark magenta", "black"),
+    ]
 
     graph_samples_per_bar = 10
     graph_num_bars = 5
@@ -121,7 +124,7 @@ class GraphView(urwid.WidgetWrap):
         self.start_time = None
         self.offset = 0
         self.last_offset = None
-        urwid.WidgetWrap.__init__(self, self.main_window())
+        super().__init__(self.main_window())
 
     def get_offset_now(self):
         if self.start_time is None:
@@ -129,7 +132,7 @@ class GraphView(urwid.WidgetWrap):
         if not self.started:
             return self.offset
         tdelta = time.time() - self.start_time
-        return int(self.offset + (tdelta*self.graph_offset_per_second))
+        return int(self.offset + (tdelta * self.graph_offset_per_second))
 
     def update_graph(self, force_update=False):
         o = self.get_offset_now()
@@ -138,42 +141,41 @@ class GraphView(urwid.WidgetWrap):
         self.last_offset = o
         gspb = self.graph_samples_per_bar
         r = gspb * self.graph_num_bars
-        d, max_value, repeat = self.controller.get_data( o, r )
-        l = []
+        d, max_value, repeat = self.controller.get_data(o, r)
+        lines = []
         for n in range(self.graph_num_bars):
-            value = sum(d[n*gspb:(n+1)*gspb])/gspb
+            value = sum(d[n * gspb : (n + 1) * gspb]) / gspb
             # toggle between two bar types
             if n & 1:
-                l.append([0,value])
+                lines.append([0, value])
             else:
-                l.append([value,0])
-        self.graph.set_data(l,max_value)
+                lines.append([value, 0])
+        self.graph.set_data(lines, max_value)
 
         # also update progress
-        if (o//repeat)&1:
+        if (o // repeat) & 1:
             # show 100% for first half, 0 for second half
-            if o%repeat > repeat//2:
+            if o % repeat > repeat // 2:
                 prog = 0
             else:
                 prog = 1
         else:
-            prog = float(o%repeat) / repeat
-        self.animate_progress.set_completion( prog )
+            prog = float(o % repeat) / repeat
+        self.animate_progress.set_completion(prog)
         return True
 
     def on_animate_button(self, button):
         """Toggle started state and button text."""
-        if self.started: # stop animation
-            button.set_label("Start")
+        if self.started:  # stop animation
+            button.base_widget.set_label("Start")
             self.offset = self.get_offset_now()
             self.started = False
             self.controller.stop_animation()
         else:
-            button.set_label("Stop")
+            button.base_widget.set_label("Stop")
             self.started = True
             self.start_time = time.time()
             self.controller.animate_graph()
-
 
     def on_reset_button(self, w):
         self.offset = 0
@@ -184,62 +186,55 @@ class GraphView(urwid.WidgetWrap):
         """Notify the controller of a new mode setting."""
         if state:
             # The new mode is the label of the button
-            self.controller.set_mode( button.get_label() )
+            self.controller.set_mode(button.get_label())
         self.last_offset = None
 
     def on_mode_change(self, m):
         """Handle external mode change by updating radio buttons."""
         for rb in self.mode_buttons:
-            if rb.get_label() == m:
-                rb.set_state(True, do_callback=False)
+            if rb.base_widget.label == m:
+                rb.base_widget.set_state(True, do_callback=False)
                 break
         self.last_offset = None
 
     def on_unicode_checkbox(self, w, state):
-        self.graph = self.bar_graph( state )
+        self.graph = self.bar_graph(state)
         self.graph_wrap._w = self.graph
-        self.animate_progress = self.progress_bar( state )
+        self.animate_progress = self.progress_bar(state)
         self.animate_progress_wrap._w = self.animate_progress
-        self.update_graph( True )
-
+        self.update_graph(True)
 
     def main_shadow(self, w):
         """Wrap a shadow and background around widget w."""
-        bg = urwid.AttrWrap(urwid.SolidFill("\u2592"), 'screen edge')
-        shadow = urwid.AttrWrap(urwid.SolidFill(" "), 'main shadow')
+        bg = urwid.AttrMap(urwid.SolidFill("\u2592"), "screen edge")
+        shadow = urwid.AttrMap(urwid.SolidFill(" "), "main shadow")
 
-        bg = urwid.Overlay( shadow, bg,
-            ('fixed left', 3), ('fixed right', 1),
-            ('fixed top', 2), ('fixed bottom', 1))
-        w = urwid.Overlay( w, bg,
-            ('fixed left', 2), ('fixed right', 3),
-            ('fixed top', 1), ('fixed bottom', 2))
+        bg = urwid.Overlay(shadow, bg, ("fixed left", 3), ("fixed right", 1), ("fixed top", 2), ("fixed bottom", 1))
+        w = urwid.Overlay(w, bg, ("fixed left", 2), ("fixed right", 3), ("fixed top", 1), ("fixed bottom", 2))
         return w
 
     def bar_graph(self, smooth=False):
         satt = None
         if smooth:
-            satt = {(1,0): 'bg 1 smooth', (2,0): 'bg 2 smooth'}
-        w = urwid.BarGraph(['bg background','bg 1','bg 2'], satt=satt)
+            satt = {(1, 0): "bg 1 smooth", (2, 0): "bg 2 smooth"}
+        w = urwid.BarGraph(["bg background", "bg 1", "bg 2"], satt=satt)
         return w
 
     def button(self, t, fn):
         w = urwid.Button(t, fn)
-        w = urwid.AttrWrap(w, 'button normal', 'button select')
+        w = urwid.AttrMap(w, "button normal", "button select")
         return w
 
-    def radio_button(self, g, l, fn):
-        w = urwid.RadioButton(g, l, False, on_state_change=fn)
-        w = urwid.AttrWrap(w, 'button normal', 'button select')
+    def radio_button(self, g, label, fn):
+        w = urwid.RadioButton(g, label, False, on_state_change=fn)
+        w = urwid.AttrMap(w, "button normal", "button select")
         return w
 
     def progress_bar(self, smooth=False):
         if smooth:
-            return urwid.ProgressBar('pg normal', 'pg complete',
-                0, 1, 'pg smooth')
-        else:
-            return urwid.ProgressBar('pg normal', 'pg complete',
-                0, 1)
+            return urwid.ProgressBar("pg normal", "pg complete", 0, 1, "pg smooth")
+
+        return urwid.ProgressBar("pg normal", "pg complete", 0, 1)
 
     def exit_program(self, w):
         raise urwid.ExitMainLoop()
@@ -250,55 +245,56 @@ class GraphView(urwid.WidgetWrap):
         self.mode_buttons = []
         group = []
         for m in modes:
-            rb = self.radio_button( group, m, self.on_mode_button )
-            self.mode_buttons.append( rb )
+            rb = self.radio_button(group, m, self.on_mode_button)
+            self.mode_buttons.append(rb)
         # setup animate button
-        self.animate_button = self.button( "", self.on_animate_button)
-        self.on_animate_button( self.animate_button )
+        self.animate_button = self.button("", self.on_animate_button)
+        self.on_animate_button(self.animate_button)
         self.offset = 0
         self.animate_progress = self.progress_bar()
-        animate_controls = urwid.GridFlow( [
-            self.animate_button,
-            self.button("Reset", self.on_reset_button),
-            ], 9, 2, 0, 'center')
+        animate_controls = urwid.GridFlow(
+            [
+                self.animate_button,
+                self.button("Reset", self.on_reset_button),
+            ],
+            9,
+            2,
+            0,
+            "center",
+        )
 
         if urwid.get_encoding_mode() == "utf8":
-            unicode_checkbox = urwid.CheckBox(
-                "Enable Unicode Graphics",
-                on_state_change=self.on_unicode_checkbox)
+            unicode_checkbox = urwid.CheckBox("Enable Unicode Graphics", on_state_change=self.on_unicode_checkbox)
         else:
-            unicode_checkbox = urwid.Text(
-                "UTF-8 encoding not detected")
+            unicode_checkbox = urwid.Text("UTF-8 encoding not detected")
 
-        self.animate_progress_wrap = urwid.WidgetWrap(
-            self.animate_progress)
+        self.animate_progress_wrap = urwid.WidgetWrap(self.animate_progress)
 
-        l = [    urwid.Text("Mode",align="center"),
-            ] + self.mode_buttons + [
+        lines = [
+            urwid.Text("Mode", align="center"),
+            *self.mode_buttons,
             urwid.Divider(),
-            urwid.Text("Animation",align="center"),
+            urwid.Text("Animation", align="center"),
             animate_controls,
             self.animate_progress_wrap,
             urwid.Divider(),
-            urwid.LineBox( unicode_checkbox ),
+            urwid.LineBox(unicode_checkbox),
             urwid.Divider(),
-            self.button("Quit", self.exit_program ),
-            ]
-        w = urwid.ListBox(urwid.SimpleListWalker(l))
+            self.button("Quit", self.exit_program),
+        ]
+        w = urwid.ListBox(urwid.SimpleListWalker(lines))
         return w
 
     def main_window(self):
         self.graph = self.bar_graph()
-        self.graph_wrap = urwid.WidgetWrap( self.graph )
-        vline = urwid.AttrWrap( urwid.SolidFill('\u2502'), 'line')
+        self.graph_wrap = urwid.WidgetWrap(self.graph)
+        vline = urwid.AttrMap(urwid.SolidFill("\u2502"), "line")
         c = self.graph_controls()
-        w = urwid.Columns([('weight',2,self.graph_wrap),
-            ('fixed',1,vline), c],
-            dividechars=1, focus_column=2)
-        w = urwid.Padding(w,('fixed left',1),('fixed right',0))
-        w = urwid.AttrWrap(w,'body')
+        w = urwid.Columns([("weight", 2, self.graph_wrap), ("fixed", 1, vline), c], dividechars=1, focus_column=2)
+        w = urwid.Padding(w, ("fixed left", 1), ("fixed right", 0))
+        w = urwid.AttrMap(w, "body")
         w = urwid.LineBox(w)
-        w = urwid.AttrWrap(w,'line')
+        w = urwid.AttrMap(w, "line")
         w = self.main_shadow(w)
         return w
 
@@ -308,15 +304,16 @@ class GraphController:
     A class responsible for setting up the model and view and running
     the application.
     """
+
     def __init__(self):
         self.animate_alarm = None
         self.model = GraphModel()
-        self.view = GraphView( self )
+        self.view = GraphView(self)
         # use the first mode as the default
         mode = self.get_modes()[0]
-        self.model.set_mode( mode )
+        self.model.set_mode(mode)
         # update the view
-        self.view.on_mode_change( mode )
+        self.view.on_mode_change(mode)
         self.view.update_graph(True)
 
     def get_modes(self):
@@ -325,14 +322,13 @@ class GraphController:
 
     def set_mode(self, m):
         """Allow our view to set the mode."""
-        rval = self.model.set_mode( m )
+        rval = self.model.set_mode(m)
         self.view.update_graph(True)
         return rval
 
-    def get_data(self, offset, range):
+    def get_data(self, offset, data_range):
         """Provide data to our view for the graph."""
-        return self.model.get_data( offset, range )
-
+        return self.model.get_data(offset, data_range)
 
     def main(self):
         self.loop = urwid.MainLoop(self.view, self.view.palette)
@@ -341,8 +337,7 @@ class GraphController:
     def animate_graph(self, loop=None, user_data=None):
         """update the graph and schedule the next update"""
         self.view.update_graph()
-        self.animate_alarm = self.loop.set_alarm_in(
-            UPDATE_INTERVAL, self.animate_graph)
+        self.animate_alarm = self.loop.set_alarm_in(UPDATE_INTERVAL, self.animate_graph)
 
     def stop_animation(self):
         """stop animating the graph"""
@@ -354,5 +349,6 @@ class GraphController:
 def main():
     GraphController().main()
 
-if '__main__'==__name__:
+
+if __name__ == "__main__":
     main()

--- a/examples/input_test.py
+++ b/examples/input_test.py
@@ -34,71 +34,68 @@ import urwid.web_display
 
 if urwid.web_display.is_web_request():
     Screen = urwid.web_display.Screen
+elif len(sys.argv) > 1 and sys.argv[1][:1] == "r":
+    Screen = urwid.raw_display.Screen
 else:
-    if len(sys.argv)>1 and sys.argv[1][:1] == "r":
-        Screen = urwid.raw_display.Screen
-    else:
-        Screen = urwid.curses_display.Screen
+    Screen = urwid.curses_display.Screen
+
 
 def key_test():
     screen = Screen()
     header = urwid.Text("Values from get_input(). Q exits.")
-    header = urwid.AttrWrap(header,'header')
+    header = urwid.AttrMap(header, "header")
     lw = urwid.SimpleListWalker([])
     listbox = urwid.ListBox(lw)
-    listbox = urwid.AttrWrap(listbox, 'listbox')
+    listbox = urwid.AttrMap(listbox, "listbox")
     top = urwid.Frame(listbox, header)
 
     def input_filter(keys, raw):
-        if 'q' in keys or 'Q' in keys:
+        if "q" in keys or "Q" in keys:
             raise urwid.ExitMainLoop
 
         t = []
-        a = []
         for k in keys:
-            if type(k) == tuple:
+            if isinstance(k, tuple):
                 out = []
                 for v in k:
                     if out:
-                        out += [', ']
-                    out += [('key',repr(v))]
-                t += ["("] + out + [")"]
+                        out += [", "]
+                    out += [("key", repr(v))]
+                t += ["(", *out, ")"]
             else:
-                t += ["'",('key',k),"' "]
+                t += ["'", ("key", k), "' "]
 
-        rawt = urwid.Text(", ".join(["%d"%r for r in raw]))
+        rawt = urwid.Text(", ".join(["%d" % r for r in raw]))
 
         if t:
-            lw.append(
-                urwid.Columns([
-                    ('weight',2,urwid.Text(t)),
-                    rawt])
-                )
-            listbox.set_focus(len(lw)-1,'above')
+            lw.append(urwid.Columns([("weight", 2, urwid.Text(t)), rawt]))
+            listbox.base_widget.set_focus(len(lw) - 1, "above")
         return keys
 
-    loop = urwid.MainLoop(top, [
-        ('header', 'black', 'dark cyan', 'standout'),
-        ('key', 'yellow', 'dark blue', 'bold'),
-        ('listbox', 'light gray', 'black' ),
-        ], screen, input_filter=input_filter)
+    loop = urwid.MainLoop(
+        top,
+        [
+            ("header", "black", "dark cyan", "standout"),
+            ("key", "yellow", "dark blue", "bold"),
+            ("listbox", "light gray", "black"),
+        ],
+        screen,
+        input_filter=input_filter,
+    )
 
     try:
-        old = screen.tty_signal_keys('undefined','undefined',
-            'undefined','undefined','undefined')
+        old = screen.tty_signal_keys("undefined", "undefined", "undefined", "undefined", "undefined")
         loop.run()
     finally:
         screen.tty_signal_keys(*old)
 
 
-
-
 def main():
-    urwid.web_display.set_preferences('Input Test')
+    urwid.web_display.set_preferences("Input Test")
     if urwid.web_display.handle_short_request():
         return
     key_test()
 
 
-if '__main__'==__name__ or urwid.web_display.is_web_request():
+if __name__ == "__main__" or urwid.web_display.is_web_request():
     main()

--- a/examples/pop_up.py
+++ b/examples/pop_up.py
@@ -2,43 +2,49 @@
 
 from __future__ import annotations
 
+import typing
+
 import urwid
 
 
 class PopUpDialog(urwid.WidgetWrap):
-    """A dialog that appears with nothing but a close button """
-    signals = ['close']
+    """A dialog that appears with nothing but a close button"""
+
+    signals: typing.ClassVar[list[str]] = ["close"]
+
     def __init__(self):
         close_button = urwid.Button("that's pretty cool")
-        urwid.connect_signal(close_button, 'click',
-            lambda button:self._emit("close"))
-        pile = urwid.Pile([urwid.Text(
-            "^^  I'm attached to the widget that opened me. "
-            "Try resizing the window!\n"), close_button])
+        urwid.connect_signal(close_button, "click", lambda button: self._emit("close"))
+        pile = urwid.Pile(
+            [
+                urwid.Text("^^  I'm attached to the widget that opened me. Try resizing the window!\n"),
+                close_button,
+            ]
+        )
         fill = urwid.Filler(pile)
-        super().__init__(urwid.AttrWrap(fill, 'popbg'))
+        super().__init__(urwid.AttrMap(fill, "popbg"))
 
 
 class ThingWithAPopUp(urwid.PopUpLauncher):
     def __init__(self):
         super().__init__(urwid.Button("click-me"))
-        urwid.connect_signal(self.original_widget, 'click',
-            lambda button: self.open_pop_up())
+        urwid.connect_signal(self.original_widget, "click", lambda button: self.open_pop_up())
 
     def create_pop_up(self):
         pop_up = PopUpDialog()
-        urwid.connect_signal(pop_up, 'close',
-            lambda button: self.close_pop_up())
+        urwid.connect_signal(pop_up, "close", lambda button: self.close_pop_up())
         return pop_up
 
     def get_pop_up_parameters(self):
-        return {'left':0, 'top':1, 'overlay_width':32, 'overlay_height':7}
+        return {"left": 0, "top": 1, "overlay_width": 32, "overlay_height": 7}
+
+    def keypress(self, key: str, size: tuple[int]) -> str | None:
+        parsed = super().keypress(key, size)
+        if parsed in ("q", "Q"):
+            raise urwid.ExitMainLoop("Done")
+        return parsed
 
 
-fill = urwid.Filler(urwid.Padding(ThingWithAPopUp(), 'center', 15))
-loop = urwid.MainLoop(
-    fill,
-    [('popbg', 'white', 'dark blue')],
-    pop_ups=True)
+fill = urwid.Filler(urwid.Padding(ThingWithAPopUp(), "center", 15))
+loop = urwid.MainLoop(fill, [("popbg", "white", "dark blue")], pop_ups=True)
 loop.run()
-

--- a/examples/tour.py
+++ b/examples/tour.py
@@ -31,114 +31,138 @@ import urwid.web_display
 
 
 def main():
-    text_header = ("Welcome to the urwid tour!  "
-        "UP / DOWN / PAGE UP / PAGE DOWN scroll.  F8 exits.")
-    text_intro = [('important', "Text"),
+    text_header = "Welcome to the urwid tour!  UP / DOWN / PAGE UP / PAGE DOWN scroll.  F8 exits."
+    text_intro = [
+        ("important", "Text"),
         " widgets are the most common in "
         "any urwid program.  This Text widget was created "
         "without setting the wrap or align mode, so it "
         "defaults to left alignment with wrapping on space "
         "characters.  ",
-        ('important', "Change the window width"),
-        " to see how the widgets on this page react.  "
-        "This Text widget is wrapped with a ",
-        ('important', "Padding"),
-        " widget to keep it indented on the left and right."]
-    text_right = ("This Text widget is right aligned.  Wrapped "
-        "words stay to the right as well. ")
+        ("important", "Change the window width"),
+        " to see how the widgets on this page react.  This Text widget is wrapped with a ",
+        ("important", "Padding"),
+        " widget to keep it indented on the left and right.",
+    ]
+    text_right = "This Text widget is right aligned.  Wrapped words stay to the right as well. "
     text_center = "This one is center aligned."
-    text_clip = ("Text widgets may be clipped instead of wrapped.\n"
+    text_clip = (
+        "Text widgets may be clipped instead of wrapped.\n"
         "Extra text is discarded instead of wrapped to the next line. "
         "65-> 70-> 75-> 80-> 85-> 90-> 95-> 100>\n"
-        "Newlines embedded in the string are still respected.")
-    text_right_clip = ("This is a right aligned and clipped Text widget.\n"
-        "<100 <-95 <-90 <-85 <-80 <-75 <-70 <-65             "
-        "Text will be cut off at the left of this widget.")
-    text_center_clip = ("Center aligned and clipped widgets will have "
-        "text cut off both sides.")
-    text_ellipsis = ("Text can be clipped using the ellipsis character (…)\n"
-        "Extra text is discarded and a … mark is shown."
-         "50-> 55-> 60-> 65-> 70-> 75-> 80-> 85-> 90-> 95-> 100>\n"
+        "Newlines embedded in the string are still respected."
     )
-    text_any = ("The 'any' wrap mode will wrap on any character.  This "
+    text_right_clip = (
+        "This is a right aligned and clipped Text widget.\n"
+        "<100 <-95 <-90 <-85 <-80 <-75 <-70 <-65             "
+        "Text will be cut off at the left of this widget."
+    )
+    text_center_clip = "Center aligned and clipped widgets will have text cut off both sides."
+    text_ellipsis = (
+        "Text can be clipped using the ellipsis character (…)\n"
+        "Extra text is discarded and a … mark is shown."
+        "50-> 55-> 60-> 65-> 70-> 75-> 80-> 85-> 90-> 95-> 100>\n"
+    )
+    text_any = (
+        "The 'any' wrap mode will wrap on any character.  This "
         "mode will not collapse space characters at the end of the "
         "line but it still honors embedded newline characters.\n"
-        "Like this one.")
-    text_padding = ("Padding widgets have many options.  This "
+        "Like this one."
+    )
+    text_padding = (
+        "Padding widgets have many options.  This "
         "is a standard Text widget wrapped with a Padding widget "
         "with the alignment set to relative 20% and with its width "
-        "fixed at 40.")
-    text_divider =  ["The ", ('important', "Divider"),
-        " widget repeats the same character across the whole line.  "
-        "It can also add blank lines above and below."]
-    text_edit = ["The ", ('important', "Edit"),
+        "fixed at 40."
+    )
+    text_divider = [
+        "The ",
+        ("important", "Divider"),
+        " widget repeats the same character across the whole line.  It can also add blank lines above and below.",
+    ]
+    text_edit = [
+        "The ",
+        ("important", "Edit"),
         " widget is a simple text editing widget.  It supports cursor "
         "movement and tries to maintain the current column when focus "
         "moves to another edit widget.  It wraps and aligns the same "
-        "way as Text widgets." ]
-    text_edit_cap1 = ('editcp', "This is a caption.  Edit here: ")
+        "way as Text widgets.",
+    ]
+    text_edit_cap1 = ("editcp", "This is a caption.  Edit here: ")
     text_edit_text1 = "editable stuff"
-    text_edit_cap2 = ('editcp', "This one supports newlines: ")
-    text_edit_text2 = ("line one starts them all\n"
+    text_edit_cap2 = ("editcp", "This one supports newlines: ")
+    text_edit_text2 = (
+        "line one starts them all\n"
         "== line 2 == with some more text to edit.. words.. whee..\n"
         "LINE III, the line to end lines one and two, unless you "
-        "change something.")
-    text_edit_cap3 = ('editcp', "This one is clipped, try "
-        "editing past the edge: ")
+        "change something."
+    )
+    text_edit_cap3 = ("editcp", "This one is clipped, try editing past the edge: ")
     text_edit_text3 = "add some text here -> -> -> ...."
     text_edit_alignments = "Different Alignments:"
     text_edit_left = "left aligned (default)"
     text_edit_center = "center aligned"
     text_edit_right = "right aligned"
-    text_intedit = ('editcp', [('important', "IntEdit"),
-        " allows only numbers: "])
-    text_edit_padding = ('editcp', "Edit widget within a Padding widget ")
-    text_columns1 = [('important', "Columns"),
+    text_intedit = ("editcp", [("important", "IntEdit"), " allows only numbers: "])
+    text_edit_padding = ("editcp", "Edit widget within a Padding widget ")
+    text_columns1 = [
+        ("important", "Columns"),
         " are used to share horizontal screen space.  "
         "This one splits the space into two parts with "
         "three characters between each column.  The "
-        "contents of each column is a single widget."]
-    text_columns2 = ["When you need to put more than one "
-        "widget into a column you can use a ",('important',
-        "Pile"), " to combine two or more widgets."]
+        "contents of each column is a single widget.",
+    ]
+    text_columns2 = [
+        "When you need to put more than one widget into a column you can use a ",
+        ("important", "Pile"),
+        " to combine two or more widgets.",
+    ]
     text_col_columns = "Columns may be placed inside other columns."
     text_col_21 = "Col 2.1"
     text_col_22 = "Col 2.2"
     text_col_23 = "Col 2.3"
-    text_column_widths = ("Columns may also have uneven relative "
+    text_column_widths = (
+        "Columns may also have uneven relative "
         "weights or fixed widths.  Use a minimum width so that "
-        "columns don't become too small.")
+        "columns don't become too small."
+    )
     text_weight = "Weight %d"
-    text_fixed_9 = "<Fixed 9>" # should be 9 columns wide
-    text_fixed_14 = "<--Fixed 14-->" # should be 14 columns wide
-    text_edit_col_cap1 = ('editcp', "Edit widget within Columns")
+    text_fixed_9 = "<Fixed 9>"  # should be 9 columns wide
+    text_fixed_14 = "<--Fixed 14-->"  # should be 14 columns wide
+    text_edit_col_cap1 = ("editcp", "Edit widget within Columns")
     text_edit_col_text1 = "here's\nsome\ninfo"
-    text_edit_col_cap2 = ('editcp', "and within Pile ")
+    text_edit_col_cap2 = ("editcp", "and within Pile ")
     text_edit_col_text2 = "more"
-    text_edit_col_cap3 = ('editcp', "another ")
+    text_edit_col_cap3 = ("editcp", "another ")
     text_edit_col_text3 = "still more"
-    text_gridflow = ["A ",('important', "GridFlow"), " widget "
+    text_gridflow = [
+        "A ",
+        ("important", "GridFlow"),
+        " widget "
         "may be used to display a list of flow widgets with equal "
         "widths.  Widgets that don't fit on the first line will "
         "flow to the next.  This is useful for small widgets that "
-        "you want to keep together such as ", ('important', "Button"),
-        ", ",('important', "CheckBox"), " and ",
-        ('important', "RadioButton"), " widgets." ]
-    text_button_list = ["Yes", "No", "Perhaps", "Certainly", "Partially",
-        "Tuesdays Only", "Help"]
-    text_cb_list = ["Wax", "Wash", "Buff", "Clear Coat", "Dry",
-        "Racing Stripe"]
+        "you want to keep together such as ",
+        ("important", "Button"),
+        ", ",
+        ("important", "CheckBox"),
+        " and ",
+        ("important", "RadioButton"),
+        " widgets.",
+    ]
+    text_button_list = ["Yes", "No", "Perhaps", "Certainly", "Partially", "Tuesdays Only", "Help"]
+    text_cb_list = ["Wax", "Wash", "Buff", "Clear Coat", "Dry", "Racing Stripe"]
     text_rb_list = ["Morning", "Afternoon", "Evening", "Weekend"]
-    text_listbox = ["All these widgets have been displayed "
-        "with the help of a ", ('important', "ListBox"), " widget.  "
-        "ListBox widgets handle scrolling and changing focus.  A ",
-        ('important', "Frame"), " widget is used to keep the "
-        "instructions at the top of the screen."]
-
+    text_listbox = [
+        "All these widgets have been displayed with the help of a ",
+        ("important", "ListBox"),
+        " widget.  ListBox widgets handle scrolling and changing focus.  A ",
+        ("important", "Frame"),
+        " widget is used to keep the instructions at the top of the screen.",
+    ]
 
     def button_press(button):
-        frame.footer = urwid.AttrWrap(urwid.Text(
-            ["Pressed: ", button.get_label()]), 'header')
+        frame.footer = urwid.AttrMap(urwid.Text(["Pressed: ", button.get_label()]), "header")
 
     radio_button_group = []
 
@@ -147,172 +171,192 @@ def main():
         blank,
         urwid.Padding(urwid.Text(text_intro), left=2, right=2, min_width=20),
         blank,
-        urwid.Text(text_right, align='right'),
+        urwid.Text(text_right, align="right"),
         blank,
-        urwid.Text(text_center, align='center'),
+        urwid.Text(text_center, align="center"),
         blank,
-        urwid.Text(text_clip, wrap='clip'),
+        urwid.Text(text_clip, wrap="clip"),
         blank,
-        urwid.Text(text_right_clip, align='right', wrap='clip'),
+        urwid.Text(text_right_clip, align="right", wrap="clip"),
         blank,
-        urwid.Text(text_center_clip, align='center', wrap='clip'),
+        urwid.Text(text_center_clip, align="center", wrap="clip"),
         blank,
-        urwid.Text(text_ellipsis, wrap='ellipsis'),
+        urwid.Text(text_ellipsis, wrap="ellipsis"),
         blank,
-        urwid.Text(text_any, wrap='any'),
+        urwid.Text(text_any, wrap="any"),
         blank,
-        urwid.Padding(urwid.Text(text_padding), ('relative', 20), 40),
+        urwid.Padding(urwid.Text(text_padding), ("relative", 20), 40),
         blank,
-        urwid.AttrWrap(urwid.Divider("=", 1), 'bright'),
+        urwid.AttrMap(urwid.Divider("=", 1), "bright"),
         urwid.Padding(urwid.Text(text_divider), left=2, right=2, min_width=20),
-        urwid.AttrWrap(urwid.Divider("-", 0, 1), 'bright'),
+        urwid.AttrMap(urwid.Divider("-", 0, 1), "bright"),
         blank,
         urwid.Padding(urwid.Text(text_edit), left=2, right=2, min_width=20),
         blank,
-        urwid.AttrWrap(urwid.Edit(text_edit_cap1, text_edit_text1),
-            'editbx', 'editfc'),
+        urwid.AttrMap(urwid.Edit(text_edit_cap1, text_edit_text1), "editbx", "editfc"),
         blank,
-        urwid.AttrWrap(urwid.Edit(text_edit_cap2, text_edit_text2,
-            multiline=True ), 'editbx', 'editfc'),
+        urwid.AttrMap(urwid.Edit(text_edit_cap2, text_edit_text2, multiline=True), "editbx", "editfc"),
         blank,
-        urwid.AttrWrap(urwid.Edit(text_edit_cap3, text_edit_text3,
-            wrap='clip' ), 'editbx', 'editfc'),
+        urwid.AttrMap(urwid.Edit(text_edit_cap3, text_edit_text3, wrap="clip"), "editbx", "editfc"),
         blank,
         urwid.Text(text_edit_alignments),
-        urwid.AttrWrap(urwid.Edit("", text_edit_left, align='left'),
-            'editbx', 'editfc' ),
-        urwid.AttrWrap(urwid.Edit("", text_edit_center,
-            align='center'), 'editbx', 'editfc' ),
-        urwid.AttrWrap(urwid.Edit("", text_edit_right, align='right'),
-            'editbx', 'editfc' ),
+        urwid.AttrMap(urwid.Edit("", text_edit_left, align="left"), "editbx", "editfc"),
+        urwid.AttrMap(urwid.Edit("", text_edit_center, align="center"), "editbx", "editfc"),
+        urwid.AttrMap(urwid.Edit("", text_edit_right, align="right"), "editbx", "editfc"),
         blank,
-        urwid.AttrWrap(urwid.IntEdit(text_intedit, 123),
-            'editbx', 'editfc' ),
+        urwid.AttrMap(urwid.IntEdit(text_intedit, 123), "editbx", "editfc"),
         blank,
-        urwid.Padding(urwid.AttrWrap(urwid.Edit(text_edit_padding, ""),
-            'editbx','editfc' ), left=10, width=50),
+        urwid.Padding(urwid.AttrMap(urwid.Edit(text_edit_padding, ""), "editbx", "editfc"), left=10, width=50),
         blank,
         blank,
-        urwid.AttrWrap(urwid.Columns([
-            urwid.Divider("."),
-            urwid.Divider(","),
-            urwid.Divider("."),
-            ]), 'bright'),
+        urwid.AttrMap(
+            urwid.Columns(
+                [
+                    urwid.Divider("."),
+                    urwid.Divider(","),
+                    urwid.Divider("."),
+                ]
+            ),
+            "bright",
+        ),
         blank,
-        urwid.Columns([
-            urwid.Padding(urwid.Text(text_columns1), left=2, right=0,
-                min_width=20),
-            urwid.Pile([
-                urwid.Divider("~"),
-                urwid.Text(text_columns2),
-                urwid.Divider("_")])
-            ], 3),
-        blank,
-        blank,
-        urwid.Columns([
-            urwid.Text(text_col_columns),
-            urwid.Columns([
-                urwid.Text(text_col_21),
-                urwid.Text(text_col_22),
-                urwid.Text(text_col_23),
-                ], 1),
-            ], 2),
-        blank,
-        urwid.Padding(urwid.Text(text_column_widths), left=2, right=2,
-            min_width=20),
-        blank,
-        urwid.Columns( [
-            urwid.AttrWrap(urwid.Text(text_weight % 1),'reverse'),
-            ('weight', 2, urwid.Text(text_weight % 2)),
-            ('weight', 3, urwid.AttrWrap(urwid.Text(
-                text_weight % 3), 'reverse')),
-            ('weight', 4, urwid.Text(text_weight % 4)),
-            ('weight', 5, urwid.AttrWrap(urwid.Text(
-                text_weight % 5), 'reverse')),
-            ('weight', 6, urwid.Text(text_weight % 6)),
-            ], 0, min_width=8),
-        blank,
-        urwid.Columns([
-            ('weight', 2, urwid.AttrWrap(urwid.Text(
-                text_weight % 2), 'reverse')),
-            ('fixed', 9, urwid.Text(text_fixed_9)),
-            ('weight', 3, urwid.AttrWrap(urwid.Text(
-                text_weight % 3), 'reverse')),
-            ('fixed', 14, urwid.Text(text_fixed_14)),
-            ], 0, min_width=8),
-        blank,
-        urwid.Columns([
-            urwid.AttrWrap(urwid.Edit(text_edit_col_cap1,
-                text_edit_col_text1, multiline=True),
-                'editbx','editfc'),
-            urwid.Pile([
-                urwid.AttrWrap(urwid.Edit(
-                    text_edit_col_cap2,
-                    text_edit_col_text2),
-                    'editbx','editfc'),
-                blank,
-                urwid.AttrWrap(urwid.Edit(
-                    text_edit_col_cap3,
-                    text_edit_col_text3),
-                    'editbx','editfc'),
-                ]),
-            ], 1),
-        blank,
-        urwid.AttrWrap(urwid.Columns([
-            urwid.Divider("'"),
-            urwid.Divider('"'),
-            urwid.Divider("~"),
-            urwid.Divider('"'),
-            urwid.Divider("'"),
-            ]), 'bright'),
+        urwid.Columns(
+            [
+                urwid.Padding(urwid.Text(text_columns1), left=2, right=0, min_width=20),
+                urwid.Pile([urwid.Divider("~"), urwid.Text(text_columns2), urwid.Divider("_")]),
+            ],
+            3,
+        ),
         blank,
         blank,
-        urwid.Padding(urwid.Text(text_gridflow), left=2, right=2,
-            min_width=20),
+        urwid.Columns(
+            [
+                urwid.Text(text_col_columns),
+                urwid.Columns(
+                    [
+                        urwid.Text(text_col_21),
+                        urwid.Text(text_col_22),
+                        urwid.Text(text_col_23),
+                    ],
+                    1,
+                ),
+            ],
+            2,
+        ),
         blank,
-        urwid.Padding(urwid.GridFlow(
-            [urwid.AttrWrap(urwid.Button(txt, button_press),
-                'buttn','buttnf') for txt in text_button_list],
-            13, 3, 1, 'left'),
-            left=4, right=3, min_width=13),
+        urwid.Padding(urwid.Text(text_column_widths), left=2, right=2, min_width=20),
         blank,
-        urwid.Padding(urwid.GridFlow(
-            [urwid.AttrWrap(urwid.CheckBox(txt),'buttn','buttnf')
-                for txt in text_cb_list],
-            10, 3, 1, 'left') ,
-            left=4, right=3, min_width=10),
+        urwid.Columns(
+            [
+                urwid.AttrMap(urwid.Text(text_weight % 1), "reverse"),
+                ("weight", 2, urwid.Text(text_weight % 2)),
+                ("weight", 3, urwid.AttrMap(urwid.Text(text_weight % 3), "reverse")),
+                ("weight", 4, urwid.Text(text_weight % 4)),
+                ("weight", 5, urwid.AttrMap(urwid.Text(text_weight % 5), "reverse")),
+                ("weight", 6, urwid.Text(text_weight % 6)),
+            ],
+            0,
+            min_width=8,
+        ),
         blank,
-        urwid.Padding(urwid.GridFlow(
-            [urwid.AttrWrap(urwid.RadioButton(radio_button_group,
-                txt), 'buttn','buttnf')
-                for txt in text_rb_list],
-            13, 3, 1, 'left') ,
-            left=4, right=3, min_width=13),
+        urwid.Columns(
+            [
+                ("weight", 2, urwid.AttrMap(urwid.Text(text_weight % 2), "reverse")),
+                ("fixed", 9, urwid.Text(text_fixed_9)),
+                ("weight", 3, urwid.AttrMap(urwid.Text(text_weight % 3), "reverse")),
+                ("fixed", 14, urwid.Text(text_fixed_14)),
+            ],
+            0,
+            min_width=8,
+        ),
+        blank,
+        urwid.Columns(
+            [
+                urwid.AttrMap(urwid.Edit(text_edit_col_cap1, text_edit_col_text1, multiline=True), "editbx", "editfc"),
+                urwid.Pile(
+                    [
+                        urwid.AttrMap(urwid.Edit(text_edit_col_cap2, text_edit_col_text2), "editbx", "editfc"),
+                        blank,
+                        urwid.AttrMap(urwid.Edit(text_edit_col_cap3, text_edit_col_text3), "editbx", "editfc"),
+                    ]
+                ),
+            ],
+            1,
+        ),
+        blank,
+        urwid.AttrMap(
+            urwid.Columns(
+                [
+                    urwid.Divider("'"),
+                    urwid.Divider('"'),
+                    urwid.Divider("~"),
+                    urwid.Divider('"'),
+                    urwid.Divider("'"),
+                ]
+            ),
+            "bright",
+        ),
         blank,
         blank,
-        urwid.Padding(urwid.Text(text_listbox), left=2, right=2,
-            min_width=20),
+        urwid.Padding(urwid.Text(text_gridflow), left=2, right=2, min_width=20),
+        blank,
+        urwid.Padding(
+            urwid.GridFlow(
+                [urwid.AttrMap(urwid.Button(txt, button_press), "buttn", "buttnf") for txt in text_button_list],
+                13,
+                3,
+                1,
+                "left",
+            ),
+            left=4,
+            right=3,
+            min_width=13,
+        ),
+        blank,
+        urwid.Padding(
+            urwid.GridFlow(
+                [urwid.AttrMap(urwid.CheckBox(txt), "buttn", "buttnf") for txt in text_cb_list], 10, 3, 1, "left"
+            ),
+            left=4,
+            right=3,
+            min_width=10,
+        ),
+        blank,
+        urwid.Padding(
+            urwid.GridFlow(
+                [urwid.AttrMap(urwid.RadioButton(radio_button_group, txt), "buttn", "buttnf") for txt in text_rb_list],
+                13,
+                3,
+                1,
+                "left",
+            ),
+            left=4,
+            right=3,
+            min_width=13,
+        ),
         blank,
         blank,
-        ]
+        urwid.Padding(urwid.Text(text_listbox), left=2, right=2, min_width=20),
+        blank,
+        blank,
+    ]
 
-    header = urwid.AttrWrap(urwid.Text(text_header), 'header')
+    header = urwid.AttrMap(urwid.Text(text_header), "header")
     listbox = urwid.ListBox(urwid.SimpleListWalker(listbox_content))
-    frame = urwid.Frame(urwid.AttrWrap(listbox, 'body'), header=header)
+    frame = urwid.Frame(urwid.AttrMap(listbox, "body"), header=header)
 
     palette = [
-        ('body','black','light gray', 'standout'),
-        ('reverse','light gray','black'),
-        ('header','white','dark red', 'bold'),
-        ('important','dark blue','light gray',('standout','underline')),
-        ('editfc','white', 'dark blue', 'bold'),
-        ('editbx','light gray', 'dark blue'),
-        ('editcp','black','light gray', 'standout'),
-        ('bright','dark gray','light gray', ('bold','standout')),
-        ('buttn','black','dark cyan'),
-        ('buttnf','white','dark blue','bold'),
-        ]
-
+        ("body", "black", "light gray", "standout"),
+        ("reverse", "light gray", "black"),
+        ("header", "white", "dark red", "bold"),
+        ("important", "dark blue", "light gray", ("standout", "underline")),
+        ("editfc", "white", "dark blue", "bold"),
+        ("editbx", "light gray", "dark blue"),
+        ("editcp", "black", "light gray", "standout"),
+        ("bright", "dark gray", "light gray", ("bold", "standout")),
+        ("buttn", "black", "dark cyan"),
+        ("buttnf", "white", "dark blue", "bold"),
+    ]
 
     # use appropriate Screen class
     if urwid.web_display.is_web_request():
@@ -321,11 +365,11 @@ def main():
         screen = urwid.raw_display.Screen()
 
     def unhandled(key):
-        if key == 'f8':
+        if key == "f8":
             raise urwid.ExitMainLoop()
 
-    urwid.MainLoop(frame, palette, screen,
-        unhandled_input=unhandled).run()
+    urwid.MainLoop(frame, palette, screen, unhandled_input=unhandled).run()
+
 
 def setup():
     urwid.web_display.set_preferences("Urwid Tour")
@@ -335,5 +379,6 @@ def setup():
 
     main()
 
-if '__main__'==__name__ or urwid.web_display.is_web_request():
+
+if __name__ == "__main__" or urwid.web_display.is_web_request():
     setup()

--- a/examples/treesample.py
+++ b/examples/treesample.py
@@ -33,35 +33,40 @@ Features:
 
 from __future__ import annotations
 
+import typing
+
 import urwid
 
 
 class ExampleTreeWidget(urwid.TreeWidget):
-    """ Display widget for leaf nodes """
+    """Display widget for leaf nodes"""
+
     def get_display_text(self):
-        return self.get_node().get_value()['name']
+        return self.get_node().get_value()["name"]
 
 
 class ExampleNode(urwid.TreeNode):
-    """ Data storage object for leaf nodes """
+    """Data storage object for leaf nodes"""
+
     def load_widget(self):
         return ExampleTreeWidget(self)
 
 
 class ExampleParentNode(urwid.ParentNode):
-    """ Data storage object for interior/parent nodes """
+    """Data storage object for interior/parent nodes"""
+
     def load_widget(self):
         return ExampleTreeWidget(self)
 
     def load_child_keys(self):
         data = self.get_value()
-        return range(len(data['children']))
+        return range(len(data["children"]))
 
     def load_child_node(self, key):
         """Return either an ExampleNode or ExampleParentNode"""
-        childdata = self.get_value()['children'][key]
+        childdata = self.get_value()["children"][key]
         childdepth = self.get_depth() + 1
-        if 'children' in childdata:
+        if "children" in childdata:
             childclass = ExampleParentNode
         else:
             childclass = ExampleNode
@@ -69,63 +74,70 @@ class ExampleParentNode(urwid.ParentNode):
 
 
 class ExampleTreeBrowser:
-    palette = [
-        ('body', 'black', 'light gray'),
-        ('focus', 'light gray', 'dark blue', 'standout'),
-        ('head', 'yellow', 'black', 'standout'),
-        ('foot', 'light gray', 'black'),
-        ('key', 'light cyan', 'black','underline'),
-        ('title', 'white', 'black', 'bold'),
-        ('flag', 'dark gray', 'light gray'),
-        ('error', 'dark red', 'light gray'),
-        ]
+    palette: typing.ClassVar[tuple[str, str, str, ...]] = [
+        ("body", "black", "light gray"),
+        ("focus", "light gray", "dark blue", "standout"),
+        ("head", "yellow", "black", "standout"),
+        ("foot", "light gray", "black"),
+        ("key", "light cyan", "black", "underline"),
+        ("title", "white", "black", "bold"),
+        ("flag", "dark gray", "light gray"),
+        ("error", "dark red", "light gray"),
+    ]
 
-    footer_text = [
-        ('title', "Example Data Browser"), "    ",
-        ('key', "UP"), ",", ('key', "DOWN"), ",",
-        ('key', "PAGE UP"), ",", ('key', "PAGE DOWN"),
+    footer_text: typing.ClassVar[list[tuple[str, str] | str]] = [
+        ("title", "Example Data Browser"),
+        "    ",
+        ("key", "UP"),
+        ",",
+        ("key", "DOWN"),
+        ",",
+        ("key", "PAGE UP"),
+        ",",
+        ("key", "PAGE DOWN"),
         "  ",
-        ('key', "+"), ",",
-        ('key', "-"), "  ",
-        ('key', "LEFT"), "  ",
-        ('key', "HOME"), "  ",
-        ('key', "END"), "  ",
-        ('key', "Q"),
-        ]
+        ("key", "+"),
+        ",",
+        ("key", "-"),
+        "  ",
+        ("key", "LEFT"),
+        "  ",
+        ("key", "HOME"),
+        "  ",
+        ("key", "END"),
+        "  ",
+        ("key", "Q"),
+    ]
 
     def __init__(self, data=None):
         self.topnode = ExampleParentNode(data)
         self.listbox = urwid.TreeListBox(urwid.TreeWalker(self.topnode))
         self.listbox.offset_rows = 1
-        self.header = urwid.Text( "" )
-        self.footer = urwid.AttrWrap( urwid.Text( self.footer_text ),
-            'foot')
+        self.header = urwid.Text("")
+        self.footer = urwid.AttrMap(urwid.Text(self.footer_text), "foot")
         self.view = urwid.Frame(
-            urwid.AttrWrap( self.listbox, 'body' ),
-            header=urwid.AttrWrap(self.header, 'head' ),
-            footer=self.footer )
+            urwid.AttrMap(self.listbox, "body"), header=urwid.AttrMap(self.header, "head"), footer=self.footer
+        )
 
     def main(self):
         """Run the program."""
 
-        self.loop = urwid.MainLoop(self.view, self.palette,
-            unhandled_input=self.unhandled_input)
+        self.loop = urwid.MainLoop(self.view, self.palette, unhandled_input=self.unhandled_input)
         self.loop.run()
 
     def unhandled_input(self, k):
-        if k in ('q','Q'):
+        if k in ("q", "Q"):
             raise urwid.ExitMainLoop()
 
 
 def get_example_tree():
-    """ generate a quick 100 leaf tree for demo purposes """
-    retval = {"name":"parent","children":[]}
+    """generate a quick 100 leaf tree for demo purposes"""
+    retval = {"name": "parent", "children": []}
     for i in range(10):
-        retval['children'].append({"name":f"child {str(i)}"})
-        retval['children'][i]['children']=[]
+        retval["children"].append({"name": f"child {i!s}"})
+        retval["children"][i]["children"] = []
         for j in range(10):
-            retval['children'][i]['children'].append({"name":"grandchild " +
-                                                      str(i) + "." + str(j)})
+            retval["children"][i]["children"].append({"name": "grandchild " + str(i) + "." + str(j)})
     return retval
 
 
@@ -134,6 +146,5 @@ def main():
     ExampleTreeBrowser(sample).main()
 
 
-if __name__=="__main__":
+if __name__ == "__main__":
     main()
-

--- a/urwid/widget/attr_wrap.py
+++ b/urwid/widget/attr_wrap.py
@@ -33,6 +33,11 @@ class AttrWrap(AttrMap):
         >>> next(aw.render(size, focus=True).content())
         [('fgreet', None, ...'hi   ')]
         """
+        warnings.warn(
+            "AttrWrap is maintained for backwards compatibility only, new code should use AttrMap instead.",
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__(w, attr, focus_attr)
 
     def _repr_attrs(self):


### PR DESCRIPTION
* `AttrWrap` was marked as deprecated in documentation, but not handled in tests/runtime

* Migrate examples from `AttrWrap` to `AttrMap` and apply auto-format

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

