### PR TITLE
Update source package manifest to include `_web.js` and `_web.css`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 recursive-include examples *.py *.tac
 recursive-include docs *.rst *.py *.py.xdotool *.png *.html *.sh Makefile
 include COPYING CHANGELOG README.rst
+include urwid/display/_web.js urwid/display/_web.css


### PR DESCRIPTION
##### Description:
As described in [this comment](https://github.com/urwid/urwid/issues/728#issuecomment-1895576376) related to packaging for debian, we may need to update the `MANIFEST.in` to include `urwid/display/_web.js` and `urwid/dispaly/_web.css`. If this is not done any source package, to the best of my understanding, will be missing them and producing a package that fails to upload `urwid.display.web` as is the case right now in Ubuntu24.04 and Debian.

Source package content in Ubuntu Noble: [file list (link) ](https://packages.ubuntu.com/noble/amd64/python3-urwid/filelist)

> Note: I tried but failed to verify this on debian, I will need someone more experienced than me to double check. In [this Launchpad discussion ](https://answers.launchpad.net/ubuntu/+source/urwid/+question/709006)the package is described as copied over from debian, so they should be the same

See: 
```
root@noble:~# apt install python3-setuptools python3-urwid
[...]
Unpacking python3-urwid (2.4.1-0.2) ...
Setting up python3-urwid (2.4.1-0.2) ...
[...]
root@noble:~# python3
Python 3.11.7 (main, Dec  8 2023, 14:22:46) [GCC 13.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import urwid.display.web
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3/dist-packages/urwid/display/web.py", line 52, in <module>
    _js_code = CURRENT_DIR.joinpath("_web.js").read_text("utf-8")
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/pathlib.py", line 1059, in read_text
    with self.open(mode='r', encoding=encoding, errors=errors) as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/pathlib.py", line 1045, in open
    return io.open(self, mode, buffering, encoding, errors, newline)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/usr/lib/python3/dist-packages/urwid/display/_web.js'
```

