### PR TITLE
Documentation: explain Windows support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,8 @@ Windows support notes
 
     pip install urwid[curses]
 
+* Window resize is not fully functional without keyboard/mouse input if RawDisplay used.
+* CursesDisplay decode limited scope of modifier keys combinations.
 * Only UTF-8 mode is supported.
 
 

--- a/README.rst
+++ b/README.rst
@@ -63,8 +63,7 @@ Windows support notes
 
     pip install urwid[curses]
 
-* For Windows OS default encoding depends on python binary version
-  and normally automatically set to the UTF-8.
+* Only UTF-8 mode is supported.
 
 
 Testing

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,9 @@ Urwid
 About
 =====
 
-Urwid is a console user interface library for Python on Linux, OSX, Cygwin or other unix-like OS.
+Urwid is a console user interface library for Python on Linux, OSX, Cygwin or other unix-like OS
+and partially supports Windows OS (see below).
+
 It includes many features useful for text console application developers including:
 
 - Applications resize quickly and smoothly
@@ -43,6 +45,27 @@ Alternatively if you are on Debian or Ubuntu
 .. code:: bash
 
    apt-get install python3-urwid
+
+Windows support notes
+=====================
+
+* Not supported:
+
+1. Terminal widget and all related render API (TermCanvas, TermCharset, TermModes, TermScroller)
+2. Any file descriptors except sockets (Windows OS limitation)
+3. ZMQEventLoop.
+
+* Special requirements:
+
+1. Extra libraries required for curses display support:
+
+.. code-block:: bash
+
+    pip install urwid[curses]
+
+* For Windows OS default encoding depends on python binary version
+  and normally automatically set to the UTF-8.
+
 
 Testing
 =======

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,8 @@ commands =
 
 [testenv:readme]
 deps =
-  twine build
+  twine
+  build
 commands =
   python -m build
   twine check {toxinidir}/dist/*


### PR DESCRIPTION
* Fix README.rst validation target in tox.ini

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [X] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
