### PR TITLE
Maintenance: Tests: Use explicit encoding for tests

### DIFF
--- a/tests/test_canvas.py
+++ b/tests/test_canvas.py
@@ -4,6 +4,7 @@ import unittest
 
 import urwid
 from urwid import canvas
+from urwid.util import get_encoding
 
 
 class CanvasCacheTest(unittest.TestCase):
@@ -303,7 +304,7 @@ class CanvasJoinTest(unittest.TestCase):
 
 class CanvasOverlayTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.old_encoding = urwid.util._target_encoding
+        self.old_encoding = get_encoding()
 
     def tearDown(self) -> None:
         urwid.set_encoding(self.old_encoding)

--- a/tests/test_doctests.py
+++ b/tests/test_doctests.py
@@ -7,7 +7,7 @@ import urwid
 import urwid.numedit
 
 
-def load_tests(loader, tests, ignore):
+def load_tests(loader: unittest.TestLoader, tests: unittest.BaseTestSuite, ignore) -> unittest.BaseTestSuite:
     module_doctests = [
         urwid.widget.attr_map,
         urwid.widget.attr_wrap,
@@ -39,11 +39,10 @@ def load_tests(loader, tests, ignore):
         urwid.monitored_list,
         urwid.raw_display,
         urwid.font,
-        'urwid.split_repr',  # override function with same name
+        "urwid.split_repr",  # override function with same name
         urwid.util,
         urwid.signals,
-        ]
+    ]
     for m in module_doctests:
-        tests.addTests(doctest.DocTestSuite(m,
-            optionflags=doctest.ELLIPSIS | doctest.IGNORE_EXCEPTION_DETAIL))
+        tests.addTests(doctest.DocTestSuite(m, optionflags=doctest.ELLIPSIS | doctest.IGNORE_EXCEPTION_DETAIL))
     return tests

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import unittest
 
 import urwid
+from urwid.util import get_encoding
 
 
 class TestFontRender(unittest.TestCase):
     def setUp(self) -> None:
-        self.old_encoding = urwid.util._target_encoding
+        self.old_encoding = get_encoding()
         urwid.set_encoding("utf-8")
 
     def tearDown(self) -> None:
@@ -15,8 +16,8 @@ class TestFontRender(unittest.TestCase):
 
     def test_001_basic(self):
         font = urwid.Thin3x3Font()
-        rendered = b'\n'.join(font.render("1").text).decode()
-        expected = ' ┐ \n │ \n ┴ '
+        rendered = b"\n".join(font.render("1").text).decode()
+        expected = " ┐ \n │ \n ┴ "
         self.assertEqual(expected, rendered)
 
     def test_002_non_rect(self):
@@ -25,6 +26,6 @@ class TestFontRender(unittest.TestCase):
         Lines as bytes should be not equal length.
         """
         font = urwid.Thin3x3Font()
-        rendered = b'\n'.join(font.render("2").text).decode()
-        expected = '┌─┐\n┌─┘\n└─ '
+        rendered = b"\n".join(font.render("2").text).decode()
+        expected = "┌─┐\n┌─┘\n└─ "
         self.assertEqual(expected, rendered)

--- a/tests/test_graphics.py
+++ b/tests/test_graphics.py
@@ -3,21 +3,24 @@ from __future__ import annotations
 import unittest
 
 import urwid
+from urwid.util import get_encoding
 from urwid.widget import bar_graph
 
 
 class LineBoxTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.old_encoding = urwid.util._target_encoding
+        self.old_encoding = get_encoding()
         urwid.set_encoding("utf-8")
 
     def tearDown(self) -> None:
         urwid.set_encoding(self.old_encoding)
 
     def border(self, tl, t, tr, l, r, bl, b, br):
-        return [b''.join([tl, t, tr]),
-                b''.join([l, b" ", r]),
-                b''.join([bl, b, br]),]
+        return [
+            b"".join([tl, t, tr]),
+            b"".join([l, b" ", r]),
+            b"".join([bl, b, br]),
+        ]
 
     def test_linebox_pack(self):
         # Bug #346 'pack' Padding does not run with LineBox
@@ -34,86 +37,186 @@ class LineBoxTest(unittest.TestCase):
         l = urwid.LineBox(t).render((3,)).text
 
         # default
-        self.assertEqual(l,
-            self.border(b"\xe2\x94\x8c", b"\xe2\x94\x80",
-                b"\xe2\x94\x90", b"\xe2\x94\x82", b"\xe2\x94\x82",
-                b"\xe2\x94\x94", b"\xe2\x94\x80", b"\xe2\x94\x98"))
+        self.assertEqual(
+            l,
+            self.border(
+                b"\xe2\x94\x8c",
+                b"\xe2\x94\x80",
+                b"\xe2\x94\x90",
+                b"\xe2\x94\x82",
+                b"\xe2\x94\x82",
+                b"\xe2\x94\x94",
+                b"\xe2\x94\x80",
+                b"\xe2\x94\x98",
+            ),
+        )
 
-        nums = [str(n).encode('iso8859-1') for n in range(8)]
-        b = dict(zip(["tlcorner", "tline", "trcorner", "lline", "rline",
-            "blcorner", "bline", "brcorner"], nums))
+        nums = [str(n).encode("iso8859-1") for n in range(8)]
+        b = dict(zip(["tlcorner", "tline", "trcorner", "lline", "rline", "blcorner", "bline", "brcorner"], nums))
         l = urwid.LineBox(t, **b).render((3,)).text
 
         self.assertEqual(l, self.border(*nums))
 
 
 class BarGraphTest(unittest.TestCase):
-    def bgtest(self, desc, data, top, widths, maxrow, exp ):
-        rval = bar_graph.calculate_bargraph_display(data,top,widths,maxrow)
+    def bgtest(self, desc, data, top, widths, maxrow, exp):
+        rval = bar_graph.calculate_bargraph_display(data, top, widths, maxrow)
         assert rval == exp, f"{desc} expected {exp!r}, got {rval!r}"
 
     def test1(self):
-        self.bgtest('simplest',[[0]],5,[1],1,
-            [(1,[(0,1)])] )
-        self.bgtest('simpler',[[0],[0]],5,[1,2],5,
-            [(5,[(0,3)])] )
-        self.bgtest('simple',[[5]],5,[1],1,
-            [(1,[(1,1)])] )
-        self.bgtest('2col-1',[[2],[0]],5,[1,2],5,
-            [(3,[(0,3)]), (2,[(1,1),(0,2)]) ] )
-        self.bgtest('2col-2',[[0],[2]],5,[1,2],5,
-            [(3,[(0,3)]), (2,[(0,1),(1,2)]) ] )
-        self.bgtest('2col-3',[[2],[3]],5,[1,2],5,
-            [(2,[(0,3)]), (1,[(0,1),(1,2)]), (2,[(1,3)]) ] )
-        self.bgtest('3col-1',[[5],[3],[0]],5,[2,1,1],5,
-            [(2,[(1,2),(0,2)]), (3,[(1,3),(0,1)]) ] )
-        self.bgtest('3col-2',[[4],[4],[4]],5,[2,1,1],5,
-            [(1,[(0,4)]), (4,[(1,4)]) ] )
-        self.bgtest('3col-3',[[1],[2],[3]],5,[2,1,1],5,
-            [(2,[(0,4)]), (1,[(0,3),(1,1)]), (1,[(0,2),(1,2)]),
-             (1,[(1,4)]) ] )
-        self.bgtest('3col-4',[[4],[2],[4]],5,[1,2,1],5,
-            [(1,[(0,4)]), (2,[(1,1),(0,2),(1,1)]), (2,[(1,4)]) ] )
+        self.bgtest("simplest", [[0]], 5, [1], 1, [(1, [(0, 1)])]),
+        self.bgtest(
+            "simpler",
+            [[0], [0]],
+            5,
+            [1, 2],
+            5,
+            [(5, [(0, 3)])],
+        )
+        self.bgtest(
+            "simple",
+            [[5]],
+            5,
+            [1],
+            1,
+            [(1, [(1, 1)])],
+        )
+        self.bgtest(
+            "2col-1",
+            [[2], [0]],
+            5,
+            [1, 2],
+            5,
+            [(3, [(0, 3)]), (2, [(1, 1), (0, 2)])],
+        )
+        self.bgtest(
+            "2col-2",
+            [[0], [2]],
+            5,
+            [1, 2],
+            5,
+            [(3, [(0, 3)]), (2, [(0, 1), (1, 2)])],
+        )
+        self.bgtest(
+            "2col-3",
+            [[2], [3]],
+            5,
+            [1, 2],
+            5,
+            [(2, [(0, 3)]), (1, [(0, 1), (1, 2)]), (2, [(1, 3)])],
+        )
+        self.bgtest(
+            "3col-1",
+            [[5], [3], [0]],
+            5,
+            [2, 1, 1],
+            5,
+            [(2, [(1, 2), (0, 2)]), (3, [(1, 3), (0, 1)])],
+        )
+        self.bgtest(
+            "3col-2",
+            [[4], [4], [4]],
+            5,
+            [2, 1, 1],
+            5,
+            [(1, [(0, 4)]), (4, [(1, 4)])],
+        )
+        self.bgtest(
+            "3col-3",
+            [[1], [2], [3]],
+            5,
+            [2, 1, 1],
+            5,
+            [(2, [(0, 4)]), (1, [(0, 3), (1, 1)]), (1, [(0, 2), (1, 2)]), (1, [(1, 4)])],
+        )
+        self.bgtest(
+            "3col-4",
+            [[4], [2], [4]],
+            5,
+            [1, 2, 1],
+            5,
+            [(1, [(0, 4)]), (2, [(1, 1), (0, 2), (1, 1)]), (2, [(1, 4)])],
+        )
 
     def test2(self):
-        self.bgtest('simple1a',[[2,0],[2,1]],2,[1,1],2,
-            [(1,[(1,2)]),(1,[(1,1),(2,1)]) ] )
-        self.bgtest('simple1b',[[2,1],[2,0]],2,[1,1],2,
-            [(1,[(1,2)]),(1,[(2,1),(1,1)]) ] )
-        self.bgtest('cross1a',[[2,2],[1,2]],2,[1,1],2,
-            [(2,[(2,2)]) ] )
-        self.bgtest('cross1b',[[1,2],[2,2]],2,[1,1],2,
-            [(2,[(2,2)]) ] )
-        self.bgtest('mix1a',[[3,2,1],[2,2,2],[1,2,3]],3,[1,1,1],3,
-            [(1,[(1,1),(0,1),(3,1)]),(1,[(2,1),(3,2)]),
-             (1,[(3,3)]) ] )
-        self.bgtest('mix1b',[[1,2,3],[2,2,2],[3,2,1]],3,[1,1,1],3,
-            [(1,[(3,1),(0,1),(1,1)]),(1,[(3,2),(2,1)]),
-             (1,[(3,3)]) ] )
+        self.bgtest(
+            "simple1a",
+            [[2, 0], [2, 1]],
+            2,
+            [1, 1],
+            2,
+            [(1, [(1, 2)]), (1, [(1, 1), (2, 1)])],
+        )
+        self.bgtest(
+            "simple1b",
+            [[2, 1], [2, 0]],
+            2,
+            [1, 1],
+            2,
+            [(1, [(1, 2)]), (1, [(2, 1), (1, 1)])],
+        )
+        self.bgtest("cross1a", [[2, 2], [1, 2]], 2, [1, 1], 2, [(2, [(2, 2)])])
+        self.bgtest("cross1b", [[1, 2], [2, 2]], 2, [1, 1], 2, [(2, [(2, 2)])])
+        self.bgtest(
+            "mix1a",
+            [[3, 2, 1], [2, 2, 2], [1, 2, 3]],
+            3,
+            [1, 1, 1],
+            3,
+            [(1, [(1, 1), (0, 1), (3, 1)]), (1, [(2, 1), (3, 2)]), (1, [(3, 3)])],
+        )
+        self.bgtest(
+            "mix1b",
+            [[1, 2, 3], [2, 2, 2], [3, 2, 1]],
+            3,
+            [1, 1, 1],
+            3,
+            [(1, [(3, 1), (0, 1), (1, 1)]), (1, [(3, 2), (2, 1)]), (1, [(3, 3)])],
+        )
+
 
 class SmoothBarGraphTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.old_encoding = urwid.util._target_encoding
+        self.old_encoding = get_encoding()
         urwid.set_encoding("utf-8")
 
     def tearDown(self) -> None:
         urwid.set_encoding(self.old_encoding)
 
-    def sbgtest(self, desc, data, top, exp ):
-        g = urwid.BarGraph( ['black','red','blue'],
-                None, {(1,0):'red/black', (2,1):'blue/red'})
-        g.set_data( data, top )
-        rval = g.calculate_display((5,3))
+    def sbgtest(self, desc, data, top, exp):
+        g = urwid.BarGraph(["black", "red", "blue"], None, {(1, 0): "red/black", (2, 1): "blue/red"})
+        g.set_data(data, top)
+        rval = g.calculate_display((5, 3))
         assert rval == exp, f"{desc} expected {exp!r}, got {rval!r}"
 
     def test1(self):
-        self.sbgtest('simple', [[3]], 5,
-            [(1, [(0, 5)]), (1, [((1, 0, 6), 5)]), (1, [(1, 5)])] )
-        self.sbgtest('boring', [[4,2]], 6,
-            [(1, [(0, 5)]), (1, [(1, 5)]), (1, [(2,5)]) ] )
-        self.sbgtest('two', [[4],[2]], 6,
-            [(1, [(0, 5)]), (1, [(1, 3), (0, 2)]), (1, [(1, 5)]) ] )
-        self.sbgtest('twos', [[3],[4]], 6,
-            [(1, [(0, 5)]), (1, [((1,0,4), 3), (1, 2)]), (1, [(1,5)]) ] )
-        self.sbgtest('twof', [[4],[3]], 6,
-            [(1, [(0, 5)]), (1, [(1,3), ((1,0,4), 2)]), (1, [(1,5)]) ] )
+        self.sbgtest(
+            "simple",
+            [[3]],
+            5,
+            [(1, [(0, 5)]), (1, [((1, 0, 6), 5)]), (1, [(1, 5)])],
+        )
+        self.sbgtest(
+            "boring",
+            [[4, 2]],
+            6,
+            [(1, [(0, 5)]), (1, [(1, 5)]), (1, [(2, 5)])],
+        )
+        self.sbgtest(
+            "two",
+            [[4], [2]],
+            6,
+            [(1, [(0, 5)]), (1, [(1, 3), (0, 2)]), (1, [(1, 5)])],
+        )
+        self.sbgtest(
+            "twos",
+            [[3], [4]],
+            6,
+            [(1, [(0, 5)]), (1, [((1, 0, 4), 3), (1, 2)]), (1, [(1, 5)])],
+        )
+        self.sbgtest(
+            "twof",
+            [[4], [3]],
+            6,
+            [(1, [(0, 5)]), (1, [(1, 3), ((1, 0, 4), 2)]), (1, [(1, 5)])],
+        )

--- a/tests/test_text_layout.py
+++ b/tests/test_text_layout.py
@@ -1,22 +1,10 @@
 from __future__ import annotations
 
 import unittest
-from collections.abc import Generator
-from contextlib import contextmanager
 
 import urwid
 from urwid import text_layout
-
-
-@contextmanager
-def encoding(encoding_name: str) -> Generator[None, None, None]:
-    old_encoding = 'ascii'  # Default fallback value
-    try:
-        old_encoding = urwid.util._target_encoding
-        urwid.set_encoding(encoding_name)
-        yield
-    finally:
-        urwid.set_encoding(old_encoding)
+from urwid.util import get_encoding, set_temporary_encoding
 
 
 class CalcBreaksTest:
@@ -46,7 +34,7 @@ class CalcBreaksCharTest(CalcBreaksTest, unittest.TestCase):
 
 class CalcBreaksDBCharTest(CalcBreaksTest, unittest.TestCase):
     def setUp(self):
-        self.old_encoding = urwid.util._target_encoding
+        self.old_encoding = get_encoding()
         urwid.set_encoding("euc-jp")
 
     def tearDown(self) -> None:
@@ -85,7 +73,7 @@ class CalcBreaksWordTest2(CalcBreaksTest, unittest.TestCase):
 
 class CalcBreaksDBWordTest(CalcBreaksTest, unittest.TestCase):
     def setUp(self):
-        self.old_encoding = urwid.util._target_encoding
+        self.old_encoding = get_encoding()
         urwid.set_encoding("euc-jp")
 
     def tearDown(self) -> None:
@@ -103,7 +91,7 @@ class CalcBreaksDBWordTest(CalcBreaksTest, unittest.TestCase):
 
 class CalcBreaksUTF8Test(CalcBreaksTest, unittest.TestCase):
     def setUp(self) -> None:
-        self.old_encoding = urwid.util._target_encoding
+        self.old_encoding = get_encoding()
         urwid.set_encoding("utf-8")
 
     def tearDown(self) -> None:
@@ -120,13 +108,13 @@ class CalcBreaksUTF8Test(CalcBreaksTest, unittest.TestCase):
 
 class CalcBreaksCantDisplayTest(unittest.TestCase):
     def test(self):
-        with encoding("euc-jp"):
+        with set_temporary_encoding("euc-jp"):
             self.assertRaises(
                 text_layout.CanNotDisplayText,
                 text_layout.default_layout.calculate_text_segments,
                 b'\xA1\xA1', 1, 'space'
             )
-        with encoding("utf-8"):
+        with set_temporary_encoding("utf-8"):
             self.assertRaises(
                 text_layout.CanNotDisplayText,
                 text_layout.default_layout.calculate_text_segments,
@@ -136,7 +124,7 @@ class CalcBreaksCantDisplayTest(unittest.TestCase):
 
 class SubsegTest(unittest.TestCase):
     def setUp(self):
-        self.old_encoding = urwid.util._target_encoding
+        self.old_encoding = get_encoding()
         urwid.set_encoding("euc-jp")
 
     def tearDown(self) -> None:
@@ -185,7 +173,7 @@ class SubsegTest(unittest.TestCase):
 
 class CalcTranslateTest:
     def setUp(self) -> None:
-        self.old_encoding = urwid.util._target_encoding
+        self.old_encoding = get_encoding()
         urwid.set_encoding("utf-8")
 
     def tearDown(self) -> None:
@@ -263,7 +251,7 @@ class CalcTranslateWordTest2(CalcTranslateTest, unittest.TestCase):
 
 class CalcTranslateWordTest3(CalcTranslateTest, unittest.TestCase):
     def setUp(self) -> None:
-        self.old_encoding = urwid.util._target_encoding
+        self.old_encoding = get_encoding()
         urwid.set_encoding('utf-8')
 
     def tearDown(self) -> None:
@@ -349,6 +337,7 @@ class CalcTranslateClipTest2(CalcTranslateTest, unittest.TestCase):
         [(6, 0, 6), (0, 6)],
         [(2, None), (2, 7, 9), (0, 9)],
         [(6, 10, 16), (0, 16)]]
+
 
 class CalcTranslateCantDisplayTest(CalcTranslateTest, unittest.TestCase):
     text = b'Hello\xe9\xa2\x96'

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -9,7 +9,7 @@ from urwid import util
 
 class CalcWidthTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.old_encoding = urwid.util._target_encoding
+        self.old_encoding = util.get_encoding()
 
     def tearDown(self) -> None:
         urwid.set_encoding(self.old_encoding)
@@ -36,7 +36,7 @@ class CalcWidthTest(unittest.TestCase):
 
 class ConvertDecSpecialTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.old_encoding = urwid.util._target_encoding
+        self.old_encoding = util.get_encoding()
 
     def tearDown(self) -> None:
         urwid.set_encoding(self.old_encoding)
@@ -63,7 +63,7 @@ class ConvertDecSpecialTest(unittest.TestCase):
 
 class WithinDoubleByteTest(unittest.TestCase):
     def setUp(self):
-        self.old_encoding = urwid.util._target_encoding
+        self.old_encoding = util.get_encoding()
         urwid.set_encoding("euc-jp")
 
     def tearDown(self) -> None:
@@ -105,7 +105,7 @@ class WithinDoubleByteTest(unittest.TestCase):
 
 class CalcTextPosTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.old_encoding = urwid.util._target_encoding
+        self.old_encoding = util.get_encoding()
 
     def tearDown(self) -> None:
         urwid.set_encoding(self.old_encoding)

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -1,21 +1,9 @@
 from __future__ import annotations
 
 import unittest
-from collections.abc import Generator
-from contextlib import contextmanager
 
 import urwid
-
-
-@contextmanager
-def encoding(encoding_name: str) -> Generator[None, None, None]:
-    old_encoding = 'ascii'  # Default fallback value
-    try:
-        old_encoding = urwid.util._target_encoding
-        urwid.set_encoding(encoding_name)
-        yield
-    finally:
-        urwid.set_encoding(old_encoding)
+from urwid.util import set_temporary_encoding
 
 
 class TextTest(unittest.TestCase):
@@ -23,139 +11,139 @@ class TextTest(unittest.TestCase):
         self.t = urwid.Text("I walk the\ncity in the night")
 
     def test1_wrap(self):
-        expected = [t.encode('iso8859-1') for t in ("I walk the","city in   ","the night ")]
+        expected = [t.encode("iso8859-1") for t in ("I walk the", "city in   ", "the night ")]
         got = self.t.render((10,))._text
         assert got == expected, f"got: {got!r} expected: {expected!r}"
 
     def test2_left(self):
-        self.t.set_align_mode('left')
-        expected = [t.encode('iso8859-1') for t in ("I walk the        ","city in the night ")]
+        self.t.set_align_mode("left")
+        expected = [t.encode("iso8859-1") for t in ("I walk the        ", "city in the night ")]
         got = self.t.render((18,))._text
         assert got == expected, f"got: {got!r} expected: {expected!r}"
 
     def test3_right(self):
-        self.t.set_align_mode('right')
-        expected = [t.encode('iso8859-1') for t in ("        I walk the"," city in the night")]
+        self.t.set_align_mode("right")
+        expected = [t.encode("iso8859-1") for t in ("        I walk the", " city in the night")]
         got = self.t.render((18,))._text
         assert got == expected, f"got: {got!r} expected: {expected!r}"
 
     def test4_center(self):
-        self.t.set_align_mode('center')
-        expected = [t.encode('iso8859-1') for t in ("    I walk the    "," city in the night")]
+        self.t.set_align_mode("center")
+        expected = [t.encode("iso8859-1") for t in ("    I walk the    ", " city in the night")]
         got = self.t.render((18,))._text
         assert got == expected, f"got: {got!r} expected: {expected!r}"
 
     def test5_encode_error(self):
-        with encoding("ascii"):
+        with set_temporary_encoding("ascii"):
             expected = [b"?  "]
-            got = urwid.Text('û').render((3,))._text
+            got = urwid.Text("û").render((3,))._text
             assert got == expected, f"got: {got!r} expected: {expected!r}"
 
 
 class EditTest(unittest.TestCase):
     def setUp(self):
-        self.t1 = urwid.Edit(b"","blah blah")
+        self.t1 = urwid.Edit(b"", "blah blah")
         self.t2 = urwid.Edit(b"stuff:", "blah blah")
-        self.t3 = urwid.Edit(b"junk:\n","blah blah\n\nbloo",1)
+        self.t3 = urwid.Edit(b"junk:\n", "blah blah\n\nbloo", 1)
         self.t4 = urwid.Edit("better:")
 
     def ktest(self, e, key, expected, pos, desc):
-        got= e.keypress((12,),key)
+        got = e.keypress((12,), key)
         assert got == expected, f"{desc}.  got: {got!r} expected:{expected!r}"
         assert e.edit_pos == pos, f"{desc}. pos: {e.edit_pos!r} expected pos: {pos!r}"
 
     def test1_left(self):
         self.t1.set_edit_pos(0)
-        self.ktest(self.t1,'left','left',0,"left at left edge")
+        self.ktest(self.t1, "left", "left", 0, "left at left edge")
 
-        self.ktest(self.t2,'left',None,8,"left within text")
+        self.ktest(self.t2, "left", None, 8, "left within text")
 
         self.t3.set_edit_pos(10)
-        self.ktest(self.t3,'left',None,9,"left after newline")
+        self.ktest(self.t3, "left", None, 9, "left after newline")
 
     def test2_right(self):
-        self.ktest(self.t1,'right','right',9,"right at right edge")
+        self.ktest(self.t1, "right", "right", 9, "right at right edge")
 
         self.t2.set_edit_pos(8)
-        self.ktest(self.t2,'right',None,9,"right at right edge-1")
+        self.ktest(self.t2, "right", None, 9, "right at right edge-1")
         self.t3.set_edit_pos(0)
-        self.t3.keypress((12,),'right')
+        self.t3.keypress((12,), "right")
         assert self.t3.get_pref_col((12,)) == 1
 
     def test3_up(self):
-        self.ktest(self.t1,'up','up',9,"up at top")
+        self.ktest(self.t1, "up", "up", 9, "up at top")
         self.t2.set_edit_pos(2)
-        self.t2.keypress((12,),"left")
+        self.t2.keypress((12,), "left")
         assert self.t2.get_pref_col((12,)) == 7
-        self.ktest(self.t2,'up','up',1,"up at top again")
+        self.ktest(self.t2, "up", "up", 1, "up at top again")
         assert self.t2.get_pref_col((12,)) == 7
         self.t3.set_edit_pos(10)
-        self.ktest(self.t3,'up',None,0,"up at top+1")
+        self.ktest(self.t3, "up", None, 0, "up at top+1")
 
     def test4_down(self):
-        self.ktest(self.t1,'down','down',9,"down single line")
+        self.ktest(self.t1, "down", "down", 9, "down single line")
         self.t3.set_edit_pos(5)
-        self.ktest(self.t3,'down',None,10,"down line 1 to 2")
-        self.ktest(self.t3,'down',None,15,"down line 2 to 3")
-        self.ktest(self.t3,'down','down',15,"down at bottom")
+        self.ktest(self.t3, "down", None, 10, "down line 1 to 2")
+        self.ktest(self.t3, "down", None, 15, "down line 2 to 3")
+        self.ktest(self.t3, "down", "down", 15, "down at bottom")
 
     def test_utf8_input(self):
-        with encoding("utf-8"):
-            self.t1.set_edit_text('')
-            self.t1.keypress((12,), 'û')
-            self.assertEqual(self.t1.edit_text, 'û'.encode())
-            self.t4.keypress((12,), 'û')
-            self.assertEqual(self.t4.edit_text, 'û')
+        with set_temporary_encoding("utf-8"):
+            self.t1.set_edit_text("")
+            self.t1.keypress((12,), "û")
+            self.assertEqual(self.t1.edit_text, "û".encode())
+            self.t4.keypress((12,), "û")
+            self.assertEqual(self.t4.edit_text, "û")
 
 
 class EditRenderTest(unittest.TestCase):
     def rtest(self, w, expected_text, expected_cursor):
-        expected_text = [t.encode('iso8859-1') for t in expected_text]
+        expected_text = [t.encode("iso8859-1") for t in expected_text]
         get_cursor = w.get_cursor_coords((4,))
         assert get_cursor == expected_cursor, f"got: {get_cursor!r} expected: {expected_cursor!r}"
-        r = w.render((4,), focus = 1)
+        r = w.render((4,), focus=1)
         text = [t for a, cs, t in [ln[0] for ln in r.content()]]
         assert text == expected_text, f"got: {text!r} expected: {expected_text!r}"
         assert r.cursor == expected_cursor, f"got: {r.cursor!r} expected: {expected_cursor!r}"
 
     def test1_SpaceWrap(self):
-        w = urwid.Edit("","blah blah")
+        w = urwid.Edit("", "blah blah")
         w.set_edit_pos(0)
-        self.rtest(w,["blah","blah"],(0,0))
+        self.rtest(w, ["blah", "blah"], (0, 0))
 
         w.set_edit_pos(4)
-        self.rtest(w,["lah ","blah"],(3,0))
+        self.rtest(w, ["lah ", "blah"], (3, 0))
 
         w.set_edit_pos(5)
-        self.rtest(w,["blah","blah"],(0,1))
+        self.rtest(w, ["blah", "blah"], (0, 1))
 
         w.set_edit_pos(9)
-        self.rtest(w,["blah","lah "],(3,1))
+        self.rtest(w, ["blah", "lah "], (3, 1))
 
     def test2_ClipWrap(self):
-        w = urwid.Edit("","blah\nblargh",1)
-        w.set_wrap_mode('clip')
+        w = urwid.Edit("", "blah\nblargh", 1)
+        w.set_wrap_mode("clip")
         w.set_edit_pos(0)
-        self.rtest(w,["blah","blar"],(0,0))
+        self.rtest(w, ["blah", "blar"], (0, 0))
 
         w.set_edit_pos(10)
-        self.rtest(w,["blah","argh"],(3,1))
+        self.rtest(w, ["blah", "argh"], (3, 1))
 
-        w.set_align_mode('right')
+        w.set_align_mode("right")
         w.set_edit_pos(6)
-        self.rtest(w,["blah","larg"],(0,1))
+        self.rtest(w, ["blah", "larg"], (0, 1))
 
     def test3_AnyWrap(self):
-        w = urwid.Edit("","blah blah")
-        w.set_wrap_mode('any')
+        w = urwid.Edit("", "blah blah")
+        w.set_wrap_mode("any")
 
-        self.rtest(w,["blah"," bla","h   "],(1,2))
+        self.rtest(w, ["blah", " bla", "h   "], (1, 2))
 
     def test4_CursorNudge(self):
-        w = urwid.Edit("","hi",align='right')
-        w.keypress((4,),'end')
+        w = urwid.Edit("", "hi", align="right")
+        w.keypress((4,), "end")
 
-        self.rtest(w,[" hi "],(3,0))
+        self.rtest(w, [" hi "], (3, 0))
 
-        w.keypress((4,),'left')
-        self.rtest(w,["  hi"],(3,0))
+        w.keypress((4,), "left")
+        self.rtest(w, ["  hi"], (3, 0))

--- a/urwid/canvas.py
+++ b/urwid/canvas.py
@@ -31,6 +31,7 @@ from urwid.util import (
     apply_target_encoding,
     calc_text_pos,
     calc_width,
+    get_encoding,
     rle_append_modify,
     rle_join_modify,
     rle_len,
@@ -409,7 +410,13 @@ class TextCanvas(Canvas):
         for i in range(len(text)):
             w = widths[i]
             if w > maxcol:
-                raise CanvasError(f"Canvas text is wider than the maxcol specified \n{maxcol!r}\n{widths!r}\n{text!r}")
+                raise CanvasError(
+                    f"Canvas text is wider than the maxcol specified:\n"
+                    f"maxcol={maxcol!r}\n"
+                    f"widths={widths!r}\n"
+                    f"text={text!r}\n"
+                    f"urwid target encoding={get_encoding()}"
+                )
             if w < maxcol:
                 text[i] += b"".rjust(maxcol - w)
             a_gap = len(text[i]) - rle_len(attr[i])

--- a/urwid/font.py
+++ b/urwid/font.py
@@ -131,14 +131,16 @@ class FontRegistry(type):
         """Get font by name if registered.
 
         This method is needed to get access to font from registry class.
+        >>> from urwid.util import set_temporary_encoding
         >>> repr(FontRegistry["a"])
         'None'
         >>> font = FontRegistry["Thin 3x3"]()
         >>> font.height
         3
-        >>> canvas: TextCanvas = font.render("+")
-        >>> b'\\n'.join(canvas.text).decode('utf-8') == "  \\n ┼\\n  "
-        True
+        >>> with set_temporary_encoding("utf-8"):
+        ...     canvas: TextCanvas = font.render("+")
+        >>> b'\\n'.join(canvas.text).decode('utf-8')
+        '  \\n ┼\\n  '
         """
         return cls.__registered.get(item)
 

--- a/urwid/util.py
+++ b/urwid/util.py
@@ -29,6 +29,8 @@ from contextlib import suppress
 from urwid import escape
 
 if typing.TYPE_CHECKING:
+    from collections.abc import Generator
+
     from typing_extensions import Self
 
 str_util = escape.str_util
@@ -118,6 +120,25 @@ def set_encoding(encoding):
         if encoding:
             "".encode(encoding)
             _target_encoding = encoding
+
+
+def get_encoding() -> str:
+    """Get target encoding."""
+    return _target_encoding
+
+
+@contextlib.contextmanager
+def set_temporary_encoding(encoding_name: str) -> Generator[None, None, None]:
+    """Internal helper for encoding specific validation in unittests/doctests.
+
+    Not exported globally.
+    """
+    old_encoding = _target_encoding
+    try:
+        set_encoding(encoding_name)
+        yield
+    finally:
+        set_encoding(old_encoding)
 
 
 def get_encoding_mode():

--- a/urwid/widget/padding.py
+++ b/urwid/widget/padding.py
@@ -86,10 +86,12 @@ class Padding(WidgetDecoration):
         ``'left'`` then self.original_widget may be clipped on the right.
 
         >>> from urwid import Divider, Text, BigText, FontRegistry
+        >>> from urwid.util import set_temporary_encoding
         >>> size = (7,)
         >>> def pr(w):
-        ...     for t in w.render(size).text:
-        ...         print(f"|{t.decode('utf-8')}|" )
+        ...     with set_temporary_encoding("utf-8"):
+        ...         for t in w.render(size).text:
+        ...             print(f"|{t.decode('utf-8')}|" )
         >>> pr(Padding(Text(u"Head"), ('relative', 20), 'pack'))
         | Head  |
         >>> pr(Padding(Divider(u"-"), left=2, right=1))


### PR DESCRIPTION
* Tests with `render` can fail if detected encoding differs from used during test write

* add non-public api for internal testing: `util.get_encoding()` for public getting _target_encoding `util.set_temporary_encoding` context manager

* Extend "Canvas text is wider than the maxcol specified" details: reproduced on nonstandard encoding

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [X] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

