### PR TITLE
Maintenance: port OSX deps installing for cases of future OSX testing

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -53,10 +53,17 @@ jobs:
         run: |
           sudo apt-get -qq update
           sudo apt-get install -y python3-gi gobject-introspection libgirepository1.0-dev
+      - name: Install Mac OS X dependencies
+        if: runner.os == 'macOS'
+        run: |
+          brew install gtk+3 gobject-introspection gtk-mac-integration
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip wheel
-          pip install -r test_requirements.txt PyGObject
+          pip install -r test_requirements.txt
+      - name: Install PyGObject
+        if: runner.os == 'Linux' || runner.os == 'macOS'
+        run: pip install PyGObject
       - name: Install package for test
         run: pip install -e .
       - name: Test


### PR DESCRIPTION
* No OSX tests trigger since we have dedicated PR
* Move `PyGObject` install to the separate step: We have plans (low priority) for Windows support

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [ ] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
