### PR TITLE
Restore `get_cursor_coords` as property

### DIFF
--- a/urwid/widget/widget.py
+++ b/urwid/widget/widget.py
@@ -719,8 +719,10 @@ def delegate_to_widget_mixin(attribute_name: str):
         def selectable(self) -> bool:
             return get_delegate(self).selectable()
 
-        def get_cursor_coords(self, size: tuple[()] | tuple[int] | tuple[int, int]) -> tuple[int, int] | None:
-            return get_delegate(self).get_cursor_coords(size)
+        @property
+        def get_cursor_coords(self) -> Callable[[tuple[()] | tuple[int] | tuple[int, int]], tuple[int, int] | None]:
+            # TODO(Aleksei):  Get rid of property usage after getting rid of "if getattr"
+            return get_delegate(self).get_cursor_coords
 
         @property
         def get_pref_col(self) -> Callable[[tuple[()] | tuple[int] | tuple[int, int]], int | None]:


### PR DESCRIPTION
`if hasattr` is used for this attribute lookup
Related: #703

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
