### PR TITLE
use Hashable for signal identifier types

### DIFF
--- a/urwid/signals.py
+++ b/urwid/signals.py
@@ -26,7 +26,7 @@ import warnings
 import weakref
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Callable, Collection, Container, Iterable
+    from collections.abc import Callable, Collection, Container, Hashable, Iterable
 
 
 class MetaSignals(type):
@@ -68,7 +68,7 @@ class Signals:
     def __init__(self):
         self._supported = {}
 
-    def register(self, sig_cls, signals: Container[str]) -> None:
+    def register(self, sig_cls, signals: Container[Hashable]) -> None:
         """
         :param sig_class: the class of an object that will be sending signals
         :type sig_class: class
@@ -84,7 +84,7 @@ class Signals:
     def connect(
         self,
         obj,
-        name: str,
+        name: Hashable,
         callback: Callable[..., typing.Any],
         user_arg: typing.Any = None,
         *,
@@ -219,7 +219,7 @@ class Signals:
     def disconnect(
         self,
         obj,
-        name: str,
+        name: Hashable,
         callback: Callable[..., typing.Any],
         user_arg: typing.Any = None,
         *,
@@ -260,7 +260,7 @@ class Signals:
                 return self.disconnect_by_key(obj, name, h[0])
         return None
 
-    def disconnect_by_key(self, obj, name: str, key: Key) -> None:
+    def disconnect_by_key(self, obj, name: Hashable, key: Key) -> None:
         """
         :param obj: the object to disconnect the signal from
         :type obj: object
@@ -281,7 +281,7 @@ class Signals:
         handlers = signals.get(name, [])
         handlers[:] = [h for h in handlers if h[0] is not key]
 
-    def emit(self, obj, name: str, *args) -> bool:
+    def emit(self, obj, name: Hashable, *args) -> bool:
         """
         :param obj: the object sending a signal
         :type obj: object

--- a/urwid/widget/widget.py
+++ b/urwid/widget/widget.py
@@ -34,7 +34,7 @@ from urwid.util import MetaSuper
 from .constants import Sizing
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Hashable
 
 
 class WidgetMeta(MetaSuper, signals.MetaSignals):
@@ -422,7 +422,7 @@ class Widget(metaclass=WidgetMeta):
         """
         CanvasCache.invalidate(self)
 
-    def _emit(self, name: str, *args):
+    def _emit(self, name: Hashable, *args):
         """
         Convenience function to emit signals with self as first
         argument.


### PR DESCRIPTION
Signal identifiers types were specified as `str`, however the code only requires that they be `Hashable` in order to be used as dict keys.

This pull request widens the type hints to `collections.abc.Hashable` in order to reflect this fact.

Closes #668

