### PR TITLE
Regression: fix typo in windows encoding detection + properties

### DIFF
--- a/urwid/util.py
+++ b/urwid/util.py
@@ -55,7 +55,7 @@ def detect_encoding() -> str:
     # in older versions maybe need to set TTF font manually to support more symbols
     # (this does not affect unicode IO).
     if sys.platform == "win32" and sys.getdefaultencoding() == "utf-8":
-        return "urf-8"
+        return "utf-8"
     # Try to determine if using a supported double-byte encoding
     import locale
 

--- a/urwid/widget/widget.py
+++ b/urwid/widget/widget.py
@@ -34,7 +34,7 @@ from urwid.util import MetaSuper
 from .constants import Sizing
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Hashable
+    from collections.abc import Callable, Hashable
 
 
 class WidgetMeta(MetaSuper, signals.MetaSignals):
@@ -722,33 +722,28 @@ def delegate_to_widget_mixin(attribute_name: str):
         def get_cursor_coords(self, size: tuple[()] | tuple[int] | tuple[int, int]) -> tuple[int, int] | None:
             return get_delegate(self).get_cursor_coords(size)
 
-        def get_pref_col(self, size: tuple[()] | tuple[int] | tuple[int, int]) -> int:
-            return get_delegate(self).get_pref_col(size)
+        @property
+        def get_pref_col(self) -> Callable[[tuple[()] | tuple[int] | tuple[int, int]], int | None]:
+            # TODO(Aleksei):  Get rid of property usage after getting rid of "if getattr"
+            return get_delegate(self).get_pref_col
 
         def keypress(self, size: tuple[()] | tuple[int] | tuple[int, int], key: str) -> str | None:
             return get_delegate(self).keypress(size, key)
 
-        def move_cursor_to_coords(
-            self,
-            size: tuple[()] | tuple[int] | tuple[int, int],
-            col: int,
-            row: int,
-        ) -> bool:
-            return get_delegate(self).move_cursor_to_coords(size, col, row)
+        @property
+        def move_cursor_to_coords(self) -> Callable[[[tuple[()] | tuple[int] | tuple[int, int], int, int]], bool]:
+            # TODO(Aleksei):  Get rid of property usage after getting rid of "if getattr"
+            return get_delegate(self).move_cursor_to_coords
 
         def rows(self, size: tuple[int], focus: bool = False) -> int:
             return get_delegate(self).rows(size, focus=focus)
 
+        @property
         def mouse_event(
             self,
-            size: tuple[()] | tuple[int] | tuple[int, int],
-            event,
-            button: int,
-            col: int,
-            row: int,
-            focus: bool,
-        ) -> bool | None:
-            return get_delegate(self).mouse_event(size, event, button, col, row, focus)
+        ) -> Callable[[tuple[()] | tuple[int] | tuple[int, int], str, int, int, int, bool], bool | None]:
+            # TODO(Aleksei):  Get rid of property usage after getting rid of "if getattr"
+            return get_delegate(self).mouse_event
 
         def sizing(self) -> frozenset[Sizing]:
             return get_delegate(self).sizing()


### PR DESCRIPTION
* Temporary `get_pref_col`, `move_cursor_to_coords`, `mouse_event` should be temporary properties (due to `hasattr` usage in a call chain)

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
