### PR TITLE
Fix #674 : old versions of setuptools_scm support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 # PEP 508 specifications for PEP 518.
 requires = [
     "setuptools >= 61.0.0",
-    "setuptools_scm[toml]>=6.2",
+    "setuptools_scm[toml]>=7.0",
     "wheel",
 ]
 build-backend="setuptools.build_meta"

--- a/urwid/__init__.py
+++ b/urwid/__init__.py
@@ -111,7 +111,8 @@ from urwid.util import (
     supports_unicode,
     within_double_byte,
 )
-from urwid.version import __version__, __version_tuple__
+from urwid.version import version as __version__
+from urwid.version import version_tuple as __version_tuple__
 from urwid.vterm import TermCanvas, TermCharset, Terminal, TermModes, TermScroller
 from urwid.widget import (
     ANY,

--- a/urwid/font.py
+++ b/urwid/font.py
@@ -152,7 +152,7 @@ class FontRegistry(type):
         """List of (font name, font class) tuples."""
         return list(mcs.__registered.items())
 
-    def __new__(  # noqa: PYI034  # new can not return Self
+    def __new__(
         cls: type[FontRegistry],
         name: str,
         bases: tuple[type, ...],


### PR DESCRIPTION
* Require `setuptools_scm` > 7.1
  Python 3.7 is minimally supported
  A lot of git bugfixes, including container support
* Use compatible imports (use aliases)

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
