### PR TITLE
Feature: extend functional keys handling with key modifiers

### DIFF
--- a/tests/test_escapes.py
+++ b/tests/test_escapes.py
@@ -10,71 +10,151 @@ import urwid.escape
 
 
 class InputEscapeSequenceParserTest(unittest.TestCase):
-    """ Tests for parser of input escape sequences """
+    """Tests for parser of input escape sequences"""
 
     def test_bare_escape(self):
         codes = [27]
-        expected = ['esc']
+        expected = ["esc"]
         actual, rest = urwid.escape.process_keyqueue(codes, more_available=False)
         self.assertListEqual(expected, actual)
         self.assertListEqual([], rest)
 
     def test_meta(self):
-        codes = [27, ord('4'), ord('2')]
-        expected = ['meta 4']
+        codes = [27, ord("4"), ord("2")]
+        expected = ["meta 4"]
         actual, rest = urwid.escape.process_keyqueue(codes, more_available=False)
         self.assertListEqual(expected, actual)
-        self.assertListEqual([ord('2')], rest)
+        self.assertListEqual([ord("2")], rest)
 
     def test_shift_arrows(self):
-        codes = [27, ord('['), ord('a')]
-        expected = ['shift up']
+        codes = [27, ord("["), ord("a")]
+        expected = ["shift up"]
         actual, rest = urwid.escape.process_keyqueue(codes, more_available=False)
         self.assertListEqual(expected, actual)
         self.assertListEqual([], rest)
 
     def test_ctrl_pgup(self):
         codes = [27, 91, 53, 59, 53, 126]
-        expected = ['ctrl page up']
+        expected = ["ctrl page up"]
         actual, rest = urwid.escape.process_keyqueue(codes, more_available=False)
         self.assertListEqual(expected, actual)
         self.assertListEqual([], rest)
 
     def test_esc_meta_1(self):
         codes = [27, 27, 49]
-        expected = ['esc', 'meta 1']
+        expected = ["esc", "meta 1"]
         actual, rest = urwid.escape.process_keyqueue(codes, more_available=False)
         self.assertListEqual(expected, actual)
         self.assertListEqual([], rest)
 
     def test_midsequence(self):
         # '[11~' is F1, '[12~' is F2, etc
-        codes = [27, ord('['), ord('1')]
+        codes = [27, ord("["), ord("1")]
 
         with self.assertRaises(urwid.escape.MoreInputRequired):
             urwid.escape.process_keyqueue(codes, more_available=True)
 
         actual, rest = urwid.escape.process_keyqueue(codes, more_available=False)
-        self.assertListEqual(['meta ['], actual)
-        self.assertListEqual([ord('1')], rest)
+        self.assertListEqual(["meta ["], actual)
+        self.assertListEqual([ord("1")], rest)
 
     def test_mouse_press(self):
         codes = [27, 91, 77, 32, 41, 48]
-        expected = [('mouse press', 1.0, 8, 15)]
+        expected = [("mouse press", 1.0, 8, 15)]
         actual, rest = urwid.escape.process_keyqueue(codes, more_available=False)
         self.assertListEqual(expected, actual)
         self.assertListEqual([], rest)
 
     def test_bug_104(self):
-        """ GH #104: click-Esc & Esc-click crashes urwid apps """
+        """GH #104: click-Esc & Esc-click crashes urwid apps"""
         codes = [27, 27, 91, 77, 32, 127, 59]
-        expected = ['esc', ('mouse press', 1.0, 94, 26)]
+        expected = ["esc", ("mouse press", 1.0, 94, 26)]
         actual, rest = urwid.escape.process_keyqueue(codes, more_available=False)
         self.assertListEqual(expected, actual)
         self.assertListEqual([], rest)
 
         codes = [27, 27, 91, 77, 35, 120, 59]
-        expected = ['esc', ('mouse release', 0, 87, 26)]
+        expected = ["esc", ("mouse release", 0, 87, 26)]
         actual, rest = urwid.escape.process_keyqueue(codes, more_available=False)
         self.assertListEqual(expected, actual)
         self.assertListEqual([], rest)
+
+    def test_functional_keys(self):
+        """Test for functional keys F1-F4, F5-F12."""
+
+        def check_key(expected: str, codes: list[int]) -> None:
+            actual, rest = urwid.escape.process_keyqueue(codes, more_available=False)
+            self.assertEqual(
+                [expected],
+                actual,
+                f"Codes {codes!r} ({[chr(code) for code in codes]}) was not decoded to {expected!r}",
+            )
+
+        # F1-F4
+        for num in range(1, 5):
+            codes = [27, ord("O"), 79 + num]
+            check_key(f"f{num}", codes)
+
+        # F5-F8
+        for num, offset in enumerate((0, 2, 3, 4), start=5):
+            codes = [27, ord("["), ord("1"), 53 + offset, ord("~")]
+            check_key(f"f{num}", codes)
+
+        # F9-F12
+        for num, offset in enumerate((0, 1, 3, 4), start=9):
+            codes = [27, ord("["), ord("2"), 48 + offset, ord("~")]
+            check_key(f"f{num}", codes)
+
+    def test_functional_keys_mods_f1_f4(self):
+        """Test for modifiers handling for functional keys F1-F4."""
+        prefixes = ("O", "[1;")
+        masks = "12345678"
+        letters = "PQRS"
+
+        for prefix in prefixes:
+            encoded_prefix = tuple(ord(element) for element in prefix)
+            for num, letter in enumerate(letters, start=1):
+                for mask in masks:
+                    codes = [27, *encoded_prefix, ord(mask), ord(letter)]
+                    actual, rest = urwid.escape.process_keyqueue(codes, more_available=False)
+                    expected = urwid.escape.escape_modifier(mask) + f"f{num}"
+                    self.assertEqual(
+                        [expected],
+                        actual,
+                        f"Codes {codes!r} ({[chr(code) for code in codes]}) was not decoded to {expected!r}",
+                    )
+
+    def test_functional_keys_mods_simple_f1_20(self):
+        """Test for modifiers handling for functional keys F1-F20."""
+        masks = "12345678"
+        numbers = (11, 12, 13, 14, 15, 17, 18, 19, 20, 21, 23, 24, 25, 26, 28, 29, 31, 32, 33, 34)
+        for num, number in enumerate(numbers, start=1):
+            encoded_number = tuple(ord(element) for element in str(number))
+            for mask in masks:
+                codes = [27, ord("["), *encoded_number, ord(";"), ord(mask), ord("~")]
+                actual, rest = urwid.escape.process_keyqueue(codes, more_available=False)
+                expected = urwid.escape.escape_modifier(mask) + f"f{num}"
+                self.assertEqual(
+                    [expected],
+                    actual,
+                    f"Codes {codes!r} ({[chr(code) for code in codes]}) was not decoded to {expected!r}",
+                )
+
+    def test_sgrmouse(self):
+        prefix = (27, ord("["), ord("<"))
+        x = 4
+        y = 8
+        coord = (ord(f"{x + 1}"), ord(";"), ord(f"{y + 1}"))
+        action = ord("M")
+        modifiers = ((0, ""), (8, "meta "), (16, "ctrl "), (24, "meta ctrl "))
+        for key, code in enumerate((0b0, 0b1, 0b10, 0b1000000, 0b1000001), start=1):
+            for mod_code, mod in modifiers:
+                key_code = tuple(ord(element) for element in str(code | mod_code))
+                codes = [*prefix, *key_code, ord(";"), *coord, action]
+                actual, rest = urwid.escape.process_keyqueue(codes, more_available=False)
+                expected = [(mod + "mouse press", key, x, y)]
+                self.assertEqual(
+                    expected,
+                    actual,
+                    f"Codes {codes!r} ({[chr(code) for code in codes]}) was not decoded to {expected!r}",
+                )

--- a/urwid/escape.py
+++ b/urwid/escape.py
@@ -328,7 +328,7 @@ class KeyqueueTrie:
         if b & 8:
             prefixes.append("meta ")
         if b & 16:
-            prefixes.append(f"ctrl ")
+            prefixes.append("ctrl ")
         prefix = "".join(prefixes)
 
         wheel_used: typing.Literal[0, 1] = (b & 64) >> 6

--- a/urwid/escape.py
+++ b/urwid/escape.py
@@ -154,10 +154,11 @@ input_sequences = [
         for letter, key in zip("ABCDEFGH", ("up", "down", "right", "left", "5", "end", "5", "home"))
     ),
     *(
-        # modified F1-F4 keys -- O#X form
-        (f"O{digit}{letter}", escape_modifier(digit) + key)
+        # modified F1-F4 keys - O#X form and [1;#X form
+        (prefix + digit + letter, escape_modifier(digit) + f"f{number}")
+        for prefix in ("O", "[1;")
         for digit in "12345678"
-        for letter, key in zip("PQRS", ("f1", "f2", "f3", "f4"))
+        for number, letter in enumerate("PQRS", start=1)
     ),
     *(
         # modified F1-F13 keys -- [XX;#~ form
@@ -173,10 +174,6 @@ input_sequences = [
             ),
         )
     ),
-    *((f"[1;{digit}P", escape_modifier(digit) + "f1") for digit in "12345678"),  # F1 is special
-    *((f"[1;{digit}Q", escape_modifier(digit) + "f2") for digit in "12345678"),  # F2 is special
-    *((f"[1;{digit}R", escape_modifier(digit) + "f3") for digit in "12345678"),  # F3 is special
-    *((f"[1;{digit}S", escape_modifier(digit) + "f4") for digit in "12345678"),  # F4 is special
     # mouse reporting (special handling done in KeyqueueTrie)
     ("[M", "mouse"),
     # mouse reporting for SGR 1006

--- a/urwid/escape.py
+++ b/urwid/escape.py
@@ -30,7 +30,7 @@ import typing
 from collections.abc import MutableMapping, Sequence
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Iterable, Collection
+    from collections.abc import Collection, Iterable
 
 try:
     from urwid import str_util

--- a/urwid/escape.py
+++ b/urwid/escape.py
@@ -174,7 +174,7 @@ input_sequences = [
                 "delete",
                 "page up",
                 "page down",
-                *(f"f{idx}" for idx in range(1, 20)),
+                *(f"f{idx}" for idx in range(1, 21)),
             ),
         )
     ),
@@ -264,7 +264,7 @@ class KeyqueueTrie:
         if b & 8:
             prefixes.append("meta ")
         if b & 16:
-            prefixes.append(f"ctrl ")
+            prefixes.append("ctrl ")
         if (b & MOUSE_MULTIPLE_CLICK_MASK) >> 9 == 1:
             prefixes.append("double ")
         if (b & MOUSE_MULTIPLE_CLICK_MASK) >> 9 == 2:


### PR DESCRIPTION
* F1 is a special and use number `1` postfixed by `P`
* F2 is a special and use number `1` postfixed by `Q`
* F3 is a special and use number `1` postfixed by `R`
* F4 is a special and use number `1` postfixed by `S`

Related #702
Related #702

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)