### PR TITLE
Documentation: Use static default text in BigText demo

### DIFF
--- a/examples/bigtext.py
+++ b/examples/bigtext.py
@@ -113,7 +113,7 @@ class BigTextDisplay:
         chosen_font_rb.base_widget.set_state(True)  # causes set_font_event call
 
         # Create Edit widget
-        edit = self.create_edit("", f"Urwid {urwid.__version__}", self.edit_change_event)
+        edit = self.create_edit("", "Urwid BigText example", self.edit_change_event)
 
         # ListBox
         chars = urwid.Pile([cah, ca])


### PR DESCRIPTION
Version based demo text causes screenshot re-generation.

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

