### PR TITLE
Remove unused deprecated "test_suite" directive from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup_d = {
     "name": "urwid",
     "ext_modules": [Extension("urwid.str_util", sources=["source/str_util.c"], py_limited_api=True)],
     "url": "https://urwid.org/",
-    "test_suite": "urwid.tests",
 }
 
 if __name__ == "__main__":


### PR DESCRIPTION
##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

