### PR TITLE
Feature: Use module path + class name for loggers and init once

### DIFF
--- a/urwid/_posix_raw_display.py
+++ b/urwid/_posix_raw_display.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 import contextlib
 import fcntl
 import functools
-import logging
 import os
 import signal
 import struct
@@ -66,7 +65,6 @@ class Screen(_raw_display_base.Screen):
             and `end paste` keystrokes when the user pastes text.
         """
         super().__init__(input, output)
-        self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
         self.gpm_mev: Popen | None = None
         self.gpm_event_pending: bool = False
         self.bracketed_paste_mode = bracketed_paste_mode

--- a/urwid/_raw_display_base.py
+++ b/urwid/_raw_display_base.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 import abc
 import contextlib
 import functools
-import logging
 import os
 import selectors
 import signal
@@ -56,7 +55,6 @@ class Screen(BaseScreen, RealTerminal):
         terminal.
         """
         super().__init__()
-        self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
 
         self._partial_codes: list[int] = []
         self._pal_escape: dict[str | None, str] = {}

--- a/urwid/_win32_raw_display.py
+++ b/urwid/_win32_raw_display.py
@@ -61,7 +61,6 @@ class Screen(_raw_display_base.Screen):
             input, self._send_input = socket.socketpair()  # noqa: A001
 
         super().__init__(input, output)
-        self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
 
     _dwOriginalOutMode = None
     _dwOriginalInMode = None

--- a/urwid/curses_display.py
+++ b/urwid/curses_display.py
@@ -25,7 +25,6 @@ Curses-based UI implementation
 from __future__ import annotations
 
 import curses
-import logging
 import sys
 import typing
 from contextlib import suppress
@@ -104,7 +103,6 @@ _curses_colours = {
 class Screen(BaseScreen, RealTerminal):
     def __init__(self):
         super().__init__()
-        self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
         self.curses_pairs = [(None, None)]  # Can't be sure what pair 0 will default to
         self.palette = {}
         self.has_color = False

--- a/urwid/display_common.py
+++ b/urwid/display_common.py
@@ -37,7 +37,6 @@ if typing.TYPE_CHECKING:
 
     from urwid import Canvas
 
-LOGGER = logging.getLogger(__name__)
 IS_WINDOWS = sys.platform == "win32"
 
 if not IS_WINDOWS:
@@ -1004,7 +1003,7 @@ class BaseScreen(metaclass=BaseMeta):
     def __init__(self) -> None:
         super().__init__()
 
-        self.logger = LOGGER.getChild(self.__class__.__name__)
+        self.logger = logging.getLogger(f"{self.__class__.__module__}.{self.__class__.__name__}")
 
         self._palette: dict[str | None, tuple[AttrSpec, AttrSpec, AttrSpec, AttrSpec, AttrSpec]] = {}
         self._started: bool = False

--- a/urwid/widget/widget.py
+++ b/urwid/widget/widget.py
@@ -21,6 +21,7 @@
 from __future__ import annotations
 
 import functools
+import logging
 import typing
 import warnings
 from operator import attrgetter
@@ -288,7 +289,7 @@ class Widget(metaclass=WidgetMeta):
        :param size: See :meth:`Widget.render` for details
        :type size: widget size
        :param key: a single keystroke value; see :ref:`keyboard-input`
-       :type key: bytes or unicode
+       :type key: str
 
        :returns: ``None`` if *key* was handled by this widget or
                  *key* (the same value passed) if *key* was not handled
@@ -414,6 +415,9 @@ class Widget(metaclass=WidgetMeta):
     _selectable = False
     _sizing = frozenset([Sizing.FLOW, Sizing.BOX, Sizing.FIXED])
     _command_map = command_map
+
+    def __init__(self):
+        self.logger = logging.getLogger(f"{self.__class__.__module__}.{self.__class__.__name__}")
 
     def _invalidate(self) -> None:
         """
@@ -598,6 +602,7 @@ class FlowWidget(Widget):
             DeprecationWarning,
             stacklevel=3,
         )
+        super().__init__()
 
     def rows(self, size: int, focus: bool = False) -> int:
         """
@@ -640,6 +645,7 @@ class BoxWidget(Widget):
             DeprecationWarning,
             stacklevel=3,
         )
+        super().__init__()
 
     def render(self, size: tuple[int, int], focus: bool = False):
         """
@@ -683,6 +689,7 @@ class FixedWidget(Widget):
             DeprecationWarning,
             stacklevel=3,
         )
+        super().__init__()
 
     def render(self, size, focus=False):
         """


### PR DESCRIPTION
* Add `logger` to all `Widget` instances (if properly subclassed)

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

