### PR TITLE
Fix deprecated `_set_focus` method usage

### DIFF
--- a/urwid/monitored_list.py
+++ b/urwid/monitored_list.py
@@ -497,7 +497,7 @@ class MonitoredFocusList(MonitoredList):
         def clear(self):
             focus = self._adjust_focus_on_contents_modified(slice(0, 0))
             rval = super().clear()
-            self._set_focus(focus)
+            self.focus = focus
             return rval
 
 


### PR DESCRIPTION
##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

Fix #658 