### PR TITLE
BUG: Columns with GIVEN width == 0 should not count in rows

### DIFF
--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -198,6 +198,18 @@ class ColumnsTest(unittest.TestCase):
                 str(ctx.warnings[0].message),
             )
 
+    def test_zero_width_column(self):
+        elem_1 = urwid.BoxAdapter(urwid.SolidFill("#"), 2)
+        elem_2 = urwid.BoxAdapter(urwid.SolidFill("*"), 4)
+
+        widget = urwid.Columns((elem_1, (0, elem_2)))
+        self.assertEqual((3, 2), widget.pack((3,)))
+
+        canvas = widget.render((3,))
+        self.assertEqual(2, canvas.rows())
+        self.assertEqual(3, canvas.cols())
+        self.assertEqual([b"###", b"###"], canvas.text)
+
     def assert_column_widths(
         self,
         expected: Collection[int],

--- a/urwid/widget/columns.py
+++ b/urwid/widget/columns.py
@@ -1063,7 +1063,7 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
 
         rows = 1
         for i, (mc, (w, (_t, _n, b))) in enumerate(zip(widths, self.contents)):
-            if b:
+            if b or mc <= 0:
                 continue
             rows = max(rows, w.rows((mc,), focus=focus and self.focus_position == i))
         return rows


### PR DESCRIPTION
Such columns were always not counted in render

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)