### PR TITLE
Feature: support FIXED render mode for Text without annotation as FIXED

### DIFF
--- a/urwid/widget/edit.py
+++ b/urwid/widget/edit.py
@@ -136,12 +136,12 @@ class Edit(Text):
 
         Text returned includes the caption and edit_text, possibly masked.
 
-        >>> Edit(u"What? ","oh, nothing.").get_text() # ... = u in Python 2
-        (...'What? oh, nothing.', [])
+        >>> Edit(u"What? ","oh, nothing.").get_text()
+        ('What? oh, nothing.', [])
         >>> Edit(('bright',u"user@host:~$ "),"ls").get_text()
-        (...'user@host:~$ ls', [('bright', 13)])
+        ('user@host:~$ ls', [('bright', 13)])
         >>> Edit(u"password:", u"seekrit", mask=u"*").get_text()
-        (...'password:*******', [])
+        ('password:*******', [])
         """
 
         if self._mask is None:
@@ -584,9 +584,10 @@ class Edit(Text):
         Render edit widget and return canvas.  Include cursor when in
         focus.
 
-        >>> c = Edit("? ","yes").render((10,), focus=True)
-        >>> c.text # ... = b in Python 3
-        [...'? yes     ']
+        >>> edit = Edit("? ","yes")
+        >>> c = edit.render((10,), focus=True)
+        >>> c.text
+        [b'? yes     ']
         >>> c.cursor
         (5, 0)
         """
@@ -604,7 +605,7 @@ class Edit(Text):
         return canv
 
     def get_line_translation(self, maxcol: int, ta=None):
-        trans = Text.get_line_translation(self, maxcol, ta)
+        trans = super().get_line_translation(maxcol, ta)
         if not self._shift_view_to_cursor:
             return trans
 
@@ -652,7 +653,7 @@ class Edit(Text):
 class IntEdit(Edit):
     """Edit widget for integer values"""
 
-    def valid_char(self, ch):
+    def valid_char(self, ch: str) -> bool:
         """
         Return true for decimal digits.
         """

--- a/urwid/widget/wimp.py
+++ b/urwid/widget/wimp.py
@@ -75,7 +75,7 @@ class SelectableIcon(Text):
         super().__init__(text, align=align, wrap=wrap, layout=layout)
         self._cursor_position = cursor_position
 
-    def render(self, size: tuple[int], focus: bool = False) -> TextCanvas | CompositeCanvas:  # type: ignore[override]
+    def render(self, size: tuple[int] | tuple[()], focus: bool = False) -> TextCanvas | CompositeCanvas:  # type: ignore[override]
         """
         Render the text content of this widget with a cursor when
         in focus.
@@ -90,6 +90,11 @@ class SelectableIcon(Text):
         (2, 0)
         >>> si.render((2,), focus=True).cursor
         (0, 1)
+        >>> si.render(()).cursor
+        >>> si.render(()).text
+        [b'((*))']
+        >>> si.render((), focus=True).cursor
+        (2, 0)
         """
         c: TextCanvas | CompositeCanvas = super().render(size, focus)
         if focus:
@@ -98,7 +103,7 @@ class SelectableIcon(Text):
             c.cursor = self.get_cursor_coords(size)
         return c
 
-    def get_cursor_coords(self, size: tuple[int]) -> tuple[int, int] | None:
+    def get_cursor_coords(self, size: tuple[int] | tuple[()]) -> tuple[int, int] | None:
         """
         Return the position of the cursor if visible.  This method
         is required for widgets that display a cursor.
@@ -107,14 +112,17 @@ class SelectableIcon(Text):
             return None
         # find out where the cursor will be displayed based on
         # the text layout
-        (maxcol,) = size
+        if size:
+            (maxcol,) = size
+        else:
+            maxcol, _ = self.pack()
         trans = self.get_line_translation(maxcol)
         x, y = calc_coords(self.text, trans, self._cursor_position)
         if maxcol <= x:
             return None
         return x, y
 
-    def keypress(self, size: tuple[int], key: str) -> str:
+    def keypress(self, size: tuple[int] | tuple[()], key: str) -> str:
         """
         No keys are handled by this widget.  This method is
         required for selectable widgets.


### PR DESCRIPTION
* Do not mark `FIXED` to prevent unexpected regressions
* `Text` was historically supported `Text().pack()` call
* Update `SelectableIcon` for `FIXED` API support

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [X] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)