### PR TITLE
Fix import from deprecated internal module

### DIFF
--- a/urwid/event_loop/main_loop.py
+++ b/urwid/event_loop/main_loop.py
@@ -33,7 +33,7 @@ from urwid import raw_display, signals
 from urwid.command_map import Command, command_map
 from urwid.display_common import INPUT_DESCRIPTORS_CHANGED
 from urwid.util import StoppingContext, is_mouse_event
-from urwid.wimp import PopUpTarget
+from urwid.widget import PopUpTarget
 
 from .abstract_loop import ExitMainLoop
 from .select_loop import SelectEventLoop


### PR DESCRIPTION
##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

Fix: #644 
