### PR TITLE
Fix Windows resize behavior for raw display

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,8 +63,7 @@ Windows support notes
 
     pip install urwid[curses]
 
-* Window resize is not fully functional without keyboard/mouse input if RawDisplay used.
-* CursesDisplay decode limited scope of modifier keys combinations.
+* CursesDisplay incorrectly handles mouse input in case of fast actions.
 * Only UTF-8 mode is supported.
 
 

--- a/urwid/_raw_display_base.py
+++ b/urwid/_raw_display_base.py
@@ -32,6 +32,7 @@ import os
 import selectors
 import signal
 import socket
+import sys
 import typing
 
 from urwid import escape, signals, util
@@ -45,6 +46,8 @@ if typing.TYPE_CHECKING:
     from typing_extensions import Literal
 
     from urwid import Canvas, EventLoop
+
+IS_WINDOWS = sys.platform == "win32"
 
 
 class Screen(BaseScreen, RealTerminal):
@@ -104,7 +107,7 @@ class Screen(BaseScreen, RealTerminal):
 
         logger.debug(f"SIGWINCH handler called with signum={signum!r}, frame={frame!r}")
 
-        if not self._resized:
+        if IS_WINDOWS or not self._resized:
             self._resize_pipe_wr.send(b"R")
             logger.debug("Sent fake resize input to the pipe")
         self._resized = True


### PR DESCRIPTION
In case of Windows OS,
need always send fake input to the resize socket on resize event.

* Update windows support issues to the actual state

Fix #700

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
