### PR TITLE
Fix regression: Columns render incorrect BOX/FLOW widgets height

### DIFF
--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -708,3 +708,39 @@ class ColumnsTest(unittest.TestCase):
             self.assertEqual(c.column_types, [("flow", None), ("weight", 1), ("weight", 1)])
             c.column_types[:] = [("weight", 2)]
             self.assertEqual(len(c.contents), 1)
+
+    def test_regression_columns_different_height(self):
+        size = (20, 5)
+        box_w = urwid.SolidFill("#")
+        f_f_widget = urwid.Text("Fixed/Flow")
+        box_flow = urwid.LineBox(urwid.Filler(f_f_widget, valign=urwid.TOP))
+        self.assertIn(urwid.BOX, box_w.sizing())
+        self.assertEqual(frozenset((urwid.BOX, urwid.FLOW)), box_flow.sizing())
+
+        with self.subTest("BoxFlow weight"):
+            widget = urwid.Columns(((1, box_w), box_flow))
+
+            self.assertEqual(
+                (
+                    "#┌─────────────────┐",
+                    "#│Fixed/Flow       │",
+                    "#│                 │",
+                    "#│                 │",
+                    "#└─────────────────┘",
+                ),
+                widget.render(size, False).decoded_text,
+            )
+
+        with self.subTest("BoxFlow GIVEN"):
+            widget = urwid.Columns((box_w, (12, box_flow)))
+
+            self.assertEqual(
+                (
+                    "########┌──────────┐",
+                    "########│Fixed/Flow│",
+                    "########│          │",
+                    "########│          │",
+                    "########└──────────┘",
+                ),
+                widget.render(size, False).decoded_text,
+            )

--- a/urwid/canvas.py
+++ b/urwid/canvas.py
@@ -268,10 +268,15 @@ class Canvas:
     @property
     def text(self) -> list[bytes]:
         """
-        Return the text content of the canvas as a list of strings,
-        one for each row.
+        Return the text content of the canvas as a list of strings, one for each row.
         """
         return [b"".join([text for (attr, cs, text) in row]) for row in self.content()]
+
+    @property
+    def decoded_text(self) -> Sequence[str]:
+        """Decoded text content of the canvas as a sequence of strings, one for each row."""
+        encoding = get_encoding()
+        return tuple(line.decode(encoding) for line in self.text)
 
     def _text_content(self):
         warnings.warn(
@@ -371,7 +376,7 @@ class Canvas:
 
     def __str__(self) -> str:
         with contextlib.suppress(BaseException):
-            return b"\n".join(self.text).decode(get_encoding())
+            return "\n".join(self.decoded_text)
 
         return repr(self)
 

--- a/urwid/widget/columns.py
+++ b/urwid/widget/columns.py
@@ -821,22 +821,9 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         for i, (width, (widget, (size_kind, _size_weight, is_box))) in enumerate(zip(widths, self.contents)):
             w_sizing = widget.sizing()
 
-            if size_kind == WHSettings.GIVEN:
-                if is_box:
-                    box.append(i)
-                elif Sizing.FLOW in w_sizing and not is_box:
-                    heights[i] = widget.rows((width,), focus and i == self.focus_position)
-                    w_h_args[i] = (width,)
-                else:
-                    box_need_height.append(i)
-
-            elif size_kind == WHSettings.PACK:
-                if Sizing.FLOW in w_sizing:
-                    heights[i] = widget.rows((width,), focus and i == self.focus_position)
-                    w_h_args[i] = (width,)
-                else:
-                    heights[i] = widget.pack((), focus and i == self.focus_position)[1]
-                    w_h_args[i] = ()
+            if len(size) == 2 and Sizing.BOX in w_sizing:
+                heights[i] = size[1]
+                w_h_args[i] = (width, size[1])
 
             elif is_box:
                 box.append(i)
@@ -844,6 +831,10 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
             elif Sizing.FLOW in w_sizing:
                 heights[i] = widget.rows((width,), focus and i == self.focus_position)
                 w_h_args[i] = (width,)
+
+            elif size_kind == WHSettings.PACK:
+                heights[i] = widget.pack((), focus and i == self.focus_position)[1]
+                w_h_args[i] = ()
 
             else:
                 box_need_height.append(i)


### PR DESCRIPTION
* Fix and re-sort calculation
* Add tests to cover regression
* Add helper property `decoded_text` to `the` Canvas to stop a copy-paste decoded lines collection for tests

Fix: #753

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [X] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
