### PR TITLE
Documentation: do not use `FlowWidget` as base class in examples

### DIFF
--- a/examples/lcd_cf635.py
+++ b/examples/lcd_cf635.py
@@ -81,13 +81,15 @@ class LCDRadioButton(urwid.RadioButton):
     reserve_columns = 1
 
 
-class LCDProgressBar(urwid.FlowWidget):
+class LCDProgressBar(urwid.Widget):
     """
     The "progress bar" used by the horizontal slider for this device,
     using custom CGRAM characters
     """
 
     segments = "\x00\x01\x02\x03"
+
+    _sizing = frozenset([urwid.Sizing.FLOW])
 
     def __init__(self, data_range, value):
         self.range = data_range


### PR DESCRIPTION
`FlowWidget` is deprecated

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
*(P. S. If this pull requests fixes an existing issue, please specify which one.)*

