### PR TITLE
Feature: Implement `keypress` and `mouse_event` default handlers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,7 +169,7 @@ extend-select = [
 extend-ignore = [
   "PLR6301", "E203", "PLW3201",
     # refactor rules (too many statements/arguments/branches)
-  "PLR0904", "PLR0911", "PLR0912", "PLR0913", "PLR0915", "PLR0917", "PLR2004",
+  "PLR0904", "PLR0911", "PLR0912", "PLR0913", "PLR0914", "PLR0915", "PLR0917", "PLR2004",
   "PLC0415",  # We have a lot of imports outside of top-level
   "RET504",  # Unnecessary variable assignment before return statement
   "SIM108",  # Use ternary operator,

--- a/urwid/listbox.py
+++ b/urwid/listbox.py
@@ -1692,6 +1692,11 @@ class ListBox(Widget, WidgetContainerMixin):
             self.change_focus((maxcol, maxrow), w_pos, wrow)
 
         if not hasattr(w, "mouse_event"):
+            warnings.warn(
+                f"{w.__class__.__module__}.{w.__class__.__name__} is not subclass of Widget",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             return False
 
         return w.mouse_event((maxcol,), event, button, col, row - wrow, focus)

--- a/urwid/widget/columns.py
+++ b/urwid/widget/columns.py
@@ -700,6 +700,11 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
                 self.focus_position = i
 
             if not hasattr(w, "mouse_event"):
+                warnings.warn(
+                    f"{w.__class__.__module__}.{w.__class__.__name__} is not subclass of Widget",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
                 return False
 
             if len(size) == 1 and b:
@@ -716,6 +721,7 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
             return 0
         col = None
         cwidth = widths[self.focus_position]
+
         if hasattr(w, "get_pref_col"):
             if len(size) == 1 and b:
                 col = w.get_pref_col((cwidth, self.rows(size)))
@@ -726,6 +732,7 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
                 col += sum(widths[: self.focus_position])
         if col is None:
             col = self.pref_col
+
         if col is None and w.selectable():
             col = cwidth // 2
             col += self.focus_position * self.dividechars

--- a/urwid/widget/filler.py
+++ b/urwid/widget/filler.py
@@ -244,7 +244,7 @@ class Filler(WidgetDecoration):
             y = maxrow - 1
         return x, y + top
 
-    def get_pref_col(self, size: tuple[int, int]) -> int:
+    def get_pref_col(self, size: tuple[int, int]) -> int | None:
         """Return pref_col from self.original_widget if any."""
         (maxcol, maxrow) = size
         if not hasattr(self._original_widget, "get_pref_col"):

--- a/urwid/widget/frame.py
+++ b/urwid/widget/frame.py
@@ -198,6 +198,19 @@ class FrameError(Exception):
     pass
 
 
+def _check_widget_subclass(widget: Widget | None) -> None:
+    if widget is None:
+        return
+
+    if not isinstance(widget, Widget):
+        obj_class_path = f"{widget.__class__.__module__}.{widget.__class__.__name__}"
+        warnings.warn(
+            f"{obj_class_path} is not subclass of Widget",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+
+
 class Frame(Widget, WidgetContainerMixin):
     """
     Frame widget is a box widget with optional header and footer
@@ -235,6 +248,9 @@ class Frame(Widget, WidgetContainerMixin):
         self._body = body
         self._footer = footer
         self.focus_part = focus_part
+        _check_widget_subclass(header)
+        _check_widget_subclass(body)
+        _check_widget_subclass(footer)
 
     @property
     def header(self) -> Widget | None:
@@ -242,6 +258,7 @@ class Frame(Widget, WidgetContainerMixin):
 
     @header.setter
     def header(self, header: Widget | None):
+        _check_widget_subclass(header)
         self._header = header
         if header is None and self.focus_part == "header":
             self.focus_part = "body"
@@ -271,6 +288,7 @@ class Frame(Widget, WidgetContainerMixin):
 
     @body.setter
     def body(self, body: Widget) -> None:
+        _check_widget_subclass(body)
         self._body = body
         self._invalidate()
 
@@ -298,6 +316,7 @@ class Frame(Widget, WidgetContainerMixin):
 
     @footer.setter
     def footer(self, footer: Widget | None) -> None:
+        _check_widget_subclass(footer)
         self._footer = footer
         if footer is None and self.focus_part == "footer":
             self.focus_part = "body"

--- a/urwid/widget/overlay.py
+++ b/urwid/widget/overlay.py
@@ -34,6 +34,16 @@ class OverlayError(Exception):
     pass
 
 
+def _check_widget_subclass(widget: Widget) -> None:
+    if not isinstance(widget, Widget):
+        obj_class_path = f"{widget.__class__.__module__}.{widget.__class__.__name__}"
+        warnings.warn(
+            f"{obj_class_path} is not subclass of Widget",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+
+
 class Overlay(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
     """
     Overlay contains two box widgets and renders one on top of the other
@@ -134,6 +144,9 @@ class Overlay(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         self.bottom_w = bottom_w
 
         self.set_overlay_parameters(align, width, valign, height, min_width, min_height, left, right, top, bottom)
+
+        _check_widget_subclass(top_w)
+        _check_widget_subclass(bottom_w)
 
     @staticmethod
     def options(
@@ -572,5 +585,10 @@ class Overlay(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
             return False
 
         return self.top_w.mouse_event(
-            self.top_w_size(size, left, right, top, bottom), event, button, col - left, row - top, focus
+            self.top_w_size(size, left, right, top, bottom),
+            event,
+            button,
+            col - left,
+            row - top,
+            focus,
         )

--- a/urwid/widget/pile.py
+++ b/urwid/widget/pile.py
@@ -648,6 +648,11 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
             self.focus_position = i
 
         if not hasattr(w, "mouse_event"):
+            warnings.warn(
+                f"{w.__class__.__module__}.{w.__class__.__name__} is not subclass of Widget",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             return False
 
         tsize = self.get_item_size(size, i, focus, item_rows)

--- a/urwid/widget/widget.py
+++ b/urwid/widget/widget.py
@@ -585,7 +585,7 @@ class Widget(metaclass=WidgetMeta):
                 self.logger.debug(f"keypress sent to non selectable widget {self!r}")
             else:
                 warnings.warn(
-                    f"Widget {self.__class__.__name__} not called 'super().__init__()",
+                    f"Widget {self.__class__.__name__} did not call 'super().__init__()",
                     WidgetWarning,
                     stacklevel=3,
                 )

--- a/urwid/widget/widget.py
+++ b/urwid/widget/widget.py
@@ -582,7 +582,7 @@ class Widget(metaclass=WidgetMeta):
         """
         if not self.selectable():
             if hasattr(self, "logger"):
-                self.logger.debug(f"Widget {self!r} is not selectable")
+                self.logger.debug(f"keypress sent to non selectable widget {self!r}")
             else:
                 warnings.warn(
                     f"Widget {self.__class__.__name__} not called 'super().__init__()",

--- a/urwid/widget/widget.py
+++ b/urwid/widget/widget.py
@@ -761,7 +761,7 @@ class FixedWidget(Widget):
         raise NotImplementedError()
 
 
-def delegate_to_widget_mixin(attribute_name: str):
+def delegate_to_widget_mixin(attribute_name: str) -> type[Widget]:
     """
     Return a mixin class that delegates all standard widget methods
     to an attribute given by attribute_name.
@@ -824,7 +824,7 @@ class WidgetWrapError(Exception):
     pass
 
 
-class WidgetWrap(delegate_to_widget_mixin("_wrapped_widget"), Widget):
+class WidgetWrap(delegate_to_widget_mixin("_wrapped_widget")):
     def __init__(self, w: Widget):
         """
         w -- widget to wrap, stored as self._w

--- a/urwid/widget/widget.py
+++ b/urwid/widget/widget.py
@@ -38,6 +38,9 @@ if typing.TYPE_CHECKING:
     from collections.abc import Callable, Hashable
 
 
+LOGGER = logging.getLogger(__name__)
+
+
 class WidgetMeta(MetaSuper, signals.MetaSignals):
     """
     Bases: :class:`MetaSuper`, :class:`MetaSignals`
@@ -74,7 +77,11 @@ class WidgetMeta(MetaSuper, signals.MetaSignals):
 
 
 class WidgetError(Exception):
-    pass
+    """Widget specific errors."""
+
+
+class WidgetWarning(Warning):
+    """Widget specific warnings."""
 
 
 def validate_size(widget, size, canv):
@@ -280,12 +287,6 @@ class Widget(metaclass=WidgetMeta):
 
     .. method:: keypress(size, key)
 
-       .. note::
-
-          This method is not implemented in :class:`.Widget` but
-          must be implemented by any selectable widget.
-          See :meth:`.selectable`.
-
        :param size: See :meth:`Widget.render` for details
        :type size: widget size
        :param key: a single keystroke value; see :ref:`keyboard-input`
@@ -310,13 +311,6 @@ class Widget(metaclass=WidgetMeta):
 
 
     .. method:: mouse_event(size, event, button, col, row, focus)
-
-       .. note::
-
-          This method is not implemented in :class:`.Widget` but
-          may be implemented by a subclass.  Not implementing this
-          method is equivalent to having a method that always returns
-          ``False``.
 
        :param size: See :meth:`Widget.render` for details.
        :type size: widget size
@@ -576,6 +570,69 @@ class Widget(metaclass=WidgetMeta):
     def _repr_attrs(self):
         return {}
 
+    def keypress(self, size: tuple[()] | tuple[int] | tuple[int, int], key: str) -> str | None:
+        """Keyboard input handler.
+
+        :param size: See :meth:`Widget.render` for details
+        :type size: tuple[()] | tuple[int] | tuple[int, int]
+        :param key: a single keystroke value; see :ref:`keyboard-input`
+        :type key: str
+        :return: ``None`` if *key* was handled by *key* (the same value passed) if *key* was not handled
+        :rtype: str | None
+        """
+        if not self.selectable():
+            if hasattr(self, "logger"):
+                self.logger.debug(f"Widget {self!r} is not selectable")
+            else:
+                warnings.warn(
+                    f"Widget {self.__class__.__name__} not called 'super().__init__()",
+                    WidgetWarning,
+                    stacklevel=3,
+                )
+                LOGGER.debug(f"Widget {self!r} is not selectable")
+        return key
+
+    def mouse_event(
+        self,
+        size: tuple[()] | tuple[int] | tuple[int, int],
+        event: str,
+        button: int,
+        col: int,
+        row: int,
+        focus: bool,
+    ) -> bool | None:
+        """Mouse event handler.
+
+        :param size: See :meth:`Widget.render` for details.
+        :type size: tuple[()] | tuple[int] | tuple[int, int]
+        :param event: Values such as ``'mouse press'``, ``'ctrl mouse press'``,
+                     ``'mouse release'``, ``'meta mouse release'``,
+                     ``'mouse drag'``; see :ref:`mouse-input`
+        :type event: str
+        :param button: 1 through 5 for press events, often 0 for release events
+                      (which button was released is often not known)
+        :type button: int
+        :param col: Column of the event, 0 is the left edge of this widget
+        :type col: int
+        :param row: Row of the event, 0 it the top row of this widget
+        :type row: int
+        :param focus: Set to ``True`` if this widget or one of its children is in focus
+        :type focus: bool
+        :return: ``True`` if the event was handled by this widget, ``False`` otherwise
+        :rtype: bool | None
+        """
+        if not self.selectable():
+            if hasattr(self, "logger"):
+                self.logger.debug(f"Widget {self!r} is not selectable")
+            else:
+                warnings.warn(
+                    f"Widget {self.__class__.__name__} not called 'super().__init__()",
+                    WidgetWarning,
+                    stacklevel=3,
+                )
+                LOGGER.debug(f"Widget {self!r} is not selectable")
+        return False
+
 
 class FlowWidget(Widget):
     """
@@ -782,6 +839,14 @@ class WidgetWrap(delegate_to_widget_mixin("_wrapped_widget"), Widget):
         of the wrapped widgets by behaving like a ContainerWidget or
         WidgetDecoration, or it may hide them from outside access.
         """
+        super().__init__()
+        if not isinstance(w, Widget):
+            obj_class_path = f"{w.__class__.__module__}.{w.__class__.__name__}"
+            warnings.warn(
+                f"{obj_class_path} is not subclass of Widget",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self._wrapped_widget = w
 
     @property

--- a/urwid/widget/widget_decoration.py
+++ b/urwid/widget/widget_decoration.py
@@ -30,6 +30,17 @@ class WidgetDecoration(Widget):  # "decorator" was already taken
     """
 
     def __init__(self, original_widget: Widget) -> None:
+        # TODO(Aleksei): reduce amount of multiple inheritance usage
+        # Special case: subclasses with multiple inheritance causes `super` call wrong way
+        # Call parent __init__ explicit
+        Widget.__init__(self)
+        if not isinstance(original_widget, Widget):
+            obj_class_path = f"{original_widget.__class__.__module__}.{original_widget.__class__.__name__}"
+            warnings.warn(
+                f"{obj_class_path} is not subclass of Widget",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self._original_widget = original_widget
 
     def _repr_words(self):


### PR DESCRIPTION
* `Widget` class to have default standard handlers
* Produce debug log for non-selectable widgets received events
* Produce `WidgetWarning` if `__init__` of base class not called
* Produce deprecation warnings if no subclassed Widget

##### Checklist
- [ ] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [X] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
