### PR TITLE
Feature: support windows-curses for curses under windows

### DIFF
--- a/classifiers.txt
+++ b/classifiers.txt
@@ -6,6 +6,7 @@ License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)
 Operating System :: POSIX
 Operating System :: Unix
 Operating System :: MacOS :: MacOS X
+Operating System :: Microsoft :: Windows
 Topic :: Software Development :: Libraries :: Python Modules
 Topic :: Software Development :: Widget Sets
 Programming Language :: Python :: 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ exclude_lines = [
 
   # Exclude methods marked as abstract
   "@abstractmethod",
+  "@abc.abstractmethod",
 
   # Exclude import statements
   "^from\b",
@@ -116,6 +117,13 @@ exclude_lines = [
 
   # OS Specific
   "if platform.system()",
+  "if IS_WINDOWS",
+  "if os.name",
+  "if sys.platform",
+
+  # Manual test code
+  "class \\w*test:",
+  "def \\wtest():"
 ]
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ namespaces = false
 classifiers = {file = ["classifiers.txt"]}
 
 [project.optional-dependencies]
+curses = ["windows-curses;sys_platform=='win32'"]
 glib = ["PyGObject"]
 tornado = ["tornado"]
 trio = ["trio>=0.22.0", "exceptiongroup"]

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -4,3 +4,4 @@ twisted
 trio
 zmq
 exceptiongroups
+windows-curses;sys_platform=="win32"

--- a/tests/test_doctests.py
+++ b/tests/test_doctests.py
@@ -49,6 +49,13 @@ def load_tests(loader: unittest.TestLoader, tests: unittest.BaseTestSuite, ignor
     for m in module_doctests:
         tests.addTests(doctest.DocTestSuite(m, optionflags=option_flags))
 
+    try:
+        from urwid import curses_display
+    except ImportError:
+        pass  # do not run tests
+    else:
+        tests.addTests(doctest.DocTestSuite(curses_display, optionflags=option_flags))
+
     if os.name == "nt":
         tests.addTests(doctest.DocTestSuite("urwid._win32_raw_display", optionflags=option_flags))
     else:

--- a/tests/test_event_loops.py
+++ b/tests/test_event_loops.py
@@ -160,7 +160,10 @@ except ImportError:
     pass
 else:
 
-    @unittest.skipIf(IS_WINDOWS, "Windows is temporary not supported by TornadoEventLoop.")
+    @unittest.skipIf(
+        IS_WINDOWS,
+        "Windows is temporary not supported by TornadoEventLoop due to race conditions.",
+    )
     class TornadoEventLoopTest(unittest.TestCase, EventLoopTestMixin):
         def setUp(self):
             from tornado.ioloop import IOLoop
@@ -176,7 +179,10 @@ except ImportError:
     pass
 else:
 
-    @unittest.skipIf(IS_WINDOWS, "Windows is temporary not supported by TwistedEventLoop.")
+    @unittest.skipIf(
+        IS_WINDOWS,
+        "Windows is temporary not supported by TwistedEventLoop due to race conditions.",
+    )
     class TwistedEventLoopTest(unittest.TestCase, EventLoopTestMixin):
         def setUp(self):
             self.evl = urwid.TwistedEventLoop()
@@ -283,6 +289,10 @@ except ImportError:
     pass
 else:
 
+    @unittest.skipIf(
+        IS_WINDOWS,
+        "Windows is temporary not supported by TrioEventLoop due to race conditions.",
+    )
     class TrioEventLoopTest(unittest.TestCase, EventLoopTestMixin):
         def setUp(self):
             self.evl = urwid.TrioEventLoop()

--- a/urwid/escape.py
+++ b/urwid/escape.py
@@ -24,6 +24,7 @@ Terminal Escape Sequences for input and display
 
 from __future__ import annotations
 
+import os
 import re
 from collections.abc import MutableMapping, Sequence
 
@@ -35,6 +36,8 @@ except ImportError:
 # NOTE: because of circular imports (urwid.util -> urwid.escape -> urwid.util)
 # from urwid.util import is_mouse_event -- will not work here
 import urwid.util
+
+IS_WINDOWS = os.name == "nt"
 
 within_double_byte = str_util.within_double_byte
 
@@ -428,6 +431,10 @@ _keyconv = {
     350: "5",  # on numpad
     360: "end",
 }
+
+if IS_WINDOWS:
+    _keyconv[351] = "shift tab"
+    _keyconv[358] = "end"
 
 
 def process_keyqueue(codes: Sequence[int], more_available: bool) -> tuple[list[str], Sequence[int]]:


### PR DESCRIPTION
* Add `curses` optional dependencies group
* Default windows-curses require UTF-8 encoding to work

### Due to issue #690 not adding windows instructions to the manual

Fix #447

Successfully tested under windows 11 with enforced UTF-8 encoding:
```python
import urwid

urwid.set_encoding("utf-8")
```

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
