### PR TITLE
Force `SelectorEventLoop` for asyncio under Windows if event loop is not set

### DIFF
--- a/docs/manual/mainloop.rst
+++ b/docs/manual/mainloop.rst
@@ -111,7 +111,15 @@ This event loop integrates with the asyncio module in Python.
     Use instead method :method:`run_in_executor` of :class:`AsyncioEventLoop`,
     which forward API of the same method from asyncio Event Loop run_in_executor_.
 
-.. _run_in_executor: https://docs.python.org/3.11/library/asyncio-eventloop.html#asyncio.loop.run_in_executor
+.. warning::
+
+    For input handling, selectors based logic is used.
+    Under Windows OS only `SelectorEventLoop`_ is supported.
+
+.. note:: `uvloop` event loop is not supported officially.
+
+.. _run_in_executor: https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.run_in_executor
+.. _SelectorEventLoop: https://docs.python.org/3/library/asyncio-eventloop.html?highlight=selectoreventloop#asyncio.SelectorEventLoop
 
 .. seealso::
 

--- a/urwid/event_loop/asyncio_loop.py
+++ b/urwid/event_loop/asyncio_loop.py
@@ -69,16 +69,16 @@ class AsyncioEventLoop(EventLoop):
         self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
         if loop:
             self._loop: asyncio.AbstractEventLoop = loop
-            self.__event_loop_policy_altered: bool = False
-            self.__original_event_loop_policy: asyncio.AbstractEventLoopPolicy | None = None
+            self._event_loop_policy_altered: bool = False
+            self._original_event_loop_policy: asyncio.AbstractEventLoopPolicy | None = None
         else:
-            self.__original_event_loop_policy = asyncio.get_event_loop_policy()
-            if IS_WINDOWS and not isinstance(self.__original_event_loop_policy, asyncio.WindowsSelectorEventLoopPolicy):
+            self._original_event_loop_policy = asyncio.get_event_loop_policy()
+            if IS_WINDOWS and not isinstance(self._original_event_loop_policy, asyncio.WindowsSelectorEventLoopPolicy):
                 self.logger.debug("Set WindowsSelectorEventLoopPolicy as asyncio event loop policy")
                 asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-                self.__event_loop_policy_altered = True
+                self._event_loop_policy_altered = True
             else:
-                self.__event_loop_policy_altered = False
+                self._event_loop_policy_altered = False
 
             self._loop = asyncio.get_event_loop()
 
@@ -89,8 +89,8 @@ class AsyncioEventLoop(EventLoop):
         self._idle_callbacks: dict[int, Callable[[], typing.Any]] = {}
 
     def __del__(self) -> None:
-        if self.__event_loop_policy_altered:
-            asyncio.set_event_loop_policy(self.__original_event_loop_policy)  # Restore default event loop policy
+        if self._event_loop_policy_altered:
+            asyncio.set_event_loop_policy(self._original_event_loop_policy)  # Restore default event loop policy
 
     def _also_call_idle(self, callback: Callable[_Spec, _T]) -> Callable[_Spec, _T]:
         """

--- a/urwid/event_loop/asyncio_loop.py
+++ b/urwid/event_loop/asyncio_loop.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import asyncio
 import functools
 import logging
+import sys
 import typing
 
 from .abstract_loop import EventLoop, ExitMainLoop
@@ -40,6 +41,7 @@ if typing.TYPE_CHECKING:
     _T = typing.TypeVar("_T")
 
 __all__ = ("AsyncioEventLoop",)
+IS_WINDOWS = sys.platform == "win32"
 
 
 class AsyncioEventLoop(EventLoop):
@@ -65,6 +67,9 @@ class AsyncioEventLoop(EventLoop):
         if loop:
             self._loop: asyncio.AbstractEventLoop = loop
         else:
+            if IS_WINDOWS:
+                asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
             self._loop = asyncio.get_event_loop()
 
         self._exc: BaseException | None = None

--- a/urwid/event_loop/asyncio_loop.py
+++ b/urwid/event_loop/asyncio_loop.py
@@ -50,7 +50,7 @@ class AsyncioEventLoop(EventLoop):
 
     .. warning::
         Under Windows, AsyncioEventLoop globally enforces WindowsSelectorEventLoopPolicy
-        if external event loop is not provided.
+        as a side-effect of creating a class instance.
         Original event loop policy is restored in destructor method.
 
     .. note::


### PR DESCRIPTION
* Document `SelectorEventLoop` is only supported under windows.
* Document `uvloop` is officially not supported.

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [X] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

