### PR TITLE
Do not produce `DeprecationWarning` for `urwid.escape`

### DIFF
--- a/urwid/__init__.py
+++ b/urwid/__init__.py
@@ -252,7 +252,6 @@ __locals: dict[str, typing.Any] = locals()  # use mutable access for pure lazy l
 
 # Backward compatible lazy load with deprecation warnings
 _moved_warn: dict[str, str] = {
-    "escape": "urwid.display.escape",
     "lcd_display": "urwid.display.lcd",
     "html_fragment": "urwid.display.html_fragment",
     "web_display": "urwid.display.web",
@@ -263,6 +262,7 @@ _moved_no_warn: dict[str, str] = {
     "display_common": "urwid.display.common",
     "raw_display": "urwid.display.raw",
     "curses_display": "urwid.display.curses",
+    "escape": "urwid.display.escape",
 }
 
 


### PR DESCRIPTION
For wide-used imports required slow deprecation path

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

