### PR TITLE
Feature: Columns accept focus widget as "focus_column"

### DIFF
--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -228,6 +228,34 @@ class ColumnsTest(unittest.TestCase):
         self.assertEqual(3, canvas.cols())
         self.assertEqual([b"###", b"###"], canvas.text)
 
+    def test_focus_column(self):
+        button_1 = urwid.Button("Selectable")
+        button_2 = urwid.Button("Other selectable")
+        widget_list = [
+            (urwid.PACK, urwid.Text("Non selectable")),
+            (urwid.PACK, button_1),
+            (urwid.PACK, button_2),
+            (urwid.PACK, urwid.Text("The end")),
+        ]
+        with self.subTest("Not provided -> select first selectable"):
+            widget = urwid.Columns(widget_list)
+            self.assertEqual(1, widget.focus_position)
+            widget.keypress((), "left")
+            self.assertEqual(1, widget.focus_position)
+
+        with self.subTest("Exact index"):
+            widget = urwid.Columns(widget_list, focus_column=2)
+            self.assertEqual(2, widget.focus_position)
+            widget.keypress((), "left")
+            self.assertEqual(1, widget.focus_position)
+
+        with self.subTest("Exact widget"):
+            widget = urwid.Columns(widget_list, focus_column=button_2)
+            self.assertEqual(2, widget.focus_position)
+            self.assertEqual(button_2, widget.focus)
+            widget.keypress((), "left")
+            self.assertEqual(1, widget.focus_position)
+
     def assert_column_widths(
         self,
         expected: Collection[int],

--- a/urwid/widget/columns.py
+++ b/urwid/widget/columns.py
@@ -196,14 +196,14 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
             | tuple[Literal["weight", "given", WHSettings.WEIGHT, WHSettings.GIVEN], int, Widget]
         ],
         dividechars: int = 0,
-        focus_column: int | None = None,
+        focus_column: int | Widget | None = None,
         min_width: int = 1,
         box_columns: Iterable[int] | None = None,
     ):
         """
         :param widget_list: iterable of flow or box widgets
         :param dividechars: number of blank characters between columns
-        :param focus_column: index into widget_list of column in focus,
+        :param focus_column: index into widget_list of column in focus or focused widget instance,
             if ``None`` the first selectable widget will be chosen.
         :param min_width: minimum width for each column which is not
             calling widget.pack() in *widget_list*.
@@ -257,7 +257,7 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
                 self.contents.append((w, (WHSettings.WEIGHT, width, i in box_columns)))
             else:
                 raise ColumnsError(f"initial widget list item invalid: {original!r}")
-            if focus_column is None and w.selectable():
+            if focus_column == w or (focus_column is None and w.selectable()):
                 focus_column = i
 
         self.dividechars = dividechars

--- a/urwid/widget/wimp.py
+++ b/urwid/widget/wimp.py
@@ -267,7 +267,7 @@ class CheckBox(WidgetWrap):
             ),
         )
 
-    def pack(self, size: tuple[int] | None = None, focus: bool = False) -> tuple[str, str]:
+    def pack(self, size: tuple[()] | tuple[int] | None = None, focus: bool = False) -> tuple[str, str]:
         """Pack for widget.
 
         :param size: size data. Special case: None - get minimal widget size to fit
@@ -281,13 +281,10 @@ class CheckBox(WidgetWrap):
         >>> ml_cb = CheckBox("Multi\\nline\\ncheckbox")
         >>> ml_cb.pack()
         (12, 3)
+        >>> ml_cb.pack((), True)
+        (12, 3)
         """
-        if size is not None:
-            return super().pack(size, focus)
-
-        width, _height = self._label.pack()
-        width += self.reserve_columns
-        return width, self.rows((width,))
+        return super().pack(size or (), focus)
 
     def _repr_words(self) -> list[str]:
         return [*super()._repr_words(), repr(self.label)]
@@ -695,7 +692,7 @@ class Button(WidgetWrap):
         if on_press:
             connect_signal(self, "click", on_press, user_data)
 
-    def pack(self, size: tuple[int] | None = None, focus: bool = False) -> tuple[int, int]:
+    def pack(self, size: tuple[()] | tuple[int] | None = None, focus: bool = False) -> tuple[int, int]:
         """Pack for widget.
 
         :param size: size data. Special case: None - get minimal widget size to fit
@@ -706,13 +703,10 @@ class Button(WidgetWrap):
         (10, 2)
         >>> btn.pack()
         (15, 1)
+        >>> btn.pack((), True)
+        (15, 1)
         """
-        if size is not None:
-            return super().pack(size, focus)
-
-        width, _height = self._label.pack()
-        width += 4  # We use Given sizing for button ends and `dividechars=1`
-        return width, self.rows((width,))
+        return super().pack(size or (), focus)
 
     def _repr_words(self) -> list[str]:
         # include button.label in repr(button)


### PR DESCRIPTION
##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [X] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

