### PR TITLE
Trivial: fix part of type annotations

### DIFF
--- a/urwid/event_loop/trio_loop.py
+++ b/urwid/event_loop/trio_loop.py
@@ -203,7 +203,7 @@ class TrioEventLoop(EventLoop):
             await self._sleep(seconds)
             callback()
 
-    def _handle_main_loop_exception(self, exc: BaseException) -> BaseException | None:
+    def _handle_main_loop_exception(self, exc: BaseException) -> None:
         """Handles exceptions raised from the main loop, catching ExitMainLoop
         instead of letting it propagate through.
 
@@ -216,7 +216,7 @@ class TrioEventLoop(EventLoop):
             exc = exc.exceptions[0]
 
         if isinstance(exc, ExitMainLoop):
-            return None
+            return
 
         raise exc
 

--- a/urwid/event_loop/zmq_loop.py
+++ b/urwid/event_loop/zmq_loop.py
@@ -40,9 +40,6 @@ if typing.TYPE_CHECKING:
     from collections.abc import Callable
 
     ZMQAlarmHandle = typing.TypeVar("ZMQAlarmHandle")
-    ZMQQueueHandle = typing.TypeVar("ZMQQueueHandle")
-    ZMQFileHandle = typing.TypeVar("ZMQFileHandle")
-    ZMQIdleHandle = typing.TypeVar("ZMQIdleHandle")
 
 
 class ZMQEventLoop(EventLoop):
@@ -100,7 +97,7 @@ class ZMQEventLoop(EventLoop):
         queue: zmq.Socket,
         callback: Callable[[], typing.Any],
         flags: int = zmq.POLLIN,
-    ) -> ZMQQueueHandle:
+    ) -> zmq.Socket:
         """
         Call *callback* when zmq *queue* has something to read (when *flags* is
         set to ``POLLIN``, the default) or is available to write (when *flags*
@@ -127,7 +124,7 @@ class ZMQEventLoop(EventLoop):
         fd: int,
         callback: Callable[[], typing.Any],
         flags: int = zmq.POLLIN,
-    ) -> ZMQFileHandle:
+    ) -> int:
         """
         Call *callback* when *fd* has some data to read. No parameters are
         passed to the callback. The *flags* are as for :meth:`watch_queue`.
@@ -148,7 +145,7 @@ class ZMQEventLoop(EventLoop):
         self._queue_callbacks[fd.fileno()] = callback
         return fd
 
-    def remove_watch_queue(self, handle: ZMQQueueHandle) -> bool:
+    def remove_watch_queue(self, handle: zmq.Socket) -> bool:
         """
         Remove a queue from background polling. Returns ``True`` if the queue
         was being monitored, ``False`` otherwise.
@@ -164,7 +161,7 @@ class ZMQEventLoop(EventLoop):
 
         return True
 
-    def remove_watch_file(self, handle: ZMQFileHandle) -> bool:
+    def remove_watch_file(self, handle: int) -> bool:
         """
         Remove a file from background polling. Returns ``True`` if the file was
         being monitored, ``False`` otherwise.
@@ -180,7 +177,7 @@ class ZMQEventLoop(EventLoop):
 
         return True
 
-    def enter_idle(self, callback: Callable[[], typing.Any]) -> ZMQIdleHandle:
+    def enter_idle(self, callback: Callable[[], typing.Any]) -> int:
         """
         Add a *callback* to be executed when the event loop detects it is idle.
         Returns a handle that may be passed to :meth:`remove_enter_idle`.
@@ -189,7 +186,7 @@ class ZMQEventLoop(EventLoop):
         self._idle_callbacks[self._idle_handle] = callback
         return self._idle_handle
 
-    def remove_enter_idle(self, handle: ZMQIdleHandle) -> bool:
+    def remove_enter_idle(self, handle: int) -> bool:
         """
         Remove an idle callback. Returns ``True`` if *handle* was removed,
         ``False`` otherwise.

--- a/urwid/listbox.py
+++ b/urwid/listbox.py
@@ -42,6 +42,8 @@ from urwid.widget import (
 )
 
 if typing.TYPE_CHECKING:
+    from collections.abc import Callable
+
     from typing_extensions import Literal
 
     from urwid.canvas import CompositeCanvas
@@ -140,7 +142,7 @@ class SimpleListWalker(MonitoredList, ListWalker):
             self.focus = max(0, len(self) - 1)
         ListWalker._modified(self)
 
-    def set_modified_callback(self, callback) -> typing.NoReturn:
+    def set_modified_callback(self, callback: Callable[[], typing.Any]) -> typing.NoReturn:
         """
         This function inherited from MonitoredList is not
         implemented in SimpleListWalker.
@@ -210,7 +212,7 @@ class SimpleFocusListWalker(ListWalker, MonitoredFocusList):
         MonitoredFocusList.__init__(self, contents)
         self.wrap_around = wrap_around
 
-    def set_modified_callback(self, callback) -> typing.NoReturn:
+    def set_modified_callback(self, callback: typing.Any) -> typing.NoReturn:
         """
         This function inherited from MonitoredList is not
         implemented in SimpleFocusListWalker.
@@ -738,7 +740,16 @@ class ListBox(Widget, WidgetContainerMixin):
             return
 
         rows = focus_widget.rows((maxcol,), focus)
-        rtop, rbot = calculate_top_bottom_filler(maxrow, vt, va, WHSettings.GIVEN, rows, None, 0, 0)
+        rtop, rbot = calculate_top_bottom_filler(
+            maxrow,
+            vt,
+            va,
+            WHSettings.GIVEN,
+            rows,
+            None,
+            0,
+            0,
+        )
 
         self.shift_focus((maxcol, maxrow), rtop)
 
@@ -1438,7 +1449,14 @@ class ListBox(Widget, WidgetContainerMixin):
             return None
         # bring in only one row if possible
         rows = widget.rows((maxcol,), True)
-        self.change_focus((maxcol, maxrow), pos, -(rows - 1), "below", (self.pref_col, rows - 1), 0)
+        self.change_focus(
+            (maxcol, maxrow),
+            pos,
+            -(rows - 1),
+            "below",
+            (self.pref_col, rows - 1),
+            0,
+        )
         return None
 
     def _keypress_page_down(self, size: tuple[int, int]) -> bool | None:
@@ -1617,7 +1635,14 @@ class ListBox(Widget, WidgetContainerMixin):
             return None
         # bring in only one row if possible
         rows = widget.rows((maxcol,), True)
-        self.change_focus((maxcol, maxrow), pos, maxrow - 1, "above", (self.pref_col, 0), 0)
+        self.change_focus(
+            (maxcol, maxrow),
+            pos,
+            maxrow - 1,
+            "above",
+            (self.pref_col, 0),
+            0,
+        )
         return None
 
     def mouse_event(self, size: tuple[int, int], event, button: int, col: int, row: int, focus: bool) -> bool | None:

--- a/urwid/vterm.py
+++ b/urwid/vterm.py
@@ -1464,7 +1464,7 @@ class Terminal(Widget):
 
     def __init__(
         self,
-        command: Sequence[str | bytes] | Callable[[], ...] | None,
+        command: Sequence[str | bytes] | Callable[[], typing.Any] | None,
         env: Mapping[str, str] | Iterable[tuple[str, str]] | None = None,
         main_loop: event_loop.EventLoop | None = None,
         escape_sequence: str | None = None,

--- a/urwid/widget/constants.py
+++ b/urwid/widget/constants.py
@@ -87,7 +87,7 @@ def normalize_align(
 
     if isinstance(align, tuple) and len(align) == 2 and align[0] == WHSettings.RELATIVE:
         align_type, align_amount = align
-        return (WHSettings(align_type), align_amount)
+        return (WHSettings.RELATIVE, align_amount)
 
     raise err(
         f"align value {align!r} is not one of 'left', 'center', 'right', ('relative', percentage 0=left 100=right)"
@@ -130,7 +130,7 @@ def simplify_align(
         if not isinstance(align_amount, int):
             raise TypeError(align_amount)
 
-        return (WHSettings(align_type), align_amount)
+        return (WHSettings.RELATIVE, align_amount)
     return Align(align_type)
 
 
@@ -163,7 +163,7 @@ def normalize_valign(
 
     if isinstance(valign, tuple) and len(valign) == 2 and valign[0] == WHSettings.RELATIVE:
         valign_type, valign_amount = valign
-        return (WHSettings(valign_type), valign_amount)
+        return (WHSettings.RELATIVE, valign_amount)
 
     raise err(
         f"valign value {valign!r} is not one of 'top', 'middle', 'bottom', ('relative', percentage 0=left 100=right)"
@@ -205,7 +205,7 @@ def simplify_valign(
     if valign_type == WHSettings.RELATIVE:
         if not isinstance(valign_amount, int):
             raise TypeError(valign_amount)
-        return (WHSettings(valign_type), valign_amount)
+        return (WHSettings.RELATIVE, valign_amount)
     return VAlign(valign_type)
 
 


### PR DESCRIPTION
* `trio_loop.TrioEventLoop._handle_main_loop_exception`
* `ZMQEventLoop` - do not use `TypeVar` if exact type known
* `vterm.Terminal` initializer
* `monitored_list._call_modified` decorator
* `MonitoredFocusList` - make generic with `list` like types

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
