### PR TITLE
Feature: `Overlay` typing and proper repr

### DIFF
--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -61,37 +61,6 @@ class FrameTest(unittest.TestCase):
             True, 10, 0)
 
 
-class OverlayTest(unittest.TestCase):
-    def test_old_params(self):
-        o1 = urwid.Overlay(urwid.SolidFill('X'), urwid.SolidFill('O'),
-            ('fixed left', 5), ('fixed right', 4),
-            ('fixed top', 3), ('fixed bottom', 2),)
-        self.assertEqual(o1.contents[1][1], (
-            'left', None, 'relative', 100, None, 5, 4,
-            'top', None, 'relative', 100, None, 3, 2))
-        o2 = urwid.Overlay(urwid.SolidFill('X'), urwid.SolidFill('O'),
-            ('fixed right', 5), ('fixed left', 4),
-            ('fixed bottom', 3), ('fixed top', 2),)
-        self.assertEqual(o2.contents[1][1], (
-            'right', None, 'relative', 100, None, 4, 5,
-            'bottom', None, 'relative', 100, None, 2, 3))
-
-    def test_get_cursor_coords(self):
-        self.assertEqual(urwid.Overlay(urwid.Filler(urwid.Edit()),
-            urwid.SolidFill('B'),
-            'right', 1, 'bottom', 1).get_cursor_coords((2,2)), (1,1))
-
-    def test_length(self):
-        ovl = urwid.Overlay(
-            urwid.SolidFill('X'),
-            urwid.SolidFill('O'),
-            'center',
-            ("relative", 20),
-            "middle",
-            ("relative", 20),
-        )
-        self.assertEqual(2, len(ovl))
-        self.assertEqual(2, len(ovl.contents))
 
 
 class WidgetSquishTest(unittest.TestCase):
@@ -192,23 +161,6 @@ class CommonContainerTest(unittest.TestCase):
         lb.focus_position = 0
         self.assertRaises(IndexError, lambda: setattr(lb, 'focus_position', -1))
         self.assertRaises(IndexError, lambda: setattr(lb, 'focus_position', 2))
-
-    def test_overlay(self):
-        s1 = urwid.SolidFill('1')
-        s2 = urwid.SolidFill('2')
-        o = urwid.Overlay(s1, s2,
-            'center', ('relative', 50), 'middle', ('relative', 50))
-        self.assertEqual(o.focus, s1)
-        self.assertEqual(o.focus_position, 1)
-        self.assertRaises(IndexError, lambda: setattr(o, 'focus_position',
-            None))
-        self.assertRaises(IndexError, lambda: setattr(o, 'focus_position', 2))
-
-        self.assertEqual(o.contents[0], (s2,
-            urwid.Overlay._DEFAULT_BOTTOM_OPTIONS))
-        self.assertEqual(o.contents[1], (s1, (
-            'center', None, 'relative', 50, None, 0, 0,
-            'middle', None, 'relative', 50, None, 0, 0)))
 
     def test_frame(self):
         s1 = urwid.SolidFill('1')

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import unittest
+
+import urwid
+
+
+class OverlayTest(unittest.TestCase):
+    def test_old_params(self):
+        o1 = urwid.Overlay(
+            urwid.SolidFill("X"),
+            urwid.SolidFill("O"),
+            ("fixed left", 5),
+            ("fixed right", 4),
+            ("fixed top", 3),
+            ("fixed bottom", 2),
+        )
+        self.assertEqual(
+            o1.contents[1][1],
+            ("left", None, "relative", 100, None, 5, 4, "top", None, "relative", 100, None, 3, 2),
+        )
+        o2 = urwid.Overlay(
+            urwid.SolidFill("X"),
+            urwid.SolidFill("O"),
+            ("fixed right", 5),
+            ("fixed left", 4),
+            ("fixed bottom", 3),
+            ("fixed top", 2),
+        )
+        self.assertEqual(
+            o2.contents[1][1],
+            ("right", None, "relative", 100, None, 4, 5, "bottom", None, "relative", 100, None, 2, 3),
+        )
+
+    def test_get_cursor_coords(self):
+        self.assertEqual(
+            urwid.Overlay(
+                urwid.Filler(urwid.Edit()),
+                urwid.SolidFill("B"),
+                "right",
+                1,
+                "bottom",
+                1,
+            ).get_cursor_coords((2, 2)),
+            (1, 1),
+        )
+
+    def test_length(self):
+        ovl = urwid.Overlay(
+            urwid.SolidFill("X"),
+            urwid.SolidFill("O"),
+            "center",
+            ("relative", 20),
+            "middle",
+            ("relative", 20),
+        )
+        self.assertEqual(2, len(ovl))
+        self.assertEqual(2, len(ovl.contents))
+
+    def test_common(self):
+        s1 = urwid.SolidFill("1")
+        s2 = urwid.SolidFill("2")
+        o = urwid.Overlay(s1, s2, "center", ("relative", 50), "middle", ("relative", 50))
+        self.assertEqual(o.focus, s1)
+        self.assertEqual(o.focus_position, 1)
+        self.assertRaises(IndexError, lambda: setattr(o, "focus_position", None))
+        self.assertRaises(IndexError, lambda: setattr(o, "focus_position", 2))
+
+        self.assertEqual(o.contents[0], (s2, urwid.Overlay._DEFAULT_BOTTOM_OPTIONS))
+        self.assertEqual(
+            o.contents[1],
+            (s1, ("center", None, "relative", 50, None, 0, 0, "middle", None, "relative", 50, None, 0, 0)),
+        )

--- a/urwid/widget/big_text.py
+++ b/urwid/widget/big_text.py
@@ -20,6 +20,10 @@ class BigText(Widget):
         markup -- same as Text widget markup
         font -- instance of a Font class
         """
+        super().__init__()
+        self.text: str = ""
+        self.attrib = []
+        self.font: Font = font
         self.set_font(font)
         self.set_text(markup)
 
@@ -44,7 +48,7 @@ class BigText(Widget):
             cols += self.font.char_width(c)
         return cols, rows
 
-    def render(self, size: tuple[()], focus: bool = False) -> CanvasJoin | CompositeCanvas:
+    def render(self, size: tuple[()], focus: bool = False) -> CompositeCanvas:
         fixed_size(size)  # complain if parameter is wrong
         a = None
         ai = ak = 0
@@ -68,6 +72,6 @@ class BigText(Widget):
         if o:
             canv = CanvasJoin(o)
         else:
-            canv = CompositeCanvas(TextCanvas([""] * rows, maxcol=0, check_width=False))
+            canv = CompositeCanvas(TextCanvas([b""] * rows, maxcol=0, check_width=False))
         canv.set_depends([])
         return canv


### PR DESCRIPTION
Better error messages and simpler debugging
* move tests for `Overlay` from `test_container` to `test_overlay`
* fix `BigText` issues found during `Overlay` testing

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

