### PR TITLE
Feature: Add internal logging for behavioral debug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,8 @@ exclude_lines = [
 
   # Code for static analysis is never covered:
   "if typing.TYPE_CHECKING:",
+  "@typing.overload",
+  "@overload",
 
   # Fallback code with no installed deps is almost impossible to cover properly
   "except ImportError:",

--- a/urwid/_win32.py
+++ b/urwid/_win32.py
@@ -81,6 +81,26 @@ class MOUSE_EVENT_RECORD(Structure):
     ]
 
 
+class MouseButtonState(enum.IntFlag):
+    """https://learn.microsoft.com/en-us/windows/console/mouse-event-record-str"""
+
+    FROM_LEFT_1ST_BUTTON_PRESSED = 0x0001
+    RIGHTMOST_BUTTON_PRESSED = 0x0002
+    FROM_LEFT_2ND_BUTTON_PRESSED = 0x0004
+    FROM_LEFT_3RD_BUTTON_PRESSED = 0x0008
+    FROM_LEFT_4TH_BUTTON_PRESSED = 0x0010
+
+
+class MouseEventFlags(enum.IntFlag):
+    """https://learn.microsoft.com/en-us/windows/console/mouse-event-record-str"""
+
+    BUTTON_PRESSED = 0x0000  # Default action, used in examples, but not in official enum
+    MOUSE_MOVED = 0x0001
+    DOUBLE_CLICK = 0x0002
+    MOUSE_WHEELED = 0x0004
+    MOUSE_HWHEELED = 0x0008
+
+
 class WINDOW_BUFFER_SIZE_RECORD(Structure):
     """https://docs.microsoft.com/en-us/windows/console/window-buffer-size-record-str"""
 

--- a/urwid/curses_display.py
+++ b/urwid/curses_display.py
@@ -25,6 +25,7 @@ Curses-based UI implementation
 from __future__ import annotations
 
 import curses
+import logging
 import sys
 import typing
 from contextlib import suppress
@@ -103,6 +104,7 @@ _curses_colours = {
 class Screen(BaseScreen, RealTerminal):
     def __init__(self):
         super().__init__()
+        self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
         self.curses_pairs = [(None, None)]  # Can't be sure what pair 0 will default to
         self.palette = {}
         self.has_color = False
@@ -550,6 +552,9 @@ class Screen(BaseScreen, RealTerminal):
 
     def draw_screen(self, size: tuple[int, int], r: Canvas):
         """Paint screen with rendered canvas."""
+
+        logger = self.logger.getChild("draw_screen")
+
         if not self._started:
             raise RuntimeError
 
@@ -557,6 +562,8 @@ class Screen(BaseScreen, RealTerminal):
 
         if r.rows() != rows:
             raise ValueError("canvas size and passed size don't match")
+
+        logger.debug(f"Drawing screen with size {size!r}")
 
         y = -1
         for row in r.content():

--- a/urwid/display_common.py
+++ b/urwid/display_common.py
@@ -21,6 +21,7 @@
 from __future__ import annotations
 
 import abc
+import logging
 import os
 import sys
 import typing
@@ -36,6 +37,7 @@ if typing.TYPE_CHECKING:
 
     from urwid import Canvas
 
+LOGGER = logging.getLogger(__name__)
 IS_WINDOWS = sys.platform == "win32"
 
 if not IS_WINDOWS:
@@ -1001,6 +1003,9 @@ class BaseScreen(metaclass=BaseMeta):
 
     def __init__(self) -> None:
         super().__init__()
+
+        self.logger = LOGGER.getChild(self.__class__.__name__)
+
         self._palette: dict[str | None, tuple[AttrSpec, AttrSpec, AttrSpec, AttrSpec, AttrSpec]] = {}
         self._started: bool = False
 

--- a/urwid/event_loop/abstract_loop.py
+++ b/urwid/event_loop/abstract_loop.py
@@ -24,6 +24,7 @@
 from __future__ import annotations
 
 import abc
+import logging
 import signal
 import typing
 
@@ -45,6 +46,11 @@ class EventLoop(abc.ABC):
     """
     Abstract class representing an event loop to be used by :class:`MainLoop`.
     """
+
+    __slots__ = ("logger",)
+
+    def __init__(self) -> None:
+        self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
 
     @abc.abstractmethod
     def alarm(self, seconds: float, callback: Callable[[], typing.Any]) -> typing.Any:

--- a/urwid/event_loop/asyncio_loop.py
+++ b/urwid/event_loop/asyncio_loop.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import asyncio
 import functools
+import logging
 import typing
 
 from .abstract_loop import EventLoop, ExitMainLoop
@@ -58,6 +59,8 @@ class AsyncioEventLoop(EventLoop):
     _we_started_event_loop = False
 
     def __init__(self, *, loop: asyncio.AbstractEventLoop | None = None, **kwargs) -> None:
+        super().__init__()
+        self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
         if loop:
             self._loop: asyncio.AbstractEventLoop = loop
         else:

--- a/urwid/event_loop/glib_loop.py
+++ b/urwid/event_loop/glib_loop.py
@@ -27,6 +27,7 @@ PyGObject library is required.
 from __future__ import annotations
 
 import functools
+import logging
 import signal
 import typing
 
@@ -56,6 +57,8 @@ class GLibEventLoop(EventLoop):
     """
 
     def __init__(self) -> None:
+        super().__init__()
+        self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
         self._alarms: list[int] = []
         self._watch_files: dict[int, int] = {}
         self._idle_handle: int = 0

--- a/urwid/event_loop/tornado_loop.py
+++ b/urwid/event_loop/tornado_loop.py
@@ -27,6 +27,7 @@ Tornado library is required.
 from __future__ import annotations
 
 import functools
+import logging
 import typing
 from contextlib import suppress
 
@@ -52,10 +53,12 @@ class TornadoEventLoop(EventLoop):
     """
 
     def __init__(self, loop: ioloop.IOLoop | None = None) -> None:
+        super().__init__()
+        self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
         if loop:
             self._loop: ioloop.IOLoop = loop
         else:
-            self._loop = ioloop.IOLoop.current()  # TODO(Aleksei): Switch to the syncio.EventLoop as tornado >= 6.0 !
+            self._loop = ioloop.IOLoop.current()  # TODO(Aleksei): Switch to the asyncio.EventLoop as tornado >= 6.0 !
 
         self._pending_alarms: dict[object, int] = {}
         self._watch_handles: dict[int, int] = {}  # {<watch_handle> : <file_descriptor>}

--- a/urwid/event_loop/trio_loop.py
+++ b/urwid/event_loop/trio_loop.py
@@ -25,6 +25,7 @@ Trio library is required.
 
 from __future__ import annotations
 
+import logging
 import typing
 
 import exceptiongroup
@@ -61,6 +62,8 @@ class TrioEventLoop(EventLoop):
 
     def __init__(self):
         """Constructor."""
+        super().__init__()
+        self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
 
         self._idle_handle = 0
         self._idle_callbacks = {}

--- a/urwid/event_loop/twisted_loop.py
+++ b/urwid/event_loop/twisted_loop.py
@@ -26,6 +26,7 @@ Twisted library is required.
 
 from __future__ import annotations
 
+import logging
 import sys
 import typing
 
@@ -86,6 +87,8 @@ class TwistedEventLoop(EventLoop):
 
         .. _Twisted: https://twisted.org/
         """
+        super().__init__()
+        self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
         if reactor is None:
             import twisted.internet.reactor
 

--- a/urwid/event_loop/zmq_loop.py
+++ b/urwid/event_loop/zmq_loop.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import contextlib
 import errno
 import heapq
+import logging
 import os
 import time
 import typing
@@ -56,6 +57,8 @@ class ZMQEventLoop(EventLoop):
     _alarm_break = count()
 
     def __init__(self):
+        super().__init__()
+        self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
         self._did_something = True
         self._alarms = []
         self._poller = zmq.Poller()


### PR DESCRIPTION
* Use standard python logging
* Use nested loggers for possibility to set atomic logging
* Add `__repr__` to the part of critical types
* In screen event loop with `selectors` usage: use IO objects instead of descriptors if possible: get human-friendly output in logs

* `MainLoop` methods`watch_pipe` / `remove_watch_pipe` are not available under Windows

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
