### PR TITLE
Declare extension use Py_LIMITED_API explicit also in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ from setuptools import Extension, setup
 
 setup_d = {
     "name": "urwid",
-    "ext_modules": [Extension("urwid.str_util", sources=["source/str_util.c"])],
+    "ext_modules": [Extension("urwid.str_util", sources=["source/str_util.c"], py_limited_api=True)],
     "url": "https://urwid.org/",
     "test_suite": "urwid.tests",
 }


### PR DESCRIPTION
* Py_LIMITED_API 0x030700f0 is already defined in sources, this change only simplifies package re-build on the same system

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
