### PR TITLE
Refactoring numedit: PEP8 arguments, allow negative, type casts

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,7 @@ commands =
     urwid/escape.py \
     urwid/command_map.py \
     urwid/graphics.py \
+    urwid/numedit.py \
     examples
 
 [testenv:black]
@@ -44,6 +45,7 @@ commands =
     urwid/escape.py \
     urwid/command_map.py \
     urwid/graphics.py \
+    urwid/numedit.py \
     examples
 
 [testenv:ruff]
@@ -57,6 +59,7 @@ commands = ruff \
     urwid/escape.py \
     urwid/command_map.py \
     urwid/graphics.py \
+    urwid/numedit.py \
     examples
 
 [testenv:docs]

--- a/urwid/widget/edit.py
+++ b/urwid/widget/edit.py
@@ -39,7 +39,7 @@ class Edit(Text):
       event handler to get into a loop of changing the text and then being
       called when the event is re-emitted.  It is up to the event
       handler to guard against this case (for instance, by not changing the
-      text if it is signaled for for text that it has already changed once).
+      text if it is signaled for text that it has already changed once).
     """
 
     _selectable = True
@@ -106,8 +106,9 @@ class Edit(Text):
         self.multiline = multiline
         self.allow_tab = allow_tab
         self._edit_pos = 0
-        self.set_caption(caption)
+        self._caption, self._attrib = decompose_tagmarkup(caption)
         self._edit_text = ""
+        self.highlight = None
         self.set_edit_text(edit_text)
         if edit_pos is None:
             edit_pos = len(edit_text)


### PR DESCRIPTION
* USE PEP8 compliant arguments and deprecate old one
* Allow cast `IntEdit` to int and `FloatEdit` to float
* Allow negative values without changing default behavior

Fix: #603
Fix: #432
Partial: #502

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [X] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

