### PR TITLE
Buildsystem: update upload/download artifact actions

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -46,7 +46,7 @@ jobs:
         env:
           SPHINX_GITHUB_CHANGELOG_TOKEN: ${{ secrets.URWID_SPHINX_RO_TOKEN }}
         run: sphinx-build docs build/documentation
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: build/documentation
           name: documentation

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -184,10 +184,10 @@ jobs:
           CIBW_ARCHS_MACOS: x86_64 universal2 arm64
           CIBW_ARCHS_WINDOWS: auto
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
-          name: wheels
+          name: built-${{ matrix.os }}
           retention-days: 3
 
   build_sdist:
@@ -209,10 +209,10 @@ jobs:
       - name: Build sdist
         run: python -m build -s
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: dist/*.tar.gz
-          name: wheels
+          name: built-sdist
           retention-days: 3
 
   Metadata:
@@ -230,12 +230,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade twine
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           # unpacks default artifact into dist/
           # if `name: wheels` is omitted, the action will create extra parent dir
-          name: wheels
+          pattern: built-*
+          merge-multiple: true
           path: dist
+
       - name: Validate metadata
         run: |
           twine check dist/*
@@ -253,11 +255,10 @@ jobs:
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          # unpacks default artifact into dist/
-          # if `name: wheels` is omitted, the action will create extra parent dir
-          name: wheels
+          pattern: built-*
+          merge-multiple: true
           path: dist
 
       - name: Publish package distributions to PyPI


### PR DESCRIPTION
v3 -> v4

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [ ] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
