### PR TITLE
Documentation: fix comma in maintainers list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,7 +76,7 @@ Maintainers
 
 `and3rson <//github.com/and3rson>`_,
 `tonycpsu <//github.com/tonycpsu>`_,
-`ulidtko <//github.com/ulidtko>`_
+`ulidtko <//github.com/ulidtko>`_,
 `penguinolog <//github.com/penguinolog>`_
 
 Contributors


### PR DESCRIPTION
##### Checklist
- [ ] I've ensured that similar functionality has not already been implemented
- [ ] I've ensured that similar functionality has not earlier been proposed and declined
- [ ] I've branched off the `master` or `python-dual-support` branch
- [ ] I've merged fresh upstream into my branch recently
- [ ] I've ran `tox` successfully in local environment
- [X] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
