### PR TITLE
Documentation: Prepare release 2.2.2

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -8,5 +8,7 @@
       - "!.github/workflows/**"
 
 "docs":
-  - all:
+  - any:
       - "docs/**"
+      - "examples/**"
+      - "README.rst"

--- a/README.rst
+++ b/README.rst
@@ -77,6 +77,7 @@ Maintainers
 `and3rson <//github.com/and3rson>`_,
 `tonycpsu <//github.com/tonycpsu>`_,
 `ulidtko <//github.com/ulidtko>`_
+`penguinolog <//github.com/penguinolog>`_
 
 Contributors
 ------------
@@ -223,14 +224,13 @@ Contributors
     :alt: current version on PyPi
     :target: https://pypi.python.org/pypi/urwid
 
-.. |docs| image:: https://readthedocs.org/projects/urwid/badge/?version=latest
+.. |docs| image:: hhttps://github.com/urwid/urwid/actions/workflows/documentation.yml/badge.svg?branch=master
     :alt: Documentation Status
-    :target: https://urwid.readthedocs.io/en/latest/?badge=latest
+    :target: https://urwid.org
 
 .. |ci| image:: https://github.com/urwid/urwid/actions/workflows/pythonpackage.yml/badge.svg?branch=master
     :target: https://github.com/urwid/urwid/actions
     :alt: CI status
-
 
 .. |coveralls| image:: https://coveralls.io/repos/github/urwid/urwid/badge.svg
     :alt: test coverage

--- a/README.rst
+++ b/README.rst
@@ -224,7 +224,7 @@ Contributors
     :alt: current version on PyPi
     :target: https://pypi.python.org/pypi/urwid
 
-.. |docs| image:: hhttps://github.com/urwid/urwid/actions/workflows/documentation.yml/badge.svg?branch=master
+.. |docs| image:: https://github.com/urwid/urwid/actions/workflows/documentation.yml/badge.svg?branch=master
     :alt: Documentation Status
     :target: https://urwid.org
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,28 @@
 Changelog
 ---------
 
+Urwid 2.2.2
+===========
+
+2023-09-25
+
+New features 🗹
+* Feature: Support pack() for CheckBox/RadioButton/Button by @penguinolog in https://github.com/urwid/urwid/pull/621
+
+Deprecations ⚡
+* Mark `AttrWrap` as `PendingDeprecation` by @penguinolog in https://github.com/urwid/urwid/pull/619
+
+Bug fixes 🕷
+* Fix font in case Font.data is `str` by @penguinolog in https://github.com/urwid/urwid/pull/618
+
+Documentation 🕮
+* Enforce examples code-style by @penguinolog in https://github.com/urwid/urwid/pull/620
+* Documentation: do not use `FlowWidget` as base class in examples by @penguinolog in https://github.com/urwid/urwid/pull/623
+* README: suggest python3-urwid for debian/ubuntu by @chronitis in https://github.com/urwid/urwid/pull/444
+
+Refactoring 🛠
+* Packaging: stop tests distribution as part of package by @penguinolog in https://github.com/urwid/urwid/pull/622
+
 Urwid 2.2.1
 ===========
 

--- a/docs/tools/templates/indexcontent.html
+++ b/docs/tools/templates/indexcontent.html
@@ -18,9 +18,7 @@
 <ul>
 <li><a href="http://github.com/urwid/urwid">Github page</a></li>
 <li><a href="http://github.com/urwid/urwid/issues">Issues</a></li>
-<li><a href="https://gitter.im/urwid/community">IRC: <code>#urwid/community on gitter.im</code></a></li>
-<li><a href="https://groups.google.com/a/excess.org/d/forum/urwid">Mailing list</a>
-(or email <a href="mailto:urwid+subscribe@excess.org">urwid+subscribe@excess.org</a>)</li>
+<li><a href="https://gitter.im/urwid/community">IRC: <code>#urwid/community on gitter.im</code></a>
 </ul>
 
 <p>Wiki:</p>
@@ -30,19 +28,18 @@
 <li><a href="http://github.com/urwid/urwid/wiki/FAQ">FAQ</a></li>
 <li><a href="http://github.com/urwid/urwid/wiki/Application-list">Applications built with Urwid</a></li>
 <li><a href="http://github.com/urwid/urwid/wiki/How-you-can-help">How you can help</a></li>
-<li><a href="http://github.com/urwid/urwid/wiki/Coding-style">Coding style</a></li>
-<li><a href="http://github.com/urwid/urwid/wiki/Planned-development">Planned development</a></li>
 </ul>
 
 <div class="section" id="requirements">
 <h3>Requirements</h3>
 <ul>
-<li>Python 2.7, 3.5+ or PyPy</li>
+<li>Python 3.7+ or PyPy</li>
 <li>Linux, OSX, Cygwin or other unix-like OS</li>
 <li>python-gi for GlibEventLoop (optional)</li>
 <li>Twisted for TwistedEventLoop (optional)</li>
 <li>Tornado for TornadoEventLoop (optional)</li>
-<li>asyncio or trollius for AsyncioEventLoop (optional)</li>
+<li>Trio for TrioEventLoop (optional)</li>
+<li>ZMQ for ZMQEventLoop (optional)</li>
 <li>Apache for web_display module (optional)</li>
 <li>ncurses for curses_display module (optional)</li>
 </ul>


### PR DESCRIPTION
* At this moment manual changelog
* Use "documentation" tag on any docs changes In case of upper priority tags, it will be used in the release changelog.
* Point documentation to urwid.org instead of readthedocs
* Remove links to the deprecated: Coding style Mailing list Planned development
* Update requirements in documentation template
* Add self as maintainer

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
