### PR TITLE
Fix #186 - disconnect_by_key should be exposed and use correct name

### DIFF
--- a/docs/reference/signals.rst
+++ b/docs/reference/signals.rst
@@ -11,7 +11,7 @@ instantiate your own Signals object.
 
 .. automethod:: Signals.connect
 
-.. function:: disconnect_by_key(obj, name, key)
+.. function:: disconnect_signal_by_key(obj, name, key)
 
 .. automethod:: Signals.disconnect_by_key
 

--- a/urwid/__init__.py
+++ b/urwid/__init__.py
@@ -90,7 +90,15 @@ from urwid.font import (
 )
 from urwid.listbox import ListBox, ListBoxError, ListWalker, ListWalkerError, SimpleFocusListWalker, SimpleListWalker
 from urwid.monitored_list import MonitoredFocusList, MonitoredList
-from urwid.signals import MetaSignals, Signals, connect_signal, disconnect_signal, emit_signal, register_signal
+from urwid.signals import (
+    MetaSignals,
+    Signals,
+    connect_signal,
+    disconnect_signal,
+    disconnect_signal_by_key,
+    emit_signal,
+    register_signal,
+)
 from urwid.text_layout import LayoutSegment, StandardTextLayout, TextLayout, default_layout
 from urwid.util import (
     MetaSuper,


### PR DESCRIPTION
* Use disconnect_signal_by_key as it instanced in signals

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [X] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

