### PR TITLE
Add `add_run_in_executor` helper to the event loop

### DIFF
--- a/docs/manual/mainloop.rst
+++ b/docs/manual/mainloop.rst
@@ -59,9 +59,9 @@ Event Loops
 
 Urwid's event loop classes handle waiting for things for the
 :class:`MainLoop`. The different event loops allow you to
-integrate with Twisted_, Glib_, Tornado_, Asyncio_ libraries,
-or use a simple ``select``-based
-loop. Event loop classes abstract the particulars of waiting for input and
+integrate with Asyncio_, Twisted_, Glib_, Tornado_, ZMQ_ libraries,
+or use a simple ``select``-based loop.
+Event loop classes abstract the particulars of waiting for input and
 calling functions as a result of timeouts.
 
 You will typically only have a single event loop in your application, even if
@@ -73,10 +73,11 @@ Using this interface gives you the special handling
 of :exc:`ExitMainLoop` and other exceptions when using Glib_, Twisted_ or
 Tornado_ callbacks.
 
+.. _Asyncio: https://docs.python.org/3/library/asyncio.html
 .. _Twisted: http://twistedmatrix.com/trac/
 .. _Glib: http://developer.gnome.org/glib/stable/
 .. _Tornado: http://www.tornadoweb.org/
-.. _Asyncio: https://docs.python.org/3/library/asyncio.html
+.. _ZMQ: https://pyzmq.readthedocs.io/en/latest/
 
 ``SelectEventLoop``
 -------------------
@@ -93,6 +94,29 @@ created if none is passed to :class:`~urwid.main_loop.MainLoop`.
 
   :class:`SelectEventLoop reference <SelectEventLoop>`
 
+``AsyncioEventLoop``
+--------------------
+
+This event loop integrates with the asyncio module in Python.
+
+::
+
+    import asyncio
+    evl = urwid.AsyncioEventLoop(loop=asyncio.get_event_loop())
+    loop = urwid.MainLoop(widget, event_loop=evl)
+
+.. note::
+
+    In case of multithreading or multiprocessing usage required, do not use executor directly!
+    Use instead method :method:`run_in_executor` of :class:`AsyncioEventLoop`,
+    which forward API of the same method from asyncio Event Loop run_in_executor_.
+
+.. _run_in_executor: https://docs.python.org/3.11/library/asyncio-eventloop.html#asyncio.loop.run_in_executor
+
+.. seealso::
+
+  :class:`AsyncioEventLoop reference <AsyncioEventLoop>`
+
 ``TwistedEventLoop``
 --------------------
 
@@ -105,6 +129,13 @@ application.
 ::
 
     loop = urwid.MainLoop(widget, event_loop=urwid.TwistedEventLoop())
+
+.. note::
+
+    In case of threading usage required, please use twisted deferToThread_ method. It supports callbacks if needed.
+    Executors from `concurrent.futures` are not supported.
+
+.. _deferToThread: https://docs.twisted.org/en/stable/core/howto/threading.html#getting-results
 
 .. seealso::
 
@@ -136,22 +167,26 @@ This event loop integrates with Tornado.
     evl = urwid.TornadoEventLoop(IOLoop())
     loop = urwid.MainLoop(widget, event_loop=evl)
 
+.. note::
+
+    In case of multithreading or multiprocessing usage required, do not use executor directly!
+    Use instead method :method:`run_in_executor` of :class:`TornadoEventLoop`,
+    which forward API of the same method from `tornado.ioloop.IOLoop` (and internally use asyncio run_in_executor_).
+
 .. seealso::
 
   :class:`TornadoEventLoop reference <TornadoEventLoop>`
 
-``AsyncioEventLoop``
---------------------
+``ZMQEventLoop``
+----------------
 
-This event loop integrates with the asyncio module in Python.
+This event loop integrates with 0MQ.
 
 ::
 
-    import asyncio
-    evl = urwid.AsyncioEventLoop(loop=asyncio.get_event_loop())
+    evl = urwid.ZMQEventLoop()
     loop = urwid.MainLoop(widget, event_loop=evl)
 
 .. seealso::
 
-  :class:`AsyncioEventLoop reference <AsyncioEventLoop>`
-
+  :class:`ZMQEventLoop reference <ZMQEventLoop>`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ classifiers = {file = ["classifiers.txt"]}
 [project.optional-dependencies]
 curses = ["windows-curses;sys_platform=='win32'"]
 glib = ["PyGObject"]
-tornado = ["tornado"]
+tornado = ["tornado>=5.0"]
 trio = ["trio>=0.22.0", "exceptiongroup"]
 twisted = ["twisted"]
 zmq = ["zmq"]

--- a/tests/test_event_loops.py
+++ b/tests/test_event_loops.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import socket
 import sys
 import typing
@@ -9,7 +10,43 @@ import unittest
 import urwid
 
 if typing.TYPE_CHECKING:
+    from concurrent.futures import Future
     from types import TracebackType
+
+try:
+    import gi.repository
+except ImportError:
+    GLIB_AVAILABLE = False
+else:
+    GLIB_AVAILABLE = True
+
+try:
+    import tornado
+except ImportError:
+    TORNADO_AVAILABLE = False
+else:
+    TORNADO_AVAILABLE = True
+
+try:
+    import twisted
+except ImportError:
+    TWISTED_AVAILABLE = False
+else:
+    TWISTED_AVAILABLE = True
+
+try:
+    import trio
+except ImportError:
+    TRIO_AVAILABLE = False
+else:
+    TRIO_AVAILABLE = True
+
+try:
+    import zmq
+except ImportError:
+    ZMQ_AVAILABLE = False
+else:
+    ZMQ_AVAILABLE = True
 
 IS_WINDOWS = sys.platform == "win32"
 
@@ -131,128 +168,46 @@ class EventLoopTestMixin:
             _handle = evl.watch_file(rd.fileno(), exit_error)
             self.assertRaises(ZeroDivisionError, evl.run)
 
+    def test_run_in_executor(self):
+        out: list[str] = []
+        wr: socket.socket
+        rd: socket.socket
 
-class SelectEventLoopTest(unittest.TestCase, EventLoopTestMixin):
-    def setUp(self):
-        self.evl = urwid.SelectEventLoop()
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
 
+            def start():
+                out.append("started")
+                self.evl.run_in_executor(executor, func).add_done_callback(callback)
 
-try:
-    import gi.repository
-except ImportError:
-    pass
-else:
+            def func() -> bool:
+                out.append("future called")
+                return True
 
-    class GLibEventLoopTest(unittest.TestCase, EventLoopTestMixin):
-        def setUp(self):
-            self.evl = urwid.GLibEventLoop()
-
-        def test_error(self):
-            evl = self.evl
-            evl.alarm(0, lambda: 1 / 0)  # Simulate error in event loop
-            self.assertRaises(ZeroDivisionError, evl.run)
-
-
-try:
-    import tornado
-except ImportError:
-    pass
-else:
-
-    @unittest.skipIf(
-        IS_WINDOWS,
-        "Windows is temporary not supported by TornadoEventLoop due to race conditions.",
-    )
-    class TornadoEventLoopTest(unittest.TestCase, EventLoopTestMixin):
-        def setUp(self):
-            from tornado.ioloop import IOLoop
-
-            self.evl = urwid.TornadoEventLoop(IOLoop())
-
-        _expected_idle_handle = None
-
-
-try:
-    import twisted
-except ImportError:
-    pass
-else:
-
-    @unittest.skipIf(
-        IS_WINDOWS,
-        "Windows is temporary not supported by TwistedEventLoop due to race conditions.",
-    )
-    class TwistedEventLoopTest(unittest.TestCase, EventLoopTestMixin):
-        def setUp(self):
-            self.evl = urwid.TwistedEventLoop()
-
-        # can't restart twisted reactor, so use shortened tests
-        def test_event_loop(self):
-            pass
-
-        def test_remove_alarm(self):
-            pass
-
-        def test_remove_watch_file(self):
-            pass
-
-        def test_run(self):
-            evl = self.evl
-            out = []
-            wr: socket.socket
-            rd: socket.socket
-
-            def step2():
-                out.append(rd.recv(2).decode("ascii"))
-
-            def say_hello():
-                out.append("hello")
-
-            def say_waiting():
-                out.append("waiting")
-
-            def test_remove_alarm():
-                handle = evl.alarm(50, lambda: None)
-                self.assertTrue(evl.remove_alarm(handle))
-                self.assertFalse(evl.remove_alarm(handle))
-                out.append("remove_alarm ok")
-
-            def test_remove_watch_file():
-                with ClosingSocketPair() as (rd_, _wr):
-                    handle = evl.watch_file(rd_.fileno(), lambda: None)
-                    self.assertTrue(evl.remove_watch_file(handle))
-                    self.assertFalse(evl.remove_watch_file(handle))
-
-                out.append("remove_watch_file ok")
+            def callback(fut: Future) -> None:
+                out.append(f"callback called with future outcome: {fut.result()}")
 
             def exit_clean() -> typing.NoReturn:
                 out.append("clean exit")
                 raise urwid.ExitMainLoop
 
-            def exit_error() -> typing.NoReturn:
-                1 / 0
+            _handle = self.evl.alarm(0.1, exit_clean)
+            _handle = self.evl.alarm(0.005, start)
+            self.evl.run()
 
-            with ClosingSocketPair() as (rd, wr):
-                self.assertEqual(wr.send(b"data"), 4)
+        self.assertEqual(
+            [
+                "started",
+                "future called",
+                "callback called with future outcome: True",
+                "clean exit",
+            ],
+            out,
+        )
 
-                _handle = evl.watch_file(rd.fileno(), step2)
-                _handle = evl.alarm(0.1, exit_clean)
-                _handle = evl.alarm(0.05, say_hello)
-                _handle = evl.alarm(0.06, test_remove_alarm)
-                _handle = evl.alarm(0.07, test_remove_watch_file)
-                self.assertEqual(evl.enter_idle(say_waiting), 1)
-                evl.run()
 
-            self.assertTrue("da" in out, out)
-            self.assertTrue("ta" in out, out)
-            self.assertTrue("hello" in out, out)
-            self.assertTrue("remove_alarm ok" in out, out)
-            self.assertTrue("clean exit" in out, out)
-
-        def test_error(self):
-            evl = self.evl
-            evl.alarm(0, lambda: 1 / 0)  # Simulate error in event loop
-            self.assertRaises(ZeroDivisionError, evl.run)
+class SelectEventLoopTest(unittest.TestCase, EventLoopTestMixin):
+    def setUp(self):
+        self.evl = urwid.SelectEventLoop()
 
 
 @unittest.skipIf(IS_WINDOWS, "Windows is temporary not supported by AsyncioEventLoop.")
@@ -282,35 +237,136 @@ class AsyncioEventLoopTest(unittest.TestCase, EventLoopTestMixin):
         self.assertRaises(ZeroDivisionError, evl.run)
 
 
-try:
-    import trio
-except ImportError:
-    pass
-else:
+@unittest.skipUnless(GLIB_AVAILABLE, "GLIB unavailable")
+class GLibEventLoopTest(unittest.TestCase, EventLoopTestMixin):
+    def setUp(self):
+        self.evl = urwid.GLibEventLoop()
 
-    @unittest.skipIf(
-        IS_WINDOWS,
-        "Windows is temporary not supported by TrioEventLoop due to race conditions.",
-    )
-    class TrioEventLoopTest(unittest.TestCase, EventLoopTestMixin):
-        def setUp(self):
-            self.evl = urwid.TrioEventLoop()
-
-        _expected_idle_handle = None
-
-        def test_error(self):
-            evl = self.evl
-            evl.alarm(0, lambda: 1 / 0)  # Simulate error in event loop
-            self.assertRaises(ZeroDivisionError, evl.run)
+    def test_error(self):
+        evl = self.evl
+        evl.alarm(0, lambda: 1 / 0)  # Simulate error in event loop
+        self.assertRaises(ZeroDivisionError, evl.run)
 
 
-try:
-    import zmq
-except ImportError:
-    pass
-else:
+@unittest.skipUnless(TORNADO_AVAILABLE, "Tornado not available")
+@unittest.skipIf(
+    IS_WINDOWS,
+    "Windows is temporary not supported by TornadoEventLoop due to race conditions.",
+)
+class TornadoEventLoopTest(unittest.TestCase, EventLoopTestMixin):
+    def setUp(self):
+        from tornado.ioloop import IOLoop
 
-    @unittest.skipIf(IS_WINDOWS, "ZMQEventLoop is not supported under windows")
-    class ZMQEventLoopTest(unittest.TestCase, EventLoopTestMixin):
-        def setUp(self):
-            self.evl = urwid.ZMQEventLoop()
+        self.evl = urwid.TornadoEventLoop(IOLoop())
+
+    _expected_idle_handle = None
+
+
+@unittest.skipUnless(TWISTED_AVAILABLE, "Twisted is not available")
+@unittest.skipIf(
+    IS_WINDOWS,
+    "Windows is temporary not supported by TwistedEventLoop due to race conditions.",
+)
+class TwistedEventLoopTest(unittest.TestCase, EventLoopTestMixin):
+    def setUp(self):
+        self.evl = urwid.TwistedEventLoop()
+
+    # can't restart twisted reactor, so use shortened tests
+    def test_event_loop(self):
+        pass
+
+    def test_remove_alarm(self):
+        pass
+
+    def test_remove_watch_file(self):
+        pass
+
+    def test_run(self):
+        evl = self.evl
+        out = []
+        wr: socket.socket
+        rd: socket.socket
+
+        def step2():
+            out.append(rd.recv(2).decode("ascii"))
+
+        def say_hello():
+            out.append("hello")
+
+        def say_waiting():
+            out.append("waiting")
+
+        def test_remove_alarm():
+            handle = evl.alarm(50, lambda: None)
+            self.assertTrue(evl.remove_alarm(handle))
+            self.assertFalse(evl.remove_alarm(handle))
+            out.append("remove_alarm ok")
+
+        def test_remove_watch_file():
+            with ClosingSocketPair() as (rd_, _wr):
+                handle = evl.watch_file(rd_.fileno(), lambda: None)
+                self.assertTrue(evl.remove_watch_file(handle))
+                self.assertFalse(evl.remove_watch_file(handle))
+
+            out.append("remove_watch_file ok")
+
+        def exit_clean() -> typing.NoReturn:
+            out.append("clean exit")
+            raise urwid.ExitMainLoop
+
+        def exit_error() -> typing.NoReturn:
+            1 / 0
+
+        with ClosingSocketPair() as (rd, wr):
+            self.assertEqual(wr.send(b"data"), 4)
+
+            _handle = evl.watch_file(rd.fileno(), step2)
+            _handle = evl.alarm(0.1, exit_clean)
+            _handle = evl.alarm(0.05, say_hello)
+            _handle = evl.alarm(0.06, test_remove_alarm)
+            _handle = evl.alarm(0.07, test_remove_watch_file)
+            self.assertEqual(evl.enter_idle(say_waiting), 1)
+            evl.run()
+
+        self.assertTrue("da" in out, out)
+        self.assertTrue("ta" in out, out)
+        self.assertTrue("hello" in out, out)
+        self.assertTrue("remove_alarm ok" in out, out)
+        self.assertTrue("clean exit" in out, out)
+
+    def test_error(self):
+        evl = self.evl
+        evl.alarm(0, lambda: 1 / 0)  # Simulate error in event loop
+        self.assertRaises(ZeroDivisionError, evl.run)
+
+    @unittest.skip("not implemented for twisted event loop")
+    def test_run_in_executor(self):
+        """Not implemented for twisted event loop."""
+
+
+@unittest.skipUnless(TRIO_AVAILABLE, "Trio not available")
+@unittest.skipIf(
+    IS_WINDOWS,
+    "Windows is temporary not supported by TrioEventLoop due to race conditions.",
+)
+class TrioEventLoopTest(unittest.TestCase, EventLoopTestMixin):
+    def setUp(self):
+        self.evl = urwid.TrioEventLoop()
+
+    _expected_idle_handle = None
+
+    def test_error(self):
+        evl = self.evl
+        evl.alarm(0, lambda: 1 / 0)  # Simulate error in event loop
+        self.assertRaises(ZeroDivisionError, evl.run)
+
+    @unittest.skip("not implemented for trio event loop")
+    def test_run_in_executor(self):
+        """Not implemented for trio event loop."""
+
+
+@unittest.skipUnless(ZMQ_AVAILABLE, "ZMQ is not available")
+@unittest.skipIf(IS_WINDOWS, "ZMQEventLoop is not supported under windows")
+class ZMQEventLoopTest(unittest.TestCase, EventLoopTestMixin):
+    def setUp(self):
+        self.evl = urwid.ZMQEventLoop()

--- a/urwid/event_loop/abstract_loop.py
+++ b/urwid/event_loop/abstract_loop.py
@@ -29,8 +29,12 @@ import signal
 import typing
 
 if typing.TYPE_CHECKING:
+    import asyncio
     from collections.abc import Callable
+    from concurrent.futures import Executor, Future
     from types import FrameType
+
+    _T = typing.TypeVar("_T")
 
 __all__ = ("ExitMainLoop", "EventLoop")
 
@@ -51,6 +55,26 @@ class EventLoop(abc.ABC):
 
     def __init__(self) -> None:
         self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
+
+    def run_in_executor(
+        self,
+        executor: Executor,
+        func: Callable[..., _T],
+        *args: object,
+    ) -> Future[_T] | asyncio.Future[_T]:
+        """Run func in executor if supported.
+
+        :param executor: executor to use for running the function
+        :type executor: concurrent.futures.Executor
+        :param func: function to call
+        :type func: Callable
+        :param args: arguments to function (positional only)
+        :type args: object
+        :return: future object for the function call outcome.
+                 (exact future type depends on the event loop type)
+        :rtype: concurrent.futures.Future | asyncio.Future
+        """
+        raise NotImplementedError
 
     @abc.abstractmethod
     def alarm(self, seconds: float, callback: Callable[[], typing.Any]) -> typing.Any:

--- a/urwid/event_loop/abstract_loop.py
+++ b/urwid/event_loop/abstract_loop.py
@@ -34,7 +34,10 @@ if typing.TYPE_CHECKING:
     from concurrent.futures import Executor, Future
     from types import FrameType
 
+    from typing_extensions import ParamSpec
+
     _T = typing.TypeVar("_T")
+    _Spec = ParamSpec("_Spec")
 
 __all__ = ("ExitMainLoop", "EventLoop")
 
@@ -59,12 +62,12 @@ class EventLoop(abc.ABC):
     def run_in_executor(
         self,
         executor: Executor,
-        func: Callable[..., _T],
-        *args: object,
+        func: Callable[_Spec, _T],
+        *args: _Spec.args,
     ) -> Future[_T] | asyncio.Future[_T]:
-        """Run func in executor if supported.
+        """Run callable in executor if supported.
 
-        :param executor: executor to use for running the function
+        :param executor: Executor to use for running the function
         :type executor: concurrent.futures.Executor
         :param func: function to call
         :type func: Callable

--- a/urwid/event_loop/asyncio_loop.py
+++ b/urwid/event_loop/asyncio_loop.py
@@ -98,14 +98,14 @@ class AsyncioEventLoop(EventLoop):
 
     def run_in_executor(
         self,
-        executor: Executor,
-        func: Callable[..., _T],
-        *args: object,
+        executor: Executor | None,
+        func: Callable[_Spec, _T],
+        *args: _Spec.args,
     ) -> asyncio.Future[_T]:
-        """Run func in executor.
+        """Run callable in executor.
 
-        :param executor: executor to use for running the function
-        :type executor: concurrent.futures.Executor
+        :param executor: Executor to use for running the function. Default asyncio executor is used if None.
+        :type executor: concurrent.futures.Executor | None
         :param func: function to call
         :type func: Callable
         :param args: arguments to function (positional only)

--- a/urwid/event_loop/asyncio_loop.py
+++ b/urwid/event_loop/asyncio_loop.py
@@ -32,6 +32,7 @@ from .abstract_loop import EventLoop, ExitMainLoop
 
 if typing.TYPE_CHECKING:
     from collections.abc import Callable
+    from concurrent.futures import Executor
 
     from typing_extensions import ParamSpec
 
@@ -94,6 +95,25 @@ class AsyncioEventLoop(EventLoop):
                 callback()
         finally:
             self._idle_asyncio_handle = None
+
+    def run_in_executor(
+        self,
+        executor: Executor,
+        func: Callable[..., _T],
+        *args: object,
+    ) -> asyncio.Future[_T]:
+        """Run func in executor.
+
+        :param executor: executor to use for running the function
+        :type executor: concurrent.futures.Executor
+        :param func: function to call
+        :type func: Callable
+        :param args: arguments to function (positional only)
+        :type args: object
+        :return: future object for the function call outcome.
+        :rtype: asyncio.Future
+        """
+        return self._loop.run_in_executor(executor, func, *args)
 
     def alarm(self, seconds: float, callback: Callable[[], typing.Any]) -> asyncio.TimerHandle:
         """

--- a/urwid/event_loop/glib_loop.py
+++ b/urwid/event_loop/glib_loop.py
@@ -37,6 +37,7 @@ from .abstract_loop import EventLoop, ExitMainLoop
 
 if typing.TYPE_CHECKING:
     from collections.abc import Callable
+    from concurrent.futures import Executor, Future
     from types import FrameType
 
     from typing_extensions import Literal, ParamSpec
@@ -68,6 +69,25 @@ class GLibEventLoop(EventLoop):
         self._exc: BaseException | None = None
         self._enable_glib_idle()
         self._signal_handlers: dict[int, int] = {}
+
+    def run_in_executor(
+        self,
+        executor: Executor,
+        func: Callable[..., _T],
+        *args: object,
+    ) -> Future[_T]:
+        """Run func in executor.
+
+        :param executor: executor to use for running the function
+        :type executor: concurrent.futures.Executor
+        :param func: function to call
+        :type func: Callable
+        :param args: arguments to function (positional only)
+        :type args: object
+        :return: future object for the function call outcome.
+        :rtype: concurrent.futures.Future
+        """
+        return executor.submit(func, *args)
 
     def alarm(
         self,

--- a/urwid/event_loop/glib_loop.py
+++ b/urwid/event_loop/glib_loop.py
@@ -73,21 +73,24 @@ class GLibEventLoop(EventLoop):
     def run_in_executor(
         self,
         executor: Executor,
-        func: Callable[..., _T],
-        *args: object,
+        func: Callable[_Spec, _T],
+        *args: _Spec.args,
+        **kwargs: _Spec.kwargs,
     ) -> Future[_T]:
-        """Run func in executor.
+        """Run callable in executor.
 
-        :param executor: executor to use for running the function
+        :param executor: Executor to use for running the function
         :type executor: concurrent.futures.Executor
         :param func: function to call
         :type func: Callable
-        :param args: arguments to function (positional only)
+        :param args: positional arguments to function
         :type args: object
+        :param kwargs: keyword arguments to function
+        :type kwargs: object
         :return: future object for the function call outcome.
         :rtype: concurrent.futures.Future
         """
-        return executor.submit(func, *args)
+        return executor.submit(func, *args, **kwargs)
 
     def alarm(
         self,

--- a/urwid/event_loop/select_loop.py
+++ b/urwid/event_loop/select_loop.py
@@ -38,9 +38,10 @@ if typing.TYPE_CHECKING:
     from collections.abc import Callable, Iterator
     from concurrent.futures import Executor, Future
 
-    from typing_extensions import Literal
+    from typing_extensions import Literal, ParamSpec
 
     _T = typing.TypeVar("_T")
+    _Spec = ParamSpec("_Spec")
 
 __all__ = ("SelectEventLoop",)
 
@@ -63,21 +64,24 @@ class SelectEventLoop(EventLoop):
     def run_in_executor(
         self,
         executor: Executor,
-        func: Callable[..., _T],
-        *args: object,
+        func: Callable[_Spec, _T],
+        *args: _Spec.args,
+        **kwargs: _Spec.kwargs,
     ) -> Future[_T]:
-        """Run func in executor.
+        """Run callable in executor.
 
-        :param executor: executor to use for running the function
+        :param executor: Executor to use for running the function
         :type executor: concurrent.futures.Executor
         :param func: function to call
         :type func: Callable
-        :param args: arguments to function (positional only)
+        :param args: positional arguments to function
         :type args: object
+        :param kwargs: keyword arguments to function
+        :type kwargs: object
         :return: future object for the function call outcome.
         :rtype: concurrent.futures.Future
         """
-        return executor.submit(func, *args)
+        return executor.submit(func, *args, **kwargs)
 
     def alarm(
         self,

--- a/urwid/event_loop/select_loop.py
+++ b/urwid/event_loop/select_loop.py
@@ -36,8 +36,11 @@ from .abstract_loop import EventLoop, ExitMainLoop
 
 if typing.TYPE_CHECKING:
     from collections.abc import Callable, Iterator
+    from concurrent.futures import Executor, Future
 
     from typing_extensions import Literal
+
+    _T = typing.TypeVar("_T")
 
 __all__ = ("SelectEventLoop",)
 
@@ -56,6 +59,25 @@ class SelectEventLoop(EventLoop):
         self._idle_callbacks: dict[int, Callable[[], typing.Any]] = {}
         self._tie_break: Iterator[int] = count()
         self._did_something: bool = False
+
+    def run_in_executor(
+        self,
+        executor: Executor,
+        func: Callable[..., _T],
+        *args: object,
+    ) -> Future[_T]:
+        """Run func in executor.
+
+        :param executor: executor to use for running the function
+        :type executor: concurrent.futures.Executor
+        :param func: function to call
+        :type func: Callable
+        :param args: arguments to function (positional only)
+        :type args: object
+        :return: future object for the function call outcome.
+        :rtype: concurrent.futures.Future
+        """
+        return executor.submit(func, *args)
 
     def alarm(
         self,

--- a/urwid/event_loop/tornado_loop.py
+++ b/urwid/event_loop/tornado_loop.py
@@ -36,7 +36,9 @@ from tornado import ioloop
 from .abstract_loop import EventLoop, ExitMainLoop
 
 if typing.TYPE_CHECKING:
+    import asyncio
     from collections.abc import Callable
+    from concurrent.futures import Executor
 
     from typing_extensions import Literal, ParamSpec
 
@@ -91,6 +93,25 @@ class TornadoEventLoop(EventLoop):
                 callback()
         finally:
             self._idle_asyncio_handle = None
+
+    def run_in_executor(
+        self,
+        executor: Executor,
+        func: Callable[..., _T],
+        *args: object,
+    ) -> asyncio.Future[_T]:
+        """Run func in executor.
+
+        :param executor: executor to use for running the function
+        :type executor: concurrent.futures.Executor
+        :param func: function to call
+        :type func: Callable
+        :param args: arguments to function (positional only)
+        :type args: object
+        :return: future object for the function call outcome.
+        :rtype: asyncio.Future
+        """
+        return self._loop.run_in_executor(executor, func, *args)
 
     def alarm(self, seconds: float, callback: Callable[[], typing.Any]):
         @self._also_call_idle

--- a/urwid/event_loop/tornado_loop.py
+++ b/urwid/event_loop/tornado_loop.py
@@ -97,12 +97,12 @@ class TornadoEventLoop(EventLoop):
     def run_in_executor(
         self,
         executor: Executor,
-        func: Callable[..., _T],
-        *args: object,
+        func: Callable[_Spec, _T],
+        *args: _Spec.args,
     ) -> asyncio.Future[_T]:
-        """Run func in executor.
+        """Run callable in executor.
 
-        :param executor: executor to use for running the function
+        :param executor: Executor to use for running the function
         :type executor: concurrent.futures.Executor
         :param func: function to call
         :type func: Callable

--- a/urwid/event_loop/trio_loop.py
+++ b/urwid/event_loop/trio_loop.py
@@ -69,7 +69,7 @@ class TrioEventLoop(EventLoop):
         self._idle_callbacks = {}
         self._pending_tasks = []
 
-        self._nursery = None
+        self._nursery: trio.Nursery | None = None
 
         self._sleep = trio.sleep
         self._wait_readable = trio.lowlevel.wait_readable

--- a/urwid/event_loop/zmq_loop.py
+++ b/urwid/event_loop/zmq_loop.py
@@ -39,8 +39,10 @@ from .abstract_loop import EventLoop, ExitMainLoop
 
 if typing.TYPE_CHECKING:
     from collections.abc import Callable
+    from concurrent.futures import Executor, Future
 
     ZMQAlarmHandle = typing.TypeVar("ZMQAlarmHandle")
+    _T = typing.TypeVar("_T")
 
 
 class ZMQEventLoop(EventLoop):
@@ -65,6 +67,25 @@ class ZMQEventLoop(EventLoop):
         self._queue_callbacks = {}
         self._idle_handle = 0
         self._idle_callbacks = {}
+
+    def run_in_executor(
+        self,
+        executor: Executor,
+        func: Callable[..., _T],
+        *args: object,
+    ) -> Future[_T]:
+        """Run func in executor.
+
+        :param executor: executor to use for running the function
+        :type executor: concurrent.futures.Executor
+        :param func: function to call
+        :type func: Callable
+        :param args: arguments to function (positional only)
+        :type args: object
+        :return: future object for the function call outcome.
+        :rtype: concurrent.futures.Future
+        """
+        return executor.submit(func, *args)
 
     def alarm(self, seconds: float, callback: Callable[[], typing.Any]) -> ZMQAlarmHandle:
         """

--- a/urwid/event_loop/zmq_loop.py
+++ b/urwid/event_loop/zmq_loop.py
@@ -41,8 +41,11 @@ if typing.TYPE_CHECKING:
     from collections.abc import Callable
     from concurrent.futures import Executor, Future
 
+    from typing_extensions import ParamSpec
+
     ZMQAlarmHandle = typing.TypeVar("ZMQAlarmHandle")
     _T = typing.TypeVar("_T")
+    _Spec = ParamSpec("_Spec")
 
 
 class ZMQEventLoop(EventLoop):
@@ -71,21 +74,24 @@ class ZMQEventLoop(EventLoop):
     def run_in_executor(
         self,
         executor: Executor,
-        func: Callable[..., _T],
-        *args: object,
+        func: Callable[_Spec, _T],
+        *args: _Spec.args,
+        **kwargs: _Spec.kwargs,
     ) -> Future[_T]:
-        """Run func in executor.
+        """Run callable in executor.
 
-        :param executor: executor to use for running the function
+        :param executor: Executor to use for running the function
         :type executor: concurrent.futures.Executor
         :param func: function to call
         :type func: Callable
-        :param args: arguments to function (positional only)
+        :param args: positional arguments to function
         :type args: object
+        :param kwargs: keyword arguments to function
+        :type kwargs: object
         :return: future object for the function call outcome.
         :rtype: concurrent.futures.Future
         """
-        return executor.submit(func, *args)
+        return executor.submit(func, *args, **kwargs)
 
     def alarm(self, seconds: float, callback: Callable[[], typing.Any]) -> ZMQAlarmHandle:
         """


### PR DESCRIPTION
Implemented only for:
* `asyncio`
* `tornado` (`asyncio` as backend since 5.0)
* `select` (call executor directly)
* `glib` (call executor directly)
* `zmq` (call executor directly)

event loops at this moment

* Rework unittests for event loop for maintainability

 Fix: #575

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [X] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

