### PR TITLE
Maintenance: CI: Build wheels only if push to upstream

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -150,7 +150,7 @@ jobs:
     name: Build wheels on ${{ matrix.os }}
     needs: [ Test, Isort, Black, Ruff ]
     # build only on push: heavy job
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.repository == 'urwid/urwid'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -240,7 +240,7 @@ jobs:
   upload_pypi:
     needs: [ build_wheels, build_sdist, Metadata ]
     # upload to PyPI on every tag
-    if: github.event_name == 'push' && github.ref_type == 'tag'
+    if: github.event_name == 'push' && github.ref_type == 'tag' && github.repository == 'urwid/urwid'
     # alternatively, to publish when a GitHub Release is created, use the following rule:
     # if: github.event_name == 'release' && github.event.action == 'published'
     runs-on: ubuntu-latest


### PR DESCRIPTION
##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [ ] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
