### PR TITLE
Extend input_test example for better debug capabilities

### DIFF
--- a/urwid/_posix_raw_display.py
+++ b/urwid/_posix_raw_display.py
@@ -84,7 +84,7 @@ class Screen(_raw_display_base.Screen):
             f"bracketed_paste_mode={self.bracketed_paste_mode})>"
         )
 
-    def _sigwinch_handler(self, signum: int, frame: FrameType | None = None) -> None:
+    def _sigwinch_handler(self, signum: int = 28, frame: FrameType | None = None) -> None:
         """
         frame -- will always be None when the GLib event loop is being used.
         """
@@ -112,7 +112,7 @@ class Screen(_raw_display_base.Screen):
             self._prev_sigcont_handler(signum, frame)
 
         self.start()
-        self._sigwinch_handler(None, None)
+        self._sigwinch_handler(28, None)
 
     def signal_init(self) -> None:
         """
@@ -271,6 +271,7 @@ class Screen(_raw_display_base.Screen):
 
             @functools.wraps(callback)
             def wrapper() -> tuple[list[str], typing.Any] | None:
+                self.logger.debug('Calling callback for "watch file"')
                 return self.parse_input(event_loop, callback, self.get_available_raw_input())
 
         fds = self.get_input_descriptors()

--- a/urwid/_win32_raw_display.py
+++ b/urwid/_win32_raw_display.py
@@ -162,7 +162,7 @@ class Screen(_raw_display_base.Screen):
 
         Subclasses may wish to use parse_input to wrap the callback.
         """
-        self._input_thread = ReadInputThread(self._send_input, lambda: self._sigwinch_handler(0))
+        self._input_thread = ReadInputThread(self._send_input, lambda: self._sigwinch_handler(28))
         self._input_thread.start()
         if hasattr(self, "get_input_nonblocking"):
             wrapper = self._make_legacy_input_wrapper(event_loop, callback)

--- a/urwid/web_display.py
+++ b/urwid/web_display.py
@@ -640,7 +640,7 @@ class Screen:
             background = "light gray"
         self.palette[name] = (foreground, background, mono)
 
-    def set_mouse_tracking(self, enable=True):
+    def set_mouse_tracking(self, enable: bool = True) -> None:
         """Not yet implemented"""
         pass
 


### PR DESCRIPTION
* Extra logging in raw display subclasses
* Better type annotations
* sigwinch_handler - use `signal.SIGWINCH` value as default

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [X] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

Related #700
