### PR TITLE
Refactoring: delegate_to_widget_mixin - use methods instead of properties

### DIFF
--- a/urwid/widget/columns.py
+++ b/urwid/widget/columns.py
@@ -600,7 +600,7 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
             canv.pad_trim_left_right(0, size[0] - canv.cols())
         return canv
 
-    def get_cursor_coords(self, size):
+    def get_cursor_coords(self, size: tuple[int] | tuple[int, int]) -> tuple[int, int] | None:
         """Return the cursor coordinates from the focus widget."""
         w, (_t, _n, b) = self.contents[self.focus_position]
 

--- a/urwid/widget/widget.py
+++ b/urwid/widget/widget.py
@@ -34,7 +34,7 @@ from urwid.util import MetaSuper
 from .constants import Sizing
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Callable, Hashable
+    from collections.abc import Hashable
 
 
 class WidgetMeta(MetaSuper, signals.MetaSignals):
@@ -716,43 +716,45 @@ def delegate_to_widget_mixin(attribute_name: str):
             canv = get_delegate(self).render(size, focus=focus)
             return CompositeCanvas(canv)
 
-        @property
-        def selectable(self) -> Callable[[], bool]:
-            return get_delegate(self).selectable
+        def selectable(self) -> bool:
+            return get_delegate(self).selectable()
 
-        @property
-        def get_cursor_coords(self):
-            return get_delegate(self).get_cursor_coords
+        def get_cursor_coords(self, size: tuple[()] | tuple[int] | tuple[int, int]) -> tuple[int, int] | None:
+            return get_delegate(self).get_cursor_coords(size)
 
-        @property
-        def get_pref_col(self):
-            return get_delegate(self).get_pref_col
+        def get_pref_col(self, size: tuple[()] | tuple[int] | tuple[int, int]) -> int:
+            return get_delegate(self).get_pref_col(size)
 
-        @property
-        def keypress(self):
-            return get_delegate(self).keypress
+        def keypress(self, size: tuple[()] | tuple[int] | tuple[int, int], key: str) -> str | None:
+            return get_delegate(self).keypress(size, key)
 
-        @property
-        def move_cursor_to_coords(self):
-            return get_delegate(self).move_cursor_to_coords
+        def move_cursor_to_coords(
+            self,
+            size: tuple[()] | tuple[int] | tuple[int, int],
+            col: int,
+            row: int,
+        ) -> bool:
+            return get_delegate(self).move_cursor_to_coords(size, col, row)
 
-        @property
-        def rows(self):
-            return get_delegate(self).rows
+        def rows(self, size: tuple[int], focus: bool = False) -> int:
+            return get_delegate(self).rows(size, focus=focus)
 
-        @property
         def mouse_event(
             self,
-        ) -> Callable[[tuple[()] | tuple[int] | tuple[int, int], str, int, int, int, bool], bool | None,]:
-            return get_delegate(self).mouse_event
+            size: tuple[()] | tuple[int] | tuple[int, int],
+            event,
+            button: int,
+            col: int,
+            row: int,
+            focus: bool,
+        ) -> bool | None:
+            return get_delegate(self).mouse_event(size, event, button, col, row, focus)
 
-        @property
-        def sizing(self):
-            return get_delegate(self).sizing
+        def sizing(self) -> frozenset[Sizing]:
+            return get_delegate(self).sizing()
 
-        @property
-        def pack(self):
-            return get_delegate(self).pack
+        def pack(self, size: tuple[()] | tuple[int] | tuple[int, int], focus: bool = False) -> tuple[int, int]:
+            return get_delegate(self).pack(size, focus)
 
     return DelegateToWidgetMixin
 


### PR DESCRIPTION
* in case of properties, static type checking is hard-fails due to re-definition method -> property -> method

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

