### PR TITLE
Fix: Phantom NULL keys codes from modifier keys on Win32 RawDisplay

### DIFF
--- a/urwid/_posix_raw_display.py
+++ b/urwid/_posix_raw_display.py
@@ -309,10 +309,7 @@ class Screen(_raw_display_base.Screen):
         if not self._started:
             return []
 
-        fd_list = [self._resize_pipe_rd]
-        fd = self._input_fileno()
-        if fd is not None:
-            fd_list.append(fd)
+        fd_list = super().get_input_descriptors()
         if self.gpm_mev is not None:
             fd_list.append(self.gpm_mev.stdout.fileno())
         return fd_list

--- a/urwid/_win32.py
+++ b/urwid/_win32.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import enum
 import typing
 from ctypes import POINTER, Structure, Union, windll
 from ctypes.wintypes import BOOL, CHAR, DWORD, HANDLE, LPDWORD, SHORT, UINT, WCHAR, WORD
@@ -116,12 +117,12 @@ class INPUT_RECORD(Structure):
     _fields_: typing.ClassVar[list[tuple[str, type]]] = [("EventType", WORD), ("Event", Event)]
 
 
-class EventType:
-    FOCUS_EVENT = 0x0010
+class EventType(enum.IntFlag):
     KEY_EVENT = 0x0001
-    MENU_EVENT = 0x0008
     MOUSE_EVENT = 0x0002
     WINDOW_BUFFER_SIZE_EVENT = 0x0004
+    MENU_EVENT = 0x0008
+    FOCUS_EVENT = 0x0010
 
 
 # https://docs.microsoft.com/de-de/windows/console/getstdhandle


### PR DESCRIPTION
* For `windows-curses` KEY_MOUSE is 539, btw signals work buggy: in case of fast click, "press" may be handled and "release" missed
* Use max 2 extra wait cycles if multiple resize commands are received. This will allow adequate terminal behavior without CPU overload.
* Explicit close resize command sockets on RawDisplay instance delete
* `get_input_descriptors` method is 90% common for both POSIX and Win32 implementations -> move to the base class and overload
* Win32 `EventType` -> use `IntFlag` type (supported since Python 3.6)

Partial #700
Partial #702

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
