### PR TITLE
Documentation: get rid of deprecated code, typing

### DIFF
--- a/examples/calc.py
+++ b/examples/calc.py
@@ -573,7 +573,6 @@ class CalcDisplay:
 
     def __init__(self):
         self.columns = urwid.Columns([HelpColumn(), CellColumn("A")], 1)
-        self.col_list = self.columns.widget_list
         self.columns.focus_position = 1
         view = urwid.AttrMap(self.columns, "body")
         self.view = urwid.Frame(view)  # for showing messages
@@ -666,7 +665,7 @@ class CalcDisplay:
             if child is None:
                 # something invalid in focus
                 return key
-            self.col_list.append(child)
+            self.columns.contents.append((child, (urwid.WEIGHT, 1, False)))
             self.set_link(parent, col, child)
             self.columns.focus_position = len(self.columns) - 1
             return None
@@ -682,7 +681,7 @@ class CalcDisplay:
                 # column has no parent
                 raise CalcEvent(E_no_parent_column)
 
-            new_i = self.col_list.index(pcol)
+            new_i = next(iter(idx for idx, (w, _) in enumerate(self.columns.contents) if w == pcol))
             self.columns.focus_position = new_i
             return None
 
@@ -720,7 +719,7 @@ class CalcDisplay:
         f = self.columns.focus_position
         if f == i:
             # move focus to the parent column
-            f = self.col_list.index(pcol)
+            f = next(iter(idx for idx, (w, _) in enumerate(self.columns.contents) if w == pcol))
             self.columns.focus_position = f
 
         parent.remove_child()
@@ -730,7 +729,7 @@ class CalcDisplay:
         # delete children of this column
         keep_right_cols = []
         remove_cols = [col]
-        for rcol in self.col_list[i:]:
+        for rcol, _ in self.columns.contents[i:]:
             parent, pcol = self.get_parent(rcol)
             if pcol in remove_cols:
                 remove_cols.append(rcol)
@@ -740,7 +739,7 @@ class CalcDisplay:
             # remove the links
             del self.col_link[rc]
         # keep only the non-children
-        self.col_list[i:] = keep_right_cols
+        self.columns.contents[i:] = [(w, (urwid.WEIGHT, 1, False)) for w in keep_right_cols]
 
         # fix the letter assignments
         for j in range(i, len(self.columns)):

--- a/urwid/monitored_list.py
+++ b/urwid/monitored_list.py
@@ -78,7 +78,7 @@ class MonitoredList(list):
         """
         self._modified = callback  # monkeypatch
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.__class__.__name__}({list(self)!r})"
 
     # noinspection PyMethodParameters
@@ -347,7 +347,7 @@ class MonitoredFocusList(MonitoredList, typing.Generic[_T]):
     def __setitem__(self, i: int | slice, y: _T | Collection[_T]) -> None:
         """
         >>> def modified(indices, new_items):
-        ...     print("range%r <- %r" % (indices, new_items))
+        ...     print(f"range{indices!r} <- {new_items!r}" )
         >>> ml = MonitoredFocusList([0,1,2,3], focus=2)
         >>> ml.set_validate_contents_modified(modified)
         >>> ml[0] = 9
@@ -383,7 +383,7 @@ class MonitoredFocusList(MonitoredList, typing.Generic[_T]):
     def __imul__(self, n: int):
         """
         >>> def modified(indices, new_items):
-        ...     print("range%r <- %r" % (indices, list(new_items)))
+        ...     print(f"range{indices!r} <- {list(new_items)!r}" )
         >>> ml = MonitoredFocusList([0,1,2], focus=2)
         >>> ml.set_validate_contents_modified(modified)
         >>> ml *= 3
@@ -406,7 +406,7 @@ class MonitoredFocusList(MonitoredList, typing.Generic[_T]):
     def append(self, item: _T) -> None:
         """
         >>> def modified(indices, new_items):
-        ...     print("range%r <- %r" % (indices, new_items))
+        ...     print(f"range{indices!r} <- {new_items!r}" )
         >>> ml = MonitoredFocusList([0,1,2], focus=2)
         >>> ml.set_validate_contents_modified(modified)
         >>> ml.append(6)
@@ -419,7 +419,7 @@ class MonitoredFocusList(MonitoredList, typing.Generic[_T]):
     def extend(self, items: Collection[_T]) -> None:
         """
         >>> def modified(indices, new_items):
-        ...     print("range%r <- %r" % (indices, list(new_items)))
+        ...     print(f"range{indices!r} <- {list(new_items)!r}" )
         >>> ml = MonitoredFocusList([0,1,2], focus=2)
         >>> ml.set_validate_contents_modified(modified)
         >>> ml.extend((6,7,8))
@@ -479,7 +479,7 @@ class MonitoredFocusList(MonitoredList, typing.Generic[_T]):
         super().remove(value)
         self.focus = focus
 
-    def reverse(self):
+    def reverse(self) -> None:
         """
         >>> ml = MonitoredFocusList([0,1,2,3,4], focus=1)
         >>> ml.reverse(); ml
@@ -489,7 +489,7 @@ class MonitoredFocusList(MonitoredList, typing.Generic[_T]):
         self.focus = max(0, len(self) - self._focus - 1)
         return rval
 
-    def sort(self, **kwargs):
+    def sort(self, **kwargs) -> None:
         """
         >>> ml = MonitoredFocusList([-2,0,1,-3,2,-1,3], focus=4)
         >>> ml.sort(); ml

--- a/urwid/treetools.py
+++ b/urwid/treetools.py
@@ -52,7 +52,7 @@ class TreeWidget(urwid.WidgetWrap):
         widget = self.get_indented_widget()
         super().__init__(widget)
 
-    def selectable(self):
+    def selectable(self) -> bool:
         """
         Allow selection of non-leaf nodes so children may be (un)expanded
         """

--- a/urwid/widget/attr_wrap.py
+++ b/urwid/widget/attr_wrap.py
@@ -6,6 +6,7 @@ import warnings
 from .attr_map import AttrMap
 
 if typing.TYPE_CHECKING:
+    from .constants import Sizing
     from .widget import Widget
 
 
@@ -135,5 +136,5 @@ class AttrWrap(AttrMap):
         """
         return getattr(self._original_widget, name)
 
-    def sizing(self):
+    def sizing(self) -> frozenset[Sizing]:
         return self._original_widget.sizing()

--- a/urwid/widget/box_adapter.py
+++ b/urwid/widget/box_adapter.py
@@ -64,8 +64,8 @@ class BoxAdapter(WidgetDecoration):
         )
         self.original_widget = widget
 
-    def sizing(self):
-        return {Sizing.FLOW}
+    def sizing(self) -> frozenset[Sizing]:
+        return frozenset((Sizing.FLOW,))
 
     def rows(self, size: tuple[int], focus: bool = False) -> int:
         """
@@ -109,7 +109,7 @@ class BoxAdapter(WidgetDecoration):
         col: int,
         row: int,
         focus: bool,
-    ) -> bool:
+    ) -> bool | None:
         (maxcol,) = size
         if not hasattr(self._original_widget, "mouse_event"):
             return False

--- a/urwid/widget/columns.py
+++ b/urwid/widget/columns.py
@@ -13,7 +13,7 @@ from .container import WidgetContainerListContentsMixin, WidgetContainerMixin, _
 from .widget import Widget, WidgetError, WidgetWarning
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Iterable, MutableSequence, Sequence
+    from collections.abc import Iterable, Sequence
 
     from typing_extensions import Literal
 
@@ -235,7 +235,11 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         """
         self._selectable = False
         super().__init__()
-        self._contents = MonitoredFocusList()
+        self._contents: MonitoredFocusList[
+            Widget,
+            tuple[Literal[WHSettings.PACK], None, bool]
+            | tuple[Literal[WHSettings.GIVEN, WHSettings.WEIGHT], int, bool],
+        ] = MonitoredFocusList()
         self._contents.set_modified_callback(self._contents_modified)
         self._contents.set_focus_changed_callback(lambda f: self._invalidate())
         self._contents.set_validate_contents_modified(self._validate_contents_modified)
@@ -421,7 +425,7 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
     @property
     def contents(
         self,
-    ) -> MutableSequence[
+    ) -> MonitoredFocusList[
         Widget,
         tuple[Literal[WHSettings.PACK], None, bool] | tuple[Literal[WHSettings.GIVEN, WHSettings.WEIGHT], int, bool],
     ]:
@@ -435,7 +439,14 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         return self._contents
 
     @contents.setter
-    def contents(self, c):
+    def contents(
+        self,
+        c: Sequence[
+            Widget,
+            tuple[Literal[WHSettings.PACK], None, bool]
+            | tuple[Literal[WHSettings.GIVEN, WHSettings.WEIGHT], int, bool],
+        ],
+    ) -> None:
         self._contents[:] = c
 
     @staticmethod

--- a/urwid/widget/edit.py
+++ b/urwid/widget/edit.py
@@ -550,7 +550,7 @@ class Edit(Text):
         self._invalidate()
         return True
 
-    def mouse_event(self, size: tuple[int], event, button: int, x: int, y: int, focus: bool) -> bool:
+    def mouse_event(self, size: tuple[int], event, button: int, x: int, y: int, focus: bool) -> bool | None:
         """
         Move the cursor to the location clicked for button 1.
 

--- a/urwid/widget/filler.py
+++ b/urwid/widget/filler.py
@@ -36,10 +36,9 @@ class Filler(WidgetDecoration):
         valign: (
             Literal["top", "middle", "bottom"] | VAlign | tuple[Literal["relative", WHSettings.RELATIVE], int]
         ) = VAlign.MIDDLE,
-        height: int
-        | Literal["pack", WHSettings.PACK]
-        | tuple[Literal["relative", WHSettings.RELATIVE], int]
-        | None = WHSettings.PACK,
+        height: (
+            int | Literal["pack", WHSettings.PACK] | tuple[Literal["relative", WHSettings.RELATIVE], int] | None
+        ) = WHSettings.PACK,
         min_height: int | None = None,
         top: int = 0,
         bottom: int = 0,
@@ -306,7 +305,7 @@ class Filler(WidgetDecoration):
         col: int,
         row: int,
         focus: bool,
-    ) -> bool:
+    ) -> bool | None:
         """Pass to self.original_widget."""
         maxcol, maxrow = self.pack(size, focus)
         if not hasattr(self._original_widget, "mouse_event"):

--- a/urwid/widget/grid_flow.py
+++ b/urwid/widget/grid_flow.py
@@ -30,7 +30,7 @@ class GridFlow(WidgetWrap, WidgetContainerMixin, WidgetContainerListContentsMixi
     bottom.
     """
 
-    def sizing(self):
+    def sizing(self) -> frozenset[Sizing]:
         return frozenset((Sizing.FLOW, Sizing.FIXED))
 
     def __init__(
@@ -41,7 +41,7 @@ class GridFlow(WidgetWrap, WidgetContainerMixin, WidgetContainerListContentsMixi
         v_sep: int,
         align: Literal["left", "center", "right"] | Align | tuple[Literal["relative", WHSettings.RELATIVE], int],
         focus: int | Widget | None = None,
-    ):
+    ) -> None:
         """
         :param cells: iterable of flow widgets to display
         :param cell_width: column width for each cell
@@ -63,7 +63,9 @@ class GridFlow(WidgetWrap, WidgetContainerMixin, WidgetContainerListContentsMixi
         if focus_position < 0:
             focus_position = 0
 
-        self._contents = MonitoredFocusList(prepared_contents, focus=focus_position)
+        self._contents: MonitoredFocusList[tuple[Widget, tuple[Literal[WHSettings.GIVEN], int]]] = MonitoredFocusList(
+            prepared_contents, focus=focus_position
+        )
         self._contents.set_modified_callback(self._invalidate)
         self._contents.set_focus_changed_callback(lambda f: self._invalidate())
         self._contents.set_validate_contents_modified(self._contents_modified)
@@ -82,7 +84,7 @@ class GridFlow(WidgetWrap, WidgetContainerMixin, WidgetContainerListContentsMixi
 
     def _contents_modified(
         self, slc, new_items: Iterable[tuple[Widget, tuple[Literal["given", WHSettings.GIVEN], int]]]
-    ):
+    ) -> None:
         for item in new_items:
             try:
                 _w, (t, _n) = item
@@ -179,7 +181,7 @@ class GridFlow(WidgetWrap, WidgetContainerMixin, WidgetContainerListContentsMixi
         self.cell_width = width
 
     @property
-    def contents(self):
+    def contents(self) -> MonitoredFocusList[tuple[Widget, tuple[Literal[WHSettings.GIVEN], int]]]:
         """
         The contents of this GridFlow as a list of (widget, options)
         tuples.

--- a/urwid/widget/overlay.py
+++ b/urwid/widget/overlay.py
@@ -388,7 +388,7 @@ class Overlay(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         right: int = 0,
         top: int = 0,
         bottom: int = 0,
-    ):
+    ) -> None:
         """
         Adjust the overlay size and position parameters.
 

--- a/urwid/widget/padding.py
+++ b/urwid/widget/padding.py
@@ -476,7 +476,7 @@ class Padding(WidgetDecoration):
         x: int,
         y: int,
         focus: bool,
-    ):
+    ) -> bool | None:
         """Send mouse event if position is within self._original_widget."""
         if not hasattr(self._original_widget, "mouse_event"):
             return False

--- a/urwid/widget/pile.py
+++ b/urwid/widget/pile.py
@@ -13,7 +13,7 @@ from .container import WidgetContainerListContentsMixin, WidgetContainerMixin, _
 from .widget import Widget, WidgetError, WidgetWarning
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Iterable, MutableSequence, Sequence
+    from collections.abc import Iterable, Sequence
 
     from typing_extensions import Literal
 
@@ -189,7 +189,10 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         """
         self._selectable = False
         super().__init__()
-        self._contents = MonitoredFocusList()
+        self._contents: MonitoredFocusList[
+            Widget,
+            tuple[Literal[WHSettings.PACK], None] | tuple[Literal[WHSettings.GIVEN, WHSettings.WEIGHT], int],
+        ] = MonitoredFocusList()
         self._contents.set_modified_callback(self._contents_modified)
         self._contents.set_focus_changed_callback(lambda f: self._invalidate())
         self._contents.set_validate_contents_modified(self._validate_contents_modified)
@@ -312,7 +315,7 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
     @property
     def contents(
         self,
-    ) -> MutableSequence[
+    ) -> MonitoredFocusList[
         Widget,
         tuple[Literal[WHSettings.PACK], None] | tuple[Literal[WHSettings.GIVEN, WHSettings.WEIGHT], int],
     ]:
@@ -345,14 +348,23 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         return self._contents
 
     @contents.setter
-    def contents(self, c):
+    def contents(
+        self,
+        c: Sequence[
+            Widget,
+            tuple[Literal[WHSettings.PACK], None] | tuple[Literal[WHSettings.GIVEN, WHSettings.WEIGHT], int],
+        ],
+    ) -> None:
         self._contents[:] = c
 
     @staticmethod
     def options(
-        height_type: Literal["pack", "given", "weight"] = WHSettings.WEIGHT,
+        height_type: Literal["pack", "given", "weight"] | WHSettings = WHSettings.WEIGHT,
         height_amount: int | None = 1,
-    ) -> tuple[Literal["pack"], None] | tuple[Literal["given", "weight"], int]:
+    ) -> (
+        tuple[Literal[WHSettings.PACK], None]
+        | tuple[Literal["given", "weight", WHSettings.GIVEN, WHSettings.WEIGHT], int]
+    ):
         """
         Return a new options tuple for use in a Pile's :attr:`contents` list.
 

--- a/urwid/widget/widget.py
+++ b/urwid/widget/widget.py
@@ -420,14 +420,14 @@ class Widget(metaclass=WidgetMeta):
         """
         CanvasCache.invalidate(self)
 
-    def _emit(self, name: Hashable, *args):
+    def _emit(self, name: Hashable, *args) -> None:
         """
         Convenience function to emit signals with self as first
         argument.
         """
         signals.emit_signal(self, name, self, *args)
 
-    def selectable(self):
+    def selectable(self) -> bool:
         """
         :returns: ``True`` if this is a widget that is designed to take the
                   focus, i.e. it contains something the user might want to

--- a/urwid/widget/widget_decoration.py
+++ b/urwid/widget/widget_decoration.py
@@ -10,6 +10,8 @@ from .widget import Widget, WidgetError, WidgetWarning, delegate_to_widget_mixin
 if typing.TYPE_CHECKING:
     from typing_extensions import Literal
 
+    from .constants import Sizing
+
 
 __all__ = ("WidgetDecoration", "WidgetPlaceholder", "WidgetDisable", "WidgetError", "WidgetWarning")
 
@@ -109,7 +111,7 @@ class WidgetDecoration(Widget):  # "decorator" was already taken
     def selectable(self) -> bool:
         return self._original_widget.selectable()
 
-    def sizing(self):
+    def sizing(self) -> frozenset[Sizing]:
         return self._original_widget.sizing()
 
 
@@ -144,7 +146,7 @@ class WidgetDisable(WidgetDecoration):
     def rows(self, size, focus: bool = False) -> int:
         return self._original_widget.rows(size, False)
 
-    def sizing(self):
+    def sizing(self) -> frozenset[Sizing]:
         return self._original_widget.sizing()
 
     def pack(self, size, focus: bool = False) -> tuple[int, int]:


### PR DESCRIPTION
* Fix examples/calc - stop using deprecated code
* Mass update typing annotations

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

