### PR TITLE
LineBox: make side only if side elements present, fix pack

### DIFF
--- a/tests/test_graphics.py
+++ b/tests/test_graphics.py
@@ -7,57 +7,6 @@ from urwid.util import get_encoding
 from urwid.widget import bar_graph
 
 
-class LineBoxTest(unittest.TestCase):
-    def setUp(self) -> None:
-        self.old_encoding = get_encoding()
-        urwid.set_encoding("utf-8")
-
-    def tearDown(self) -> None:
-        urwid.set_encoding(self.old_encoding)
-
-    def border(self, tl, t, tr, l, r, bl, b, br):
-        return [
-            b"".join([tl, t, tr]),
-            b"".join([l, b" ", r]),
-            b"".join([bl, b, br]),
-        ]
-
-    def test_linebox_pack(self):
-        # Bug #346 'pack' Padding does not run with LineBox
-        t = urwid.Text("AAA\nCCC\nDDD")
-        size = t.pack()
-        l = urwid.LineBox(t)
-
-        self.assertEqual(l.pack()[0], size[0] + 2)
-        self.assertEqual(l.pack()[1], size[1] + 2)
-
-    def test_linebox_border(self):
-        t = urwid.Text("")
-
-        l = urwid.LineBox(t).render((3,)).text
-
-        # default
-        self.assertEqual(
-            l,
-            self.border(
-                b"\xe2\x94\x8c",
-                b"\xe2\x94\x80",
-                b"\xe2\x94\x90",
-                b"\xe2\x94\x82",
-                b"\xe2\x94\x82",
-                b"\xe2\x94\x94",
-                b"\xe2\x94\x80",
-                b"\xe2\x94\x98",
-            ),
-        )
-
-        nums = [str(n).encode("iso8859-1") for n in range(8)]
-        b = dict(zip(["tlcorner", "tline", "trcorner", "lline", "rline", "blcorner", "bline", "brcorner"], nums))
-        l = urwid.LineBox(t, **b).render((3,)).text
-
-        self.assertEqual(l, self.border(*nums))
-
-
 class BarGraphTest(unittest.TestCase):
     def bgtest(self, desc, data, top, widths, maxrow, exp):
         rval = bar_graph.calculate_bargraph_display(data, top, widths, maxrow)

--- a/tests/test_line_box.py
+++ b/tests/test_line_box.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import unittest
+
+import urwid
+from urwid.util import get_encoding
+
+
+class LineBoxTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.old_encoding = get_encoding()
+        urwid.set_encoding("utf-8")
+
+    def tearDown(self) -> None:
+        urwid.set_encoding(self.old_encoding)
+
+    def test_linebox_pack(self):
+        # Bug #346 'pack' Padding does not run with LineBox
+        t = urwid.Text("AAA\nCCC\nDDD")
+        size = t.pack()
+        l = urwid.LineBox(t)
+
+        self.assertEqual(l.pack()[0], size[0] + 2)
+        self.assertEqual(l.pack()[1], size[1] + 2)
+
+    def test_border(self):
+        wrapped = urwid.Text("Text\non\nfour\nlines", align=urwid.CENTER)
+        l = urwid.LineBox(wrapped, tlcorner="╭", trcorner="╮", blcorner="╰", brcorner="╯")
+        cols, rows = 7, 6
+        self.assertEqual((cols, rows), l.pack(()))
+
+        canvas = l.render(())
+        self.assertEqual(cols, canvas.cols())
+        self.assertEqual(rows, canvas.rows())
+
+        self.assertEqual(
+            [
+                "╭─────╮",
+                "│ Text│",
+                "│  on │",
+                "│ four│",
+                "│lines│",
+                "╰─────╯",
+            ],
+            [line.decode("utf-8") for line in canvas.text],
+        )
+
+    def test_header(self):
+        wrapped = urwid.Text("Some text")
+        l = urwid.LineBox(wrapped, title="Title", tlcorner="╭", trcorner="╮", blcorner="╰", brcorner="╯")
+        cols, rows = 11, 3
+        self.assertEqual((cols, rows), l.pack(()))
+
+        canvas = l.render(())
+        self.assertEqual(cols, canvas.cols())
+        self.assertEqual(rows, canvas.rows())
+
+        self.assertEqual(
+            [
+                "╭─ Title ─╮",
+                "│Some text│",
+                "╰─────────╯",
+            ],
+            [line.decode("utf-8") for line in canvas.text],
+        )
+
+    def test_negative(self):
+        wrapped = urwid.Text("")
+        with self.assertRaises(ValueError) as ctx:
+            l = urwid.LineBox(wrapped, title="Title", tline="")
+
+        self.assertEqual("Cannot have a title when tline is empty string", str(ctx.exception))
+
+    def test_partial_contour(self):
+        def mark_pressed(btn: urwid.Button) -> None:
+            nonlocal pressed
+
+            pressed = True
+
+        pressed = False
+        wrapped = urwid.Button("Wrapped", on_press=mark_pressed)
+
+        with self.subTest("No top line -> no top"):
+            l = urwid.LineBox(wrapped, tline="")
+            cols, rows = 13, 2
+            self.assertEqual((cols, rows), l.pack(()))
+
+            canvas = l.render(())
+            self.assertEqual(cols, canvas.cols())
+            self.assertEqual(rows, canvas.rows())
+
+            self.assertEqual(
+                [
+                    "│< Wrapped >│",
+                    "└───────────┘",
+                ],
+                [line.decode("utf-8") for line in canvas.text],
+            )
+            self.assertIsNone(l.keypress((), "enter"))
+            self.assertTrue(pressed)
+
+        pressed = False
+
+        with self.subTest("No right side elements -> no side"):
+            l = urwid.LineBox(wrapped, trcorner="", rline="", brcorner="")
+            cols, rows = 12, 3
+            self.assertEqual((cols, rows), l.pack(()))
+
+            canvas = l.render(())
+            self.assertEqual(cols, canvas.cols())
+            self.assertEqual(rows, canvas.rows())
+
+            self.assertEqual(
+                [
+                    "┌───────────",
+                    "│< Wrapped >",
+                    "└───────────",
+                ],
+                [line.decode("utf-8") for line in canvas.text],
+            )
+            self.assertIsNone(l.keypress((), "enter"))
+            self.assertTrue(pressed)
+
+        pressed = False
+
+        with self.subTest("No left side elements -> no side"):
+            l = urwid.LineBox(wrapped, tlcorner="", lline="", blcorner="")
+            cols, rows = 12, 3
+            self.assertEqual((cols, rows), l.pack(()))
+
+            canvas = l.render(())
+            self.assertEqual(cols, canvas.cols())
+            self.assertEqual(rows, canvas.rows())
+
+            self.assertEqual(
+                [
+                    "───────────┐",
+                    "< Wrapped >│",
+                    "───────────┘",
+                ],
+                [line.decode("utf-8") for line in canvas.text],
+            )
+            self.assertIsNone(l.keypress((), "enter"))
+            self.assertTrue(pressed)
+
+        pressed = False
+
+        with self.subTest("No bottom line -> no bottom"):
+            l = urwid.LineBox(wrapped, bline="")
+            cols, rows = 13, 2
+            self.assertEqual((cols, rows), l.pack(()))
+
+            canvas = l.render(())
+            self.assertEqual(cols, canvas.cols())
+            self.assertEqual(rows, canvas.rows())
+
+            self.assertEqual(
+                [
+                    "┌───────────┐",
+                    "│< Wrapped >│",
+                ],
+                [line.decode("utf-8") for line in canvas.text],
+            )
+            self.assertIsNone(l.keypress((), "enter"))
+            self.assertTrue(pressed)
+
+        pressed = False

--- a/tests/test_line_box.py
+++ b/tests/test_line_box.py
@@ -71,6 +71,12 @@ class LineBoxTest(unittest.TestCase):
 
         self.assertEqual("Cannot have a title when tline is empty string", str(ctx.exception))
 
+        l = urwid.LineBox(wrapped, tline="")
+        with self.assertRaises(ValueError) as ctx:
+            l.set_title("Fail")
+
+        self.assertEqual("Cannot set title when tline is unset", str(ctx.exception))
+
     def test_partial_contour(self):
         def mark_pressed(btn: urwid.Button) -> None:
             nonlocal pressed

--- a/tests/test_line_box.py
+++ b/tests/test_line_box.py
@@ -165,3 +165,23 @@ class LineBoxTest(unittest.TestCase):
             self.assertTrue(pressed)
 
         pressed = False
+
+    def test_columns_of_lineboxes(self):
+        # BUG #748
+        # Using PACK: width of widget 1 is 4, width of widget 2 is 5.
+        # With equal weight widget 1 will be rendered also 5.
+        columns = urwid.Columns(
+            [
+                (urwid.PACK, urwid.LineBox(urwid.Text("lol"), rline="", trcorner="", brcorner="")),
+                (urwid.PACK, urwid.LineBox(urwid.Text("wtf"), tlcorner="┬", blcorner="┴")),
+            ]
+        )
+        canvas = columns.render(())
+        self.assertEqual(
+            [
+                "┌───┬───┐",
+                "│lol│wtf│",
+                "└───┴───┘",
+            ],
+            [line.decode("utf-8") for line in canvas.text],
+        )

--- a/tests/test_line_box.py
+++ b/tests/test_line_box.py
@@ -64,6 +64,16 @@ class LineBoxTest(unittest.TestCase):
             [line.decode("utf-8") for line in canvas.text],
         )
 
+        l.set_title("New")
+        self.assertEqual(
+            [
+                "╭── New ──╮",
+                "│Some text│",
+                "╰─────────╯",
+            ],
+            [line.decode("utf-8") for line in l.render(()).text],
+        )
+
     def test_negative(self):
         wrapped = urwid.Text("")
         with self.assertRaises(ValueError) as ctx:

--- a/tests/test_line_box.py
+++ b/tests/test_line_box.py
@@ -108,7 +108,7 @@ class LineBoxTest(unittest.TestCase):
         pressed = False
 
         with self.subTest("No right side elements -> no side"):
-            l = urwid.LineBox(wrapped, trcorner="", rline="", brcorner="")
+            l = urwid.LineBox(wrapped, rline="")
             cols, rows = 12, 3
             self.assertEqual((cols, rows), l.pack(()))
 
@@ -130,7 +130,7 @@ class LineBoxTest(unittest.TestCase):
         pressed = False
 
         with self.subTest("No left side elements -> no side"):
-            l = urwid.LineBox(wrapped, tlcorner="", lline="", blcorner="")
+            l = urwid.LineBox(wrapped, lline="")
             cols, rows = 12, 3
             self.assertEqual((cols, rows), l.pack(()))
 

--- a/urwid/widget/__init__.py
+++ b/urwid/widget/__init__.py
@@ -29,9 +29,9 @@ from .filler import Filler, FillerError, calculate_top_bottom_filler
 from .frame import Frame, FrameError
 from .grid_flow import GridFlow, GridFlowError
 from .line_box import LineBox
-from .overlay import Overlay, OverlayError
+from .overlay import Overlay, OverlayError, OverlayWarning
 from .padding import Padding, PaddingError, calculate_left_right_padding
-from .pile import Pile, PileError
+from .pile import Pile, PileError, PileWarning
 from .popup import PopUpLauncher, PopUpTarget
 from .progress_bar import ProgressBar
 from .solid_fill import SolidFill
@@ -123,12 +123,15 @@ __all__ = (
     "GridFlowError",
     "Overlay",
     "OverlayError",
+    "OverlayWarning",
     "Frame",
     "FrameError",
     "Pile",
     "PileError",
+    "PileWarning",
     "Columns",
     "ColumnsError",
+    "ColumnsWarning",
     "WidgetContainerMixin",
     "PopUpLauncher",
     "PopUpTarget",
@@ -147,7 +150,6 @@ __all__ = (
     "ProgressBar",
     "WidgetContainerListContentsMixin",
     "WidgetWarning",
-    "ColumnsWarning",
 )
 
 # Backward compatibility

--- a/urwid/widget/columns.py
+++ b/urwid/widget/columns.py
@@ -874,7 +874,7 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
             tuple(w_h_args[idx] for idx in range(len(w_h_args))),
         )
 
-    def pack(self, size: tuple[()] | tuple[int] | tuple[int, int], focus: bool = False) -> tuple[int, int]:
+    def pack(self, size: tuple[()] | tuple[int] | tuple[int, int] = (), focus: bool = False) -> tuple[int, int]:
         """Get packed sized for widget."""
         if size:
             return super().pack(size, focus)

--- a/urwid/widget/grid_flow.py
+++ b/urwid/widget/grid_flow.py
@@ -481,7 +481,7 @@ class GridFlow(WidgetWrap, WidgetContainerMixin, WidgetContainerListContentsMixi
             self._set_focus_from_display_widget()
         return key
 
-    def pack(self, size: tuple[int] | tuple[()], focus: bool = False) -> tuple[int, int]:
+    def pack(self, size: tuple[int] | tuple[()] = (), focus: bool = False) -> tuple[int, int]:
         if size:
             return super().pack(size, focus)
         cols = len(self) * self.cell_width + (len(self) - 1) * self.h_sep

--- a/urwid/widget/line_box.py
+++ b/urwid/widget/line_box.py
@@ -120,7 +120,7 @@ class LineBox(WidgetDecoration, WidgetWrap):
         return ""
 
     def set_title(self, text: str) -> None:
-        if not self.title_widget:
+        if not self.tline_widget:
             raise ValueError("Cannot set title when tline is unset")
         self.title_widget.set_text(self.format_title(text))
         self.tline_widget._invalidate()

--- a/urwid/widget/line_box.py
+++ b/urwid/widget/line_box.py
@@ -52,9 +52,9 @@ class LineBox(WidgetDecoration, WidgetWrap):
             blcorner: bottom left corner
             brcorner: bottom right corner
 
-        If empty string is specified for one of the lines/corners, then no
-        character will be output there.  This allows for seamless use of
-        adjoining LineBoxes.
+        If empty string is specified for one of the lines/corners, then no character will be output there.
+        If no top/bottom/left/right lines - whole lines will be omitted.
+        This allows for seamless use of adjoining LineBoxes.
         """
 
         w_lline = SolidFill(lline)
@@ -82,7 +82,13 @@ class LineBox(WidgetDecoration, WidgetWrap):
                     tline_widgets.append(w_tline)
 
             self.tline_widget = Columns(tline_widgets)
-            top = Columns(((int(bool(tlcorner)), w_tlcorner), self.tline_widget, (int(bool(trcorner)), w_trcorner)))
+            top = Columns(
+                (
+                    (int(bool(tlcorner and lline)), w_tlcorner),
+                    self.tline_widget,
+                    (int(bool(trcorner and rline)), w_trcorner),
+                )
+            )
 
         else:
             self.tline_widget = None
@@ -97,7 +103,13 @@ class LineBox(WidgetDecoration, WidgetWrap):
         )
 
         if bline:
-            bottom = Columns(((int(bool(blcorner)), w_blcorner), w_bline, (int(bool(brcorner)), w_brcorner)))
+            bottom = Columns(
+                (
+                    (int(bool(blcorner and lline)), w_blcorner),
+                    w_bline,
+                    (int(bool(brcorner and rline)), w_brcorner),
+                )
+            )
         else:
             bottom = None
 

--- a/urwid/widget/line_box.py
+++ b/urwid/widget/line_box.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import typing
 
 from .columns import Columns
-from .constants import Align, Sizing
+from .constants import Align, WHSettings
 from .divider import Divider
 from .pile import Pile
 from .solid_fill import SolidFill
@@ -57,17 +57,11 @@ class LineBox(WidgetDecoration, WidgetWrap):
         adjoining LineBoxes.
         """
 
-        if tline:
-            tline = Divider(tline)
-        if bline:
-            bline = Divider(bline)
-        if lline:
-            lline = SolidFill(lline)
-        if rline:
-            rline = SolidFill(rline)
+        w_lline = SolidFill(lline)
+        w_rline = SolidFill(rline)
 
-        tlcorner, trcorner = Text(tlcorner), Text(trcorner)
-        blcorner, brcorner = Text(blcorner), Text(brcorner)
+        w_tlcorner, w_tline, w_trcorner = Text(tlcorner), Divider(tline), Text(trcorner)
+        w_blcorner, w_bline, w_brcorner = Text(blcorner), Divider(bline), Text(brcorner)
 
         if not tline and title:
             raise ValueError("Cannot have a title when tline is empty string")
@@ -81,34 +75,29 @@ class LineBox(WidgetDecoration, WidgetWrap):
             if title_align not in {Align.LEFT, Align.CENTER, Align.RIGHT}:
                 raise ValueError('title_align must be one of "left", "right", or "center"')
             if title_align == Align.LEFT:
-                tline_widgets = [("flow", self.title_widget), tline]
+                tline_widgets = [(WHSettings.PACK, self.title_widget), w_tline]
             else:
-                tline_widgets = [tline, (Sizing.FLOW, self.title_widget)]
+                tline_widgets = [w_tline, (WHSettings.PACK, self.title_widget)]
                 if title_align == Align.CENTER:
-                    tline_widgets.append(tline)
+                    tline_widgets.append(w_tline)
+
             self.tline_widget = Columns(tline_widgets)
-            top = Columns([(Sizing.FIXED, 1, tlcorner), self.tline_widget, (Sizing.FIXED, 1, trcorner)])
+            top = Columns(((int(bool(tlcorner)), w_tlcorner), self.tline_widget, (int(bool(trcorner)), w_trcorner)))
 
         else:
             self.tline_widget = None
             top = None
 
-        middle_widgets = []
-        if lline:
-            middle_widgets.append(("fixed", 1, lline))
-        else:
-            # Note: We need to define a fixed first widget (even if it's 0 width) so that the other
-            # widgets have something to anchor onto
-            middle_widgets.append(("fixed", 0, SolidFill("")))
-        middle_widgets.append(original_widget)
-        focus_col = len(middle_widgets) - 1
-        if rline:
-            middle_widgets.append((Sizing.FIXED, 1, rline))
-
-        middle = Columns(middle_widgets, box_columns=[0, 2], focus_column=focus_col)
+        # Note: We need to define a fixed first widget (even if it's 0 width) so that the other
+        # widgets have something to anchor onto
+        middle = Columns(
+            ((int(bool(lline)), w_lline), original_widget, (int(bool(rline)), w_rline)),
+            box_columns=[0, 2],
+            focus_column=original_widget,
+        )
 
         if bline:
-            bottom = Columns([(Sizing.FIXED, 1, blcorner), bline, (Sizing.FIXED, 1, brcorner)])
+            bottom = Columns(((int(bool(blcorner)), w_blcorner), w_bline, (int(bool(brcorner)), w_brcorner)))
         else:
             bottom = None
 
@@ -130,29 +119,11 @@ class LineBox(WidgetDecoration, WidgetWrap):
 
         return ""
 
-    def set_title(self, text):
+    def set_title(self, text: str) -> None:
         if not self.title_widget:
             raise ValueError("Cannot set title when tline is unset")
         self.title_widget.set_text(self.format_title(text))
         self.tline_widget._invalidate()
-
-    def pack(
-        self,
-        size: tuple[()] | tuple[int] | tuple[int, int] | None = None,
-        focus: bool = False,
-    ) -> tuple[int, int]:
-        """
-        Return the number of screen columns and rows required for
-        this Linebox widget to be displayed without wrapping or
-        clipping, as a single element tuple.
-
-        :param size: Widget size correct for the supported sizing
-        :type size: tuple[()] | tuple[int] | tuple[int, int]
-        :param focus: widget is focused on
-        :type focus: bool
-        """
-        size = self._original_widget.pack(size, focus)
-        return size[0] + 2, size[1] + 2
 
     @property
     def focus(self) -> Widget | None:

--- a/urwid/widget/overlay.py
+++ b/urwid/widget/overlay.py
@@ -227,7 +227,7 @@ class Overlay(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
 
         return frozenset(sizing)
 
-    def pack(self, size: tuple[()] | tuple[int] | tuple[int, int], focus: bool = False) -> tuple[int, int]:
+    def pack(self, size: tuple[()] | tuple[int] | tuple[int, int] = (), focus: bool = False) -> tuple[int, int]:
         if size:
             return super().pack(size, focus)
 

--- a/urwid/widget/padding.py
+++ b/urwid/widget/padding.py
@@ -265,7 +265,7 @@ class Padding(WidgetDecoration):
         )
         self.width = width
 
-    def pack(self, size: tuple[()] | tuple[int] | tuple[int, int], focus: bool = False) -> tuple[int, int]:
+    def pack(self, size: tuple[()] | tuple[int] | tuple[int, int] = (), focus: bool = False) -> tuple[int, int]:
         if size:
             return super().pack(size, focus)
         if self._width_type == WHSettings.CLIP:

--- a/urwid/widget/pile.py
+++ b/urwid/widget/pile.py
@@ -584,9 +584,10 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
                 if Sizing.FIXED in w_sizing:
                     widths[idx], heights[idx] = widget.pack((), focused)
                     w_h_args[idx] = ()
-                elif Sizing.FLOW in w_sizing:
+                if Sizing.FLOW in w_sizing:
+                    # re-calculate height at the end
                     flow.append((widget, idx, focused))
-                else:
+                if not w_sizing & {Sizing.FIXED, Sizing.FLOW}:
                     raise PileError(f"Unsupported sizing {w_sizing} for {size_kind.upper()}")
 
             elif size_kind == WHSettings.GIVEN:
@@ -708,7 +709,7 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
 
         return (tuple(widths), tuple(heights), tuple(w_h_args))
 
-    def pack(self, size: tuple[()] | tuple[int] | tuple[int, int], focus: bool = False) -> tuple[int, int]:
+    def pack(self, size: tuple[()] | tuple[int] | tuple[int, int] = (), focus: bool = False) -> tuple[int, int]:
         """Get packed sized for widget."""
         if size:
             return super().pack(size, focus)


### PR DESCRIPTION
* BUG: `LineBox().pack` was ignored nonexistent top/bottom. Switch to the backend (Pile) `pack` usage to get proper size
* Semi-bug: in case of no side, empty elements was partially added (top and bottom) with fixed size == 1  (Bug #393 )
* BUG: `set_title` without title was not properly checked for top widget availability and caused exception
* For consistency add right corner with width=0 if no right corner
* Propagate default empty size for `pack` if widgets are optionally FIXED No size will be handled internally

Fix #337

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [X] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

