### PR TITLE
Fix windows encoding detection: encoding depends on python build options

### DIFF
--- a/tests/test_doctests.py
+++ b/tests/test_doctests.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import doctest
-import os
+import sys
 import unittest
 
 import urwid
@@ -56,7 +56,7 @@ def load_tests(loader: unittest.TestLoader, tests: unittest.BaseTestSuite, ignor
     else:
         tests.addTests(doctest.DocTestSuite(curses_display, optionflags=option_flags))
 
-    if os.name == "nt":
+    if sys.platform == "win32":
         tests.addTests(doctest.DocTestSuite("urwid._win32_raw_display", optionflags=option_flags))
     else:
         tests.addTests(doctest.DocTestSuite("urwid._posix_raw_display", optionflags=option_flags))

--- a/tests/test_event_loops.py
+++ b/tests/test_event_loops.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import os
 import socket
 import sys
 import typing
@@ -12,7 +11,7 @@ import urwid
 if typing.TYPE_CHECKING:
     from types import TracebackType
 
-IS_WINDOWS = os.name == "nt"
+IS_WINDOWS = sys.platform == "win32"
 
 
 class ClosingSocketPair(typing.ContextManager[typing.Tuple[socket.socket, socket.socket]]):

--- a/tests/test_vterm.py
+++ b/tests/test_vterm.py
@@ -31,7 +31,7 @@ from time import sleep
 import urwid
 from urwid.util import set_temporary_encoding
 
-IS_WINDOWS = os.name == "nt"
+IS_WINDOWS = sys.platform == "win32"
 
 
 class DummyCommand:

--- a/urwid/__init__.py
+++ b/urwid/__init__.py
@@ -21,7 +21,7 @@
 
 from __future__ import annotations
 
-import os
+import sys
 
 from urwid import raw_display
 from urwid.canvas import (
@@ -231,7 +231,7 @@ except ImportError:
     pass
 
 # OS Specific
-if os.name != "nt":
+if sys.platform != "win32":
     from urwid.vterm import TermCanvas, TermCharset, Terminal, TermModes, TermScroller
 
     # ZMQEventLoop cause interpreter crash on windows

--- a/urwid/curses_display.py
+++ b/urwid/curses_display.py
@@ -25,7 +25,7 @@ Curses-based UI implementation
 from __future__ import annotations
 
 import curses
-import os
+import sys
 import typing
 from contextlib import suppress
 
@@ -37,7 +37,7 @@ from urwid.display_common import UNPRINTABLE_TRANS_TABLE, AttrSpec, BaseScreen, 
 if typing.TYPE_CHECKING:
     from typing_extensions import Literal
 
-IS_WINDOWS = os.name == "nt"
+IS_WINDOWS = sys.platform == "win32"
 
 # curses.KEY_RESIZE (sometimes not defined)
 if IS_WINDOWS:

--- a/urwid/display_common.py
+++ b/urwid/display_common.py
@@ -34,7 +34,7 @@ if typing.TYPE_CHECKING:
 
     from typing_extensions import Literal, Self
 
-IS_WINDOWS = os.name == "nt"
+IS_WINDOWS = sys.platform == "win32"
 
 if not IS_WINDOWS:
     import termios

--- a/urwid/escape.py
+++ b/urwid/escape.py
@@ -24,8 +24,8 @@ Terminal Escape Sequences for input and display
 
 from __future__ import annotations
 
-import os
 import re
+import sys
 from collections.abc import MutableMapping, Sequence
 
 try:
@@ -37,7 +37,7 @@ except ImportError:
 # from urwid.util import is_mouse_event -- will not work here
 import urwid.util
 
-IS_WINDOWS = os.name == "nt"
+IS_WINDOWS = sys.platform == "win32"
 
 within_double_byte = str_util.within_double_byte
 

--- a/urwid/event_loop/__init__.py
+++ b/urwid/event_loop/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import os
+import sys
 
 from .abstract_loop import EventLoop, ExitMainLoop
 from .asyncio_loop import AsyncioEventLoop
@@ -39,7 +39,7 @@ try:
 except ImportError:
     pass
 
-if os.name != "nt":
+if sys.platform != "win32":
     # ZMQEventLoop cause interpreter crash on windows
     try:
         from .zmq_loop import ZMQEventLoop

--- a/urwid/raw_display.py
+++ b/urwid/raw_display.py
@@ -24,11 +24,11 @@ Direct terminal UI implementation
 
 from __future__ import annotations
 
-import os
+import sys
 
 __all__ = ("Screen",)
 
-IS_WINDOWS = os.name == "nt"
+IS_WINDOWS = sys.platform == "win32"
 
 if IS_WINDOWS:
     from ._win32_raw_display import Screen

--- a/urwid/util.py
+++ b/urwid/util.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import codecs
 import contextlib
+import sys
 import typing
 import warnings
 from contextlib import suppress
@@ -45,6 +46,16 @@ within_double_byte = str_util.within_double_byte
 
 
 def detect_encoding() -> str:
+    # Windows is a special case:
+    # CMD is Unicode and non-unicode at the same time:
+    # Unicode display support depends on C API usage and partially limited by font settings.
+    # By default, python is distributed in "Unicode" version, and since Python version 3.8 only Unicode.
+    # In case of curses, "windows-curses" is distributed in unicode-only.
+    # Since Windows 10 default console font is already unicode,
+    # in older versions maybe need to set TTF font manually to support more symbols
+    # (this does not affect unicode IO).
+    if sys.platform == "win32" and sys.getdefaultencoding() == "utf-8":
+        return "urf-8"
     # Try to determine if using a supported double-byte encoding
     import locale
 


### PR DESCRIPTION
* Normalize Windows OS detection to `sys.platform == "win32"`

Fix #690
Related #692 
Related #448 
Related #447 
Related #689 
Related #240 

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
