### PR TITLE
Implement default keypress/mouse_event in Widget

### DIFF
--- a/urwid/event_loop/main_loop.py
+++ b/urwid/event_loop/main_loop.py
@@ -571,7 +571,7 @@ class MainLoop:
             elif isinstance(k, tuple):
                 if is_mouse_event(k):
                     event, button, col, row = k
-                    if hasattr(self._topmost_widget, "mouse_event") and self._topmost_widget.mouse_event(
+                    if self._topmost_widget.mouse_event(
                         self.screen_size,
                         event,
                         button,

--- a/urwid/listbox.py
+++ b/urwid/listbox.py
@@ -1691,9 +1691,6 @@ class ListBox(Widget, WidgetContainerMixin):
         if is_mouse_press(event) and button == 1 and w.selectable():
             self.change_focus((maxcol, maxrow), w_pos, wrow)
 
-        if not hasattr(w, "mouse_event"):
-            return False
-
         return w.mouse_event((maxcol,), event, button, col, row - wrow, focus)
 
     def ends_visible(self, size: tuple[int, int], focus: bool = False):

--- a/urwid/widget/box_adapter.py
+++ b/urwid/widget/box_adapter.py
@@ -111,8 +111,6 @@ class BoxAdapter(WidgetDecoration):
         focus: bool,
     ) -> bool:
         (maxcol,) = size
-        if not hasattr(self._original_widget, "mouse_event"):
-            return False
         return self._original_widget.mouse_event((maxcol, self.height), event, button, col, row, focus)
 
     def render(self, size: tuple[int], focus: bool = False) -> CompositeCanvas:

--- a/urwid/widget/columns.py
+++ b/urwid/widget/columns.py
@@ -699,9 +699,6 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
             if is_mouse_press(event) and button == 1 and w.selectable():
                 self.focus_position = i
 
-            if not hasattr(w, "mouse_event"):
-                return False
-
             if len(size) == 1 and b:
                 return w.mouse_event((end - x, self.rows(size)), event, button, col - x, row, focus)
             return w.mouse_event((end - x,) + size[1:], event, button, col - x, row, focus)
@@ -716,6 +713,7 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
             return 0
         col = None
         cwidth = widths[self.focus_position]
+
         if hasattr(w, "get_pref_col"):
             if len(size) == 1 and b:
                 col = w.get_pref_col((cwidth, self.rows(size)))
@@ -726,6 +724,7 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
                 col += sum(widths[: self.focus_position])
         if col is None:
             col = self.pref_col
+
         if col is None and w.selectable():
             col = cwidth // 2
             col += self.focus_position * self.dividechars

--- a/urwid/widget/filler.py
+++ b/urwid/widget/filler.py
@@ -244,7 +244,7 @@ class Filler(WidgetDecoration):
             y = maxrow - 1
         return x, y + top
 
-    def get_pref_col(self, size: tuple[int, int]) -> int:
+    def get_pref_col(self, size: tuple[int, int]) -> int | None:
         """Return pref_col from self.original_widget if any."""
         (maxcol, maxrow) = size
         if not hasattr(self._original_widget, "get_pref_col"):
@@ -283,8 +283,6 @@ class Filler(WidgetDecoration):
     ) -> bool:
         """Pass to self.original_widget."""
         (maxcol, maxrow) = size
-        if not hasattr(self._original_widget, "mouse_event"):
-            return False
 
         top, bottom = self.filler_values(size, True)
         if row < top or row >= maxrow - bottom:

--- a/urwid/widget/frame.py
+++ b/urwid/widget/frame.py
@@ -627,16 +627,14 @@ class Frame(Widget, WidgetContainerMixin):
             focus = focus and self.focus_part == "header"
             if is_mouse_press(event) and button == 1 and self.header.selectable():
                 self.focus_position = "header"
-            if not hasattr(self.header, "mouse_event"):
-                return False
+
             return self.header.mouse_event((maxcol,), event, button, col, row, focus)
 
         if row >= maxrow - ftrim:  # within footer
             focus = focus and self.focus_part == "footer"
             if is_mouse_press(event) and button == 1 and self.footer.selectable():
                 self.focus_position = "footer"
-            if not hasattr(self.footer, "mouse_event"):
-                return False
+
             return self.footer.mouse_event((maxcol,), event, button, col, row - maxrow + ftrim, focus)
 
         # within body
@@ -644,8 +642,6 @@ class Frame(Widget, WidgetContainerMixin):
         if is_mouse_press(event) and button == 1 and self.body.selectable():
             self.focus_position = "body"
 
-        if not hasattr(self.body, "mouse_event"):
-            return False
         return self.body.mouse_event((maxcol, maxrow - htrim - ftrim), event, button, col, row - htrim, focus)
 
     def get_cursor_coords(self, size: tuple[int, int]) -> tuple[int, int] | None:

--- a/urwid/widget/overlay.py
+++ b/urwid/widget/overlay.py
@@ -563,8 +563,6 @@ class Overlay(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
 
     def mouse_event(self, size: tuple[int, int], event, button: int, col: int, row: int, focus: bool) -> bool | None:
         """Pass event to top_w, ignore if outside of top_w."""
-        if not hasattr(self.top_w, "mouse_event"):
-            return False
 
         left, right, top, bottom = self.calculate_padding_filler(size, focus)
         maxcol, maxrow = size
@@ -572,5 +570,10 @@ class Overlay(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
             return False
 
         return self.top_w.mouse_event(
-            self.top_w_size(size, left, right, top, bottom), event, button, col - left, row - top, focus
+            self.top_w_size(size, left, right, top, bottom),
+            event,
+            button,
+            col - left,
+            row - top,
+            focus,
         )

--- a/urwid/widget/padding.py
+++ b/urwid/widget/padding.py
@@ -359,9 +359,6 @@ class Padding(WidgetDecoration):
         focus: bool,
     ):
         """Send mouse event if position is within self._original_widget."""
-        if not hasattr(self._original_widget, "mouse_event"):
-            return False
-
         left, right = self.padding_values(size, focus)
         maxcol = size[0]
         if x < left or x >= maxcol - right:

--- a/urwid/widget/pile.py
+++ b/urwid/widget/pile.py
@@ -647,8 +647,5 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         if is_mouse_press(event) and button == 1 and w.selectable():
             self.focus_position = i
 
-        if not hasattr(w, "mouse_event"):
-            return False
-
         tsize = self.get_item_size(size, i, focus, item_rows)
         return w.mouse_event(tsize, event, button, col, row - wrow, focus)


### PR DESCRIPTION
* log if widget not selectable
* `keypress` -> return key (unhandled)
* `mouse_event` -> return `False` (unhandled)

Partial #703

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [X] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

