### PR TITLE
Documentation: TrioEventLoop is missed

### DIFF
--- a/docs/reference/main_loop.rst
+++ b/docs/reference/main_loop.rst
@@ -13,6 +13,16 @@ SelectEventLoop
 
 .. autoclass:: SelectEventLoop
 
+AsyncioEventLoop
+----------------
+
+.. autoclass:: AsyncioEventLoop
+
+TrioEventLoop
+----------------
+
+.. autoclass:: TrioEventLoop
+
 GLibEventLoop
 -------------
 
@@ -27,11 +37,6 @@ TornadoEventLoop
 ----------------
 
 .. autoclass:: TornadoEventLoop
-
-AsyncioEventLoop
-----------------
-
-.. autoclass:: AsyncioEventLoop
 
 ZMQEventLoop
 ------------


### PR DESCRIPTION
##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [ ] I've ran `tox` successfully in local environment
- [X] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
