### PR TITLE
Replace deprecated use of MultiError with exceptiongroup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ classifiers = {file = ["classifiers.txt"]}
 [project.optional-dependencies]
 glib = ["PyGObject"]
 tornado = ["tornado"]
-trio = ["trio", "exceptiongroup"]
+trio = ["trio>=0.22.0", "exceptiongroup"]
 twisted = ["twisted"]
 zmq = ["zmq"]
 # for lcd_display

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ classifiers = {file = ["classifiers.txt"]}
 [project.optional-dependencies]
 glib = ["PyGObject"]
 tornado = ["tornado"]
-trio = ["trio"]
+trio = ["trio", "exceptiongroup"]
 twisted = ["twisted"]
 zmq = ["zmq"]
 # for lcd_display

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,3 +3,4 @@ coverage[toml]
 twisted
 trio
 zmq
+exceptiongroups


### PR DESCRIPTION
##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:

This pull request fixes a deprecation warning when running with recent versions of trio (and a TODO comment from the relevant section of the code) by replacing usage of trio's `MultiError.catch` with `exceptiongroup.catch`. It required a little bit of fiddling to get the right semantics, but as far as I can tell this should now be identical behaviour without the deprecation warning (and it passes all the tests)

This does have the possibly slightly undesirable feature of adding a dependency on exceptiongroup for using trio. I think this is mostly harmless - it's a dependency of trio anyway in Python versions prior to `except*` syntax being added. If you want I can do a slightly more complicated version of this pull request that removes the dependency on Python versions recent enough to not need it, but that seemed likely to be more trouble than it was worth compared to just installing the backport unconditionally.
