### PR TITLE
Documentation Remove unneeded closing tags in TOC

### DIFF
--- a/docs/tools/templates/localtoc.html
+++ b/docs/tools/templates/localtoc.html
@@ -1,18 +1,18 @@
 {%- if pagename.startswith('manual/') -%}
-  <h3>Table of contents</a></h3>
+  <h3>Table of contents</h3>
     <ul><li><a href="index.html">Manual</a></li>
     {%- if display_toc -%}
       {{ toc }}
     {%- endif %}
     </ul>
 {%- elif pagename.startswith('reference/') -%}
-  <h3>Table of contents</a></h3>
+  <h3>Table of contents</h3>
     <ul><li><a href="index.html">Reference</a></li>
     {%- if display_toc -%}
       {{ toc }}
     {%- endif %}
     </ul>
 {%- elif display_toc -%}
-  <h3>Table of contents</a></h3>
+  <h3>Table of contents</h3>
   {{ toc }}
 {% endif %}


### PR DESCRIPTION
Generated construction **before** change:
```html
</a></p><h3>Table of contents</a></h3>
```

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [X] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
