### PR TITLE
Expose `widget` and `event_loop` packages

### DIFF
--- a/urwid/__init__.py
+++ b/urwid/__init__.py
@@ -194,6 +194,8 @@ from urwid.widget import (
     scale_bar_values,
 )
 
+from . import event_loop, widget
+
 from urwid.treetools import ParentNode, TreeListBox, TreeNode, TreeWalker, TreeWidget, TreeWidgetError  # isort: skip
 
 # Optional event loops with external dependencies

--- a/urwid/widget/__init__.py
+++ b/urwid/widget/__init__.py
@@ -22,7 +22,7 @@ from .constants import (
     simplify_valign,
     simplify_width,
 )
-from .container import WidgetContainerMixin
+from .container import WidgetContainerListContentsMixin, WidgetContainerMixin
 from .divider import Divider
 from .edit import Edit, EditError, IntEdit
 from .filler import Filler, FillerError, calculate_top_bottom_filler
@@ -144,6 +144,7 @@ __all__ = (
     "GraphVScale",
     "scale_bar_values",
     "ProgressBar",
+    "WidgetContainerListContentsMixin"
 )
 
 # Backward compatibility

--- a/urwid/widget/__init__.py
+++ b/urwid/widget/__init__.py
@@ -144,7 +144,7 @@ __all__ = (
     "GraphVScale",
     "scale_bar_values",
     "ProgressBar",
-    "WidgetContainerListContentsMixin"
+    "WidgetContainerListContentsMixin",
 )
 
 # Backward compatibility


### PR DESCRIPTION
`urwid.widget` expose classes and methods,
which are not public directly:

* `WidgetContainerListContentsMixin`
* `calculate_left_right_padding`
* `calculate_top_bottom_filler`
* `nocache_widget_render`
* `nocache_widget_render_instance`
* `normalize_align`
* `normalize_height`
* `normalize_valign`
* `normalize_width`
* `simplify_align`
* `simplify_height`
* `simplify_valign`
* `simplify_width`

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

Fix: #491 
