### PR TITLE
Deduplicate code in `frame` module

### DIFF
--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -7,22 +7,21 @@ import urwid
 
 
 class FrameTest(unittest.TestCase):
-    def ftbtest(self, desc, focus_part, header_rows, footer_rows, size,
-            focus, top, bottom):
+    def ftbtest(self, desc, focus_part, header_rows, footer_rows, size, focus, top, bottom):
         class FakeWidget:
             def __init__(self, rows, want_focus):
                 self.ret_rows = rows
                 self.want_focus = want_focus
+
             def rows(self, size, focus=False):
                 assert self.want_focus == focus
                 return self.ret_rows
+
         header = footer = None
         if header_rows:
-            header = FakeWidget(header_rows,
-                focus and focus_part == 'header')
+            header = FakeWidget(header_rows, focus and focus_part == "header")
         if footer_rows:
-            footer = FakeWidget(footer_rows,
-                focus and focus_part == 'footer')
+            footer = FakeWidget(footer_rows, focus and focus_part == "footer")
 
         f = urwid.Frame(None, header, footer, focus_part)
 
@@ -31,45 +30,31 @@ class FrameTest(unittest.TestCase):
         assert exp == rval, f"{desc} expected {exp!r} but got {rval!r}"
 
     def test(self):
-        self.ftbtest("simple", 'body', 0, 0, (9, 10), True, 0, 0)
-        self.ftbtest("simple h", 'body', 3, 0, (9, 10), True, 3, 0)
-        self.ftbtest("simple f", 'body', 0, 3, (9, 10), True, 0, 3)
-        self.ftbtest("simple hf", 'body', 3, 3, (9, 10), True, 3, 3)
-        self.ftbtest("almost full hf", 'body', 4, 5, (9, 10),
-            True, 4, 5)
-        self.ftbtest("full hf", 'body', 5, 5, (9, 10),
-            True, 4, 5)
-        self.ftbtest("x full h+1f", 'body', 6, 5, (9, 10),
-            False, 4, 5)
-        self.ftbtest("full h+1f", 'body', 6, 5, (9, 10),
-            True, 4, 5)
-        self.ftbtest("full hf+1", 'body', 5, 6, (9, 10),
-            True, 3, 6)
-        self.ftbtest("F full h+1f", 'footer', 6, 5, (9, 10),
-            True, 5, 5)
-        self.ftbtest("F full hf+1", 'footer', 5, 6, (9, 10),
-            True, 4, 6)
-        self.ftbtest("F full hf+5", 'footer', 5, 11, (9, 10),
-            True, 0, 10)
-        self.ftbtest("full hf+5", 'body', 5, 11, (9, 10),
-            True, 0, 9)
-        self.ftbtest("H full hf+1", 'header', 5, 6, (9, 10),
-            True, 5, 5)
-        self.ftbtest("H full h+1f", 'header', 6, 5, (9, 10),
-            True, 6, 4)
-        self.ftbtest("H full h+5f", 'header', 11, 5, (9, 10),
-            True, 10, 0)
-
-
+        self.ftbtest("simple", "body", 0, 0, (9, 10), True, 0, 0)
+        self.ftbtest("simple h", "body", 3, 0, (9, 10), True, 3, 0)
+        self.ftbtest("simple f", "body", 0, 3, (9, 10), True, 0, 3)
+        self.ftbtest("simple hf", "body", 3, 3, (9, 10), True, 3, 3)
+        self.ftbtest("almost full hf", "body", 4, 5, (9, 10), True, 4, 5)
+        self.ftbtest("full hf", "body", 5, 5, (9, 10), True, 4, 5)
+        self.ftbtest("x full h+1f", "body", 6, 5, (9, 10), False, 4, 5)
+        self.ftbtest("full h+1f", "body", 6, 5, (9, 10), True, 4, 5)
+        self.ftbtest("full hf+1", "body", 5, 6, (9, 10), True, 3, 6)
+        self.ftbtest("F full h+1f", "footer", 6, 5, (9, 10), True, 5, 5)
+        self.ftbtest("F full hf+1", "footer", 5, 6, (9, 10), True, 4, 6)
+        self.ftbtest("F full hf+5", "footer", 5, 11, (9, 10), True, 0, 10)
+        self.ftbtest("full hf+5", "body", 5, 11, (9, 10), True, 0, 9)
+        self.ftbtest("H full hf+1", "header", 5, 6, (9, 10), True, 5, 5)
+        self.ftbtest("H full h+1f", "header", 6, 5, (9, 10), True, 6, 4)
+        self.ftbtest("H full h+5f", "header", 11, 5, (9, 10), True, 10, 0)
 
 
 class WidgetSquishTest(unittest.TestCase):
     def wstest(self, w):
-        c = w.render((80,0), focus=False)
+        c = w.render((80, 0), focus=False)
         assert c.rows() == 0
-        c = w.render((80,0), focus=True)
+        c = w.render((80, 0), focus=True)
         assert c.rows() == 0
-        c = w.render((80,1), focus=False)
+        c = w.render((80, 1), focus=False)
         assert c.rows() == 1
         c = w.render((0, 25), focus=False)
         c = w.render((1, 25), focus=False)
@@ -79,7 +64,7 @@ class WidgetSquishTest(unittest.TestCase):
             wrows = w.rows((cols,), focus)
             c = w.render((cols,), focus)
             self.assertEqual(c.rows(), wrows, f"Canvas rows {c.rows()} != widget rows {wrows}")
-            if focus and hasattr(w, 'get_cursor_coords'):
+            if focus and hasattr(w, "get_cursor_coords"):
                 gcc = w.get_cursor_coords((cols,))
                 self.assertEqual(c.cursor, gcc, f"Canvas cursor {c.cursor} != widget cursor {gcc}")
 
@@ -92,11 +77,11 @@ class WidgetSquishTest(unittest.TestCase):
         self.wstest(urwid.ListBox(urwid.SimpleListWalker([urwid.Text("hello")])))
 
     def test_bargraph(self):
-        self.wstest(urwid.BarGraph(['foo','bar']))
+        self.wstest(urwid.BarGraph(["foo", "bar"]))
 
     def test_graphvscale(self):
-        self.wstest(urwid.GraphVScale([(0,"hello")], 1))
-        self.wstest(urwid.GraphVScale([(5,"hello")], 1))
+        self.wstest(urwid.GraphVScale([(0, "hello")], 1))
+        self.wstest(urwid.GraphVScale([(5, "hello")], 1))
 
     def test_solidfill(self):
         self.wstest(urwid.SolidFill())
@@ -105,25 +90,21 @@ class WidgetSquishTest(unittest.TestCase):
         self.wstest(urwid.Filler(urwid.Text("hello")))
 
     def test_overlay(self):
-        self.wstest(urwid.Overlay(
-            urwid.BigText("hello",urwid.Thin6x6Font()),
-            urwid.SolidFill(),
-            'center', None, 'middle', None))
-        self.wstest(urwid.Overlay(
-            urwid.Text("hello"), urwid.SolidFill(),
-            'center',  ('relative', 100), 'middle', None))
+        self.wstest(
+            urwid.Overlay(
+                urwid.BigText("hello", urwid.Thin6x6Font()), urwid.SolidFill(), "center", None, "middle", None
+            )
+        )
+        self.wstest(urwid.Overlay(urwid.Text("hello"), urwid.SolidFill(), "center", ("relative", 100), "middle", None))
 
     def test_frame(self):
         self.wstest(urwid.Frame(urwid.SolidFill()))
-        self.wstest(urwid.Frame(urwid.SolidFill(),
-            header=urwid.Text("hello")))
-        self.wstest(urwid.Frame(urwid.SolidFill(),
-            header=urwid.Text("hello"),
-            footer=urwid.Text("hello")))
+        self.wstest(urwid.Frame(urwid.SolidFill(), header=urwid.Text("hello")))
+        self.wstest(urwid.Frame(urwid.SolidFill(), header=urwid.Text("hello"), footer=urwid.Text("hello")))
 
     def test_pile(self):
         self.wstest(urwid.Pile([urwid.SolidFill()]))
-        self.wstest(urwid.Pile([('flow', urwid.Text("hello"))]))
+        self.wstest(urwid.Pile([("flow", urwid.Text("hello"))]))
         self.wstest(urwid.Pile([]))
 
     def test_columns(self):
@@ -145,13 +126,12 @@ class CommonContainerTest(unittest.TestCase):
     def test_list_box(self):
         lb = urwid.ListBox(urwid.SimpleFocusListWalker([]))
         self.assertEqual(lb.focus, None)
-        self.assertRaises(IndexError, lambda: getattr(lb, 'focus_position'))
-        self.assertRaises(IndexError, lambda: setattr(lb, 'focus_position',
-            None))
-        self.assertRaises(IndexError, lambda: setattr(lb, 'focus_position', 0))
+        self.assertRaises(IndexError, lambda: getattr(lb, "focus_position"))
+        self.assertRaises(IndexError, lambda: setattr(lb, "focus_position", None))
+        self.assertRaises(IndexError, lambda: setattr(lb, "focus_position", 0))
 
-        t1 = urwid.Text('one')
-        t2 = urwid.Text('two')
+        t1 = urwid.Text("one")
+        t2 = urwid.Text("two")
         lb = urwid.ListBox(urwid.SimpleListWalker([t1, t2]))
         self.assertEqual(lb.focus, t1)
         self.assertEqual(lb.focus_position, 0)
@@ -159,65 +139,67 @@ class CommonContainerTest(unittest.TestCase):
         self.assertEqual(lb.focus, t2)
         self.assertEqual(lb.focus_position, 1)
         lb.focus_position = 0
-        self.assertRaises(IndexError, lambda: setattr(lb, 'focus_position', -1))
-        self.assertRaises(IndexError, lambda: setattr(lb, 'focus_position', 2))
+        self.assertRaises(IndexError, lambda: setattr(lb, "focus_position", -1))
+        self.assertRaises(IndexError, lambda: setattr(lb, "focus_position", 2))
 
     def test_frame(self):
-        s1 = urwid.SolidFill('1')
+        s1 = urwid.SolidFill("1")
 
         f = urwid.Frame(s1)
         self.assertEqual(f.focus, s1)
-        self.assertEqual(f.focus_position, 'body')
-        self.assertRaises(IndexError, lambda: setattr(f, 'focus_position',
-            None))
-        self.assertRaises(IndexError, lambda: setattr(f, 'focus_position',
-            'header'))
+        self.assertEqual(f.focus_position, "body")
+        self.assertRaises(IndexError, lambda: setattr(f, "focus_position", None))
+        self.assertRaises(IndexError, lambda: setattr(f, "focus_position", "header"))
 
-        t1 = urwid.Text('one')
-        t2 = urwid.Text('two')
-        t3 = urwid.Text('three')
-        f = urwid.Frame(s1, t1, t2, 'header')
+        t1 = urwid.Text("one")
+        t2 = urwid.Text("two")
+        t3 = urwid.Text("three")
+        f = urwid.Frame(s1, t1, t2, "header")
         self.assertEqual(f.focus, t1)
-        self.assertEqual(f.focus_position, 'header')
-        f.focus_position = 'footer'
+        self.assertEqual(f.focus_position, "header")
+        f.focus_position = "footer"
         self.assertEqual(f.focus, t2)
-        self.assertEqual(f.focus_position, 'footer')
-        self.assertRaises(IndexError, lambda: setattr(f, 'focus_position', -1))
-        self.assertRaises(IndexError, lambda: setattr(f, 'focus_position', 2))
-        del f.contents['footer']
+        self.assertEqual(f.focus_position, "footer")
+        self.assertRaises(IndexError, lambda: setattr(f, "focus_position", -1))
+        self.assertRaises(IndexError, lambda: setattr(f, "focus_position", 2))
+        del f.contents["footer"]
         self.assertEqual(f.footer, None)
-        self.assertEqual(f.focus_position, 'body')
+        self.assertEqual(f.focus_position, "body")
         f.contents.update(footer=(t3, None), header=(t2, None))
         self.assertEqual(f.header, t2)
         self.assertEqual(f.footer, t3)
+
         def set1():
-            f.contents['body'] = t1
+            f.contents["body"] = t1
+
         self.assertRaises(urwid.FrameError, set1)
+
         def set2():
-            f.contents['body'] = (t1, 'given')
+            f.contents["body"] = (t1, "given")
+
         self.assertRaises(urwid.FrameError, set2)
 
     def test_focus_path(self):
         # big tree of containers
-        t = urwid.Text('x')
-        e = urwid.Edit('?')
+        t = urwid.Text("x")
+        e = urwid.Edit("?")
         c = urwid.Columns([t, e, t, t])
         p = urwid.Pile([t, t, c, t])
-        a = urwid.AttrMap(p, 'gets ignored')
-        s = urwid.SolidFill('/')
-        o = urwid.Overlay(e, s, 'center', 'pack', 'middle', 'pack')
+        a = urwid.AttrMap(p, "gets ignored")
+        s = urwid.SolidFill("/")
+        o = urwid.Overlay(e, s, "center", "pack", "middle", "pack")
         lb = urwid.ListBox(urwid.SimpleFocusListWalker([t, a, o, t]))
         lb.focus_position = 1
-        g = urwid.GridFlow([t, t, t, t, e, t], 10, 0, 0, 'left')
+        g = urwid.GridFlow([t, t, t, t, e, t], 10, 0, 0, "left")
         g.focus_position = 4
         f = urwid.Frame(lb, header=t, footer=g)
 
-        self.assertEqual(f.get_focus_path(), ['body', 1, 2, 1])
-        f.set_focus_path(['footer']) # same as f.focus_position = 'footer'
-        self.assertEqual(f.get_focus_path(), ['footer', 4])
-        f.set_focus_path(['body', 1, 2, 2])
-        self.assertEqual(f.get_focus_path(), ['body', 1, 2, 2])
+        self.assertEqual(f.get_focus_path(), ["body", 1, 2, 1])
+        f.set_focus_path(["footer"])  # same as f.focus_position = 'footer'
+        self.assertEqual(f.get_focus_path(), ["footer", 4])
+        f.set_focus_path(["body", 1, 2, 2])
+        self.assertEqual(f.get_focus_path(), ["body", 1, 2, 2])
         self.assertRaises(IndexError, lambda: f.set_focus_path([0, 1, 2]))
-        self.assertRaises(IndexError, lambda: f.set_focus_path(['body', 2, 2]))
-        f.set_focus_path(['body', 2]) # focus the overlay
-        self.assertEqual(f.get_focus_path(), ['body', 2, 1])
+        self.assertRaises(IndexError, lambda: f.set_focus_path(["body", 2, 2]))
+        f.set_focus_path(["body", 2])  # focus the overlay
+        self.assertEqual(f.get_focus_path(), ["body", 2, 1])

--- a/tests/test_doctests.py
+++ b/tests/test_doctests.py
@@ -44,7 +44,7 @@ def load_tests(loader: unittest.TestLoader, tests: unittest.BaseTestSuite, ignor
         "urwid.split_repr",  # override function with same name
         urwid.util,
         urwid.signals,
-        ]
+    ]
     try:
         module_doctests.append(urwid.display.curses)
     except (AttributeError, NameError):

--- a/tests/test_event_loops.py
+++ b/tests/test_event_loops.py
@@ -283,6 +283,7 @@ class TwistedEventLoopTest(unittest.TestCase, EventLoopTestMixin):
 
     def test_run(self):
         from twisted.internet import threads
+
         evl = self.evl
         out = []
         wr: socket.socket

--- a/tests/test_floatedit.py
+++ b/tests/test_floatedit.py
@@ -7,7 +7,7 @@ from urwid.numedit import FloatEdit
 
 class FloatEditNoPreservePrecicionTest(unittest.TestCase):
     def test(self):
-        for v in ('1.01', '2.5', '300', '4.100', '5.001'):
+        for v in ("1.01", "2.5", "300", "4.100", "5.001"):
             f = FloatEdit(preserveSignificance=False)
             f.set_edit_text(v)
             print(f.value(), Decimal(v))
@@ -27,16 +27,11 @@ class FloatEditNoPreservePrecicionTest(unittest.TestCase):
 
 
 class FloatEditPreservePrecicionTest(unittest.TestCase):
-
     def test(self):
-        for v, sig, sep in product(('1.010', '2.500', '300.000', '4.100', '5.001'), (0, 1, 2, 3), ('.', ',')):
-            precision_template = '0.' + '0'*sig
+        for v, sig, sep in product(("1.010", "2.500", "300.000", "4.100", "5.001"), (0, 1, 2, 3), (".", ",")):
+            precision_template = "0." + "0" * sig
             expected = Decimal(v).quantize(Decimal(precision_template))
             f = FloatEdit(preserveSignificance=True, default=precision_template, decimalSeparator=sep)
 
-            f.set_edit_text(v.replace('.', sep))
-            self.assertEqual(
-                expected,
-                f.value(),
-                f'{f.value()} != {expected} (significance={sig!r})'
-            )
+            f.set_edit_text(v.replace(".", sep))
+            self.assertEqual(expected, f.value(), f"{f.value()} != {expected} (significance={sig!r})")

--- a/tests/test_raw_display.py
+++ b/tests/test_raw_display.py
@@ -10,5 +10,5 @@ class TestRawDisplay(unittest.TestCase):
         s = urwid.display.raw.Screen()
         s.set_terminal_properties(colors=256)
         a2e = s._attrspec_to_escape
-        self.assertEqual('\x1b[0;33;42m', a2e(s.AttrSpec('brown', 'dark green')))
-        self.assertEqual('\x1b[0;38;5;229;4;48;5;164m', a2e(s.AttrSpec('#fea,underline', '#d0d')))
+        self.assertEqual("\x1b[0;33;42m", a2e(s.AttrSpec("brown", "dark green")))
+        self.assertEqual("\x1b[0;38;5;229;4;48;5;164m", a2e(s.AttrSpec("#fea,underline", "#d0d")))

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -6,24 +6,23 @@ from urwid import Edit, Signals, connect_signal, disconnect_signal, emit_signal,
 
 
 class SiglnalsTest(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls):
-        cls.EmClass = type("EmClass", (object, ), {})
+        cls.EmClass = type("EmClass", (object,), {})
         register_signal(cls.EmClass, ["change", "test"])
 
     def test_connect(self):
         obj = Mock()
         handler = Mock()
-        edit = Edit('')
-        key = connect_signal(edit, 'change', handler, user_args=[obj])
+        edit = Edit("")
+        key = connect_signal(edit, "change", handler, user_args=[obj])
         self.assertIsNotNone(key)
-        edit.set_edit_text('long test text')
-        handler.assert_called_once_with(obj, edit, 'long test text')
+        edit.set_edit_text("long test text")
+        handler.assert_called_once_with(obj, edit, "long test text")
 
         handler.reset_mock()
-        disconnect_signal(edit, 'change', handler, user_args=[obj])
-        edit.set_edit_text('another text')
+        disconnect_signal(edit, "change", handler, user_args=[obj])
+        edit.set_edit_text("another text")
         handler.assert_not_called()
 
     @unittest.skipIf(sys.implementation.name == "pypy", "WeakRef works differently on PyPy")
@@ -36,30 +35,30 @@ class SiglnalsTest(unittest.TestCase):
         handler1 = Mock(name="handler1")
         handler2 = Mock(name="handler2")
 
-        k1 = connect_signal(emitter, 'test', handler1, weak_args=[w1], user_args=[42, "abc"])
-        k2 = connect_signal(emitter, 'test', handler2, weak_args=[w2, w3], user_args=[8])
+        k1 = connect_signal(emitter, "test", handler1, weak_args=[w1], user_args=[42, "abc"])
+        k2 = connect_signal(emitter, "test", handler2, weak_args=[w2, w3], user_args=[8])
         self.assertIsNotNone(k2)
 
-        emit_signal(emitter, 'test', "Foo")
-        handler1.assert_called_once_with(w1, 42, "abc",  "Foo")
+        emit_signal(emitter, "test", "Foo")
+        handler1.assert_called_once_with(w1, 42, "abc", "Foo")
         handler2.assert_called_once_with(w2, w3, 8, "Foo")
 
         handler1.reset_mock()
         handler2.reset_mock()
         del w1
         self.assertEqual(
-            len(getattr(emitter, Signals._signal_attr)['test']),
+            len(getattr(emitter, Signals._signal_attr)["test"]),
             1,
-            getattr(emitter, Signals._signal_attr)['test']
+            getattr(emitter, Signals._signal_attr)["test"],
         )
-        emit_signal(emitter, 'test', "Bar")
+        emit_signal(emitter, "test", "Bar")
         handler1.assert_not_called()
         handler2.assert_called_once_with(w2, w3, 8, "Bar")
 
         handler2.reset_mock()
         del w3
-        emit_signal(emitter, 'test', "Baz")
+        emit_signal(emitter, "test", "Baz")
         handler1.assert_not_called()
         handler2.assert_not_called()
-        self.assertEqual(len(getattr(emitter, Signals._signal_attr)['test']), 0)
+        self.assertEqual(len(getattr(emitter, Signals._signal_attr)["test"]), 0)
         del w2

--- a/tests/test_str_util.py
+++ b/tests/test_str_util.py
@@ -7,32 +7,32 @@ from urwid.display.escape import str_util
 
 class DecodeOneTest(unittest.TestCase):
     def gwt(self, ch, exp_ord, exp_pos):
-        ch = ch.encode('iso8859-1')
-        o, pos = str_util.decode_one(ch,0)
-        assert o==exp_ord, f" got:{o!r} expected:{exp_ord!r}"
-        assert pos==exp_pos, f" got:{pos!r} expected:{exp_pos!r}"
+        ch = ch.encode("iso8859-1")
+        o, pos = str_util.decode_one(ch, 0)
+        assert o == exp_ord, f" got:{o!r} expected:{exp_ord!r}"
+        assert pos == exp_pos, f" got:{pos!r} expected:{exp_pos!r}"
 
     def test1byte(self):
         self.gwt("ab", ord("a"), 1)
-        self.gwt("\xc0a", ord("?"), 1) # error
+        self.gwt("\xc0a", ord("?"), 1)  # error
 
     def test2byte(self):
-        self.gwt("\xc2", ord("?"), 1) # error
-        self.gwt("\xc0\x80", ord("?"), 1) # error
+        self.gwt("\xc2", ord("?"), 1)  # error
+        self.gwt("\xc0\x80", ord("?"), 1)  # error
         self.gwt("\xc2\x80", 0x80, 2)
-        self.gwt("\xdf\xbf", 0x7ff, 2)
+        self.gwt("\xdf\xbf", 0x7FF, 2)
 
     def test3byte(self):
-        self.gwt("\xe0", ord("?"), 1) # error
-        self.gwt("\xe0\xa0", ord("?"), 1) # error
-        self.gwt("\xe0\x90\x80", ord("?"), 1) # error
+        self.gwt("\xe0", ord("?"), 1)  # error
+        self.gwt("\xe0\xa0", ord("?"), 1)  # error
+        self.gwt("\xe0\x90\x80", ord("?"), 1)  # error
         self.gwt("\xe0\xa0\x80", 0x800, 3)
-        self.gwt("\xef\xbf\xbf", 0xffff, 3)
+        self.gwt("\xef\xbf\xbf", 0xFFFF, 3)
 
     def test4byte(self):
-        self.gwt("\xf0", ord("?"), 1) # error
-        self.gwt("\xf0\x90", ord("?"), 1) # error
-        self.gwt("\xf0\x90\x80", ord("?"), 1) # error
-        self.gwt("\xf0\x80\x80\x80", ord("?"), 1) # error
+        self.gwt("\xf0", ord("?"), 1)  # error
+        self.gwt("\xf0\x90", ord("?"), 1)  # error
+        self.gwt("\xf0\x90\x80", ord("?"), 1)  # error
+        self.gwt("\xf0\x80\x80\x80", ord("?"), 1)  # error
         self.gwt("\xf0\x90\x80\x80", 0x10000, 4)
-        self.gwt("\xf3\xbf\xbf\xbf", 0xfffff, 4)
+        self.gwt("\xf3\xbf\xbf\xbf", 0xFFFFF, 4)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -15,17 +15,17 @@ class CalcWidthTest(unittest.TestCase):
         urwid.set_encoding(self.old_encoding)
 
     def wtest(self, desc, s, exp):
-        s = s.encode('iso8859-1')
-        result = util.calc_width( s, 0, len(s))
-        assert result==exp, f"{desc} got:{result!r} expected:{exp!r}"
+        s = s.encode("iso8859-1")
+        result = util.calc_width(s, 0, len(s))
+        assert result == exp, f"{desc} got:{result!r} expected:{exp!r}"
 
     def test1(self):
         util.set_encoding("utf-8")
         self.wtest("narrow", "hello", 5)
-        self.wtest("wide char", '\xe6\x9b\xbf', 2)
-        self.wtest("invalid", '\xe6', 1)
-        self.wtest("zero width", '\xcc\x80', 0)
-        self.wtest("mixed", 'hello\xe6\x9b\xbf\xe6\x9b\xbf', 9)
+        self.wtest("wide char", "\xe6\x9b\xbf", 2)
+        self.wtest("invalid", "\xe6", 1)
+        self.wtest("zero width", "\xcc\x80", 0)
+        self.wtest("mixed", "hello\xe6\x9b\xbf\xe6\x9b\xbf", 9)
 
     def test2(self):
         util.set_encoding("euc-jp")
@@ -42,23 +42,21 @@ class ConvertDecSpecialTest(unittest.TestCase):
         urwid.set_encoding(self.old_encoding)
 
     def ctest(self, desc, s, exp, expcs):
-        exp = exp.encode('iso8859-1')
-        util.set_encoding('ascii')
+        exp = exp.encode("iso8859-1")
+        util.set_encoding("ascii")
         c = urwid.Text(s).render((5,))
         result = c._text[0]
-        assert result==exp, f"{desc} got:{result!r} expected:{exp!r}"
+        assert result == exp, f"{desc} got:{result!r} expected:{exp!r}"
         resultcs = c._cs[0]
-        assert resultcs==expcs, f"{desc} got:{resultcs!r} expected:{expcs!r}"
+        assert resultcs == expcs, f"{desc} got:{resultcs!r} expected:{expcs!r}"
 
     def test1(self):
-        self.ctest("no conversion", "hello", "hello", [(None,5)])
-        self.ctest("only special", "£££££", "}}}}}", [("0",5)])
-        self.ctest("mix left", "££abc", "}}abc", [("0",2),(None,3)])
-        self.ctest("mix right", "abc££", "abc}}", [(None,3),("0",2)])
-        self.ctest("mix inner", "a££bc", "a}}bc",
-            [(None,1),("0",2),(None,2)] )
-        self.ctest("mix well", "£a£b£", "}a}b}",
-            [("0",1),(None,1),("0",1),(None,1),("0",1)] )
+        self.ctest("no conversion", "hello", "hello", [(None, 5)])
+        self.ctest("only special", "£££££", "}}}}}", [("0", 5)])
+        self.ctest("mix left", "££abc", "}}abc", [("0", 2), (None, 3)])
+        self.ctest("mix right", "abc££", "abc}}", [(None, 3), ("0", 2)])
+        self.ctest("mix inner", "a££bc", "a}}bc", [(None, 1), ("0", 2), (None, 2)])
+        self.ctest("mix well", "£a£b£", "}a}b}", [("0", 1), (None, 1), ("0", 1), (None, 1), ("0", 1)])
 
 
 class WithinDoubleByteTest(unittest.TestCase):
@@ -70,37 +68,38 @@ class WithinDoubleByteTest(unittest.TestCase):
         urwid.set_encoding(self.old_encoding)
 
     def wtest(self, s, ls, pos, expected, desc):
-        result = util.within_double_byte(s.encode('iso8859-1'), ls, pos)
-        assert result==expected, f"{desc} got:{result!r} expected: {expected!r}"
+        result = util.within_double_byte(s.encode("iso8859-1"), ls, pos)
+        assert result == expected, f"{desc} got:{result!r} expected: {expected!r}"
+
     def test1(self):
-        self.wtest("mnopqr",0,2,0,'simple no high bytes')
-        self.wtest("mn\xA1\xA1qr",0,2,1,'simple 1st half')
-        self.wtest("mn\xA1\xA1qr",0,3,2,'simple 2nd half')
-        self.wtest("m\xA1\xA1\xA1\xA1r",0,3,1,'subsequent 1st half')
-        self.wtest("m\xA1\xA1\xA1\xA1r",0,4,2,'subsequent 2nd half')
-        self.wtest("mn\xA1@qr",0,3,2,'simple 2nd half lo')
-        self.wtest("mn\xA1\xA1@r",0,4,0,'subsequent not 2nd half lo')
-        self.wtest("m\xA1\xA1\xA1@r",0,4,2,'subsequent 2nd half lo')
+        self.wtest("mnopqr", 0, 2, 0, "simple no high bytes")
+        self.wtest("mn\xA1\xA1qr", 0, 2, 1, "simple 1st half")
+        self.wtest("mn\xA1\xA1qr", 0, 3, 2, "simple 2nd half")
+        self.wtest("m\xA1\xA1\xA1\xA1r", 0, 3, 1, "subsequent 1st half")
+        self.wtest("m\xA1\xA1\xA1\xA1r", 0, 4, 2, "subsequent 2nd half")
+        self.wtest("mn\xA1@qr", 0, 3, 2, "simple 2nd half lo")
+        self.wtest("mn\xA1\xA1@r", 0, 4, 0, "subsequent not 2nd half lo")
+        self.wtest("m\xA1\xA1\xA1@r", 0, 4, 2, "subsequent 2nd half lo")
 
     def test2(self):
-        self.wtest("\xA1\xA1qr",0,0,1,'begin 1st half')
-        self.wtest("\xA1\xA1qr",0,1,2,'begin 2nd half')
-        self.wtest("\xA1@qr",0,1,2,'begin 2nd half lo')
-        self.wtest("\xA1\xA1\xA1\xA1r",0,2,1,'begin subs. 1st half')
-        self.wtest("\xA1\xA1\xA1\xA1r",0,3,2,'begin subs. 2nd half')
-        self.wtest("\xA1\xA1\xA1@r",0,3,2,'begin subs. 2nd half lo')
-        self.wtest("\xA1@\xA1@r",0,3,2,'begin subs. 2nd half lo lo')
-        self.wtest("@\xA1\xA1@r",0,3,0,'begin subs. not 2nd half lo')
+        self.wtest("\xA1\xA1qr", 0, 0, 1, "begin 1st half")
+        self.wtest("\xA1\xA1qr", 0, 1, 2, "begin 2nd half")
+        self.wtest("\xA1@qr", 0, 1, 2, "begin 2nd half lo")
+        self.wtest("\xA1\xA1\xA1\xA1r", 0, 2, 1, "begin subs. 1st half")
+        self.wtest("\xA1\xA1\xA1\xA1r", 0, 3, 2, "begin subs. 2nd half")
+        self.wtest("\xA1\xA1\xA1@r", 0, 3, 2, "begin subs. 2nd half lo")
+        self.wtest("\xA1@\xA1@r", 0, 3, 2, "begin subs. 2nd half lo lo")
+        self.wtest("@\xA1\xA1@r", 0, 3, 0, "begin subs. not 2nd half lo")
 
     def test3(self):
-        self.wtest("abc \xA1\xA1qr",4,4,1,'newline 1st half')
-        self.wtest("abc \xA1\xA1qr",4,5,2,'newline 2nd half')
-        self.wtest("abc \xA1@qr",4,5,2,'newline 2nd half lo')
-        self.wtest("abc \xA1\xA1\xA1\xA1r",4,6,1,'newl subs. 1st half')
-        self.wtest("abc \xA1\xA1\xA1\xA1r",4,7,2,'newl subs. 2nd half')
-        self.wtest("abc \xA1\xA1\xA1@r",4,7,2,'newl subs. 2nd half lo')
-        self.wtest("abc \xA1@\xA1@r",4,7,2,'newl subs. 2nd half lo lo')
-        self.wtest("abc @\xA1\xA1@r",4,7,0,'newl subs. not 2nd half lo')
+        self.wtest("abc \xA1\xA1qr", 4, 4, 1, "newline 1st half")
+        self.wtest("abc \xA1\xA1qr", 4, 5, 2, "newline 2nd half")
+        self.wtest("abc \xA1@qr", 4, 5, 2, "newline 2nd half lo")
+        self.wtest("abc \xA1\xA1\xA1\xA1r", 4, 6, 1, "newl subs. 1st half")
+        self.wtest("abc \xA1\xA1\xA1\xA1r", 4, 7, 2, "newl subs. 2nd half")
+        self.wtest("abc \xA1\xA1\xA1@r", 4, 7, 2, "newl subs. 2nd half lo")
+        self.wtest("abc \xA1@\xA1@r", 4, 7, 2, "newl subs. 2nd half lo lo")
+        self.wtest("abc @\xA1\xA1@r", 4, 7, 0, "newl subs. not 2nd half lo")
 
 
 class CalcTextPosTest(unittest.TestCase):
@@ -111,109 +110,110 @@ class CalcTextPosTest(unittest.TestCase):
         urwid.set_encoding(self.old_encoding)
 
     def ctptest(self, text, tests):
-        text = text.encode('iso8859-1')
-        for s,e,p, expected in tests:
-            got = util.calc_text_pos( text, s, e, p )
+        text = text.encode("iso8859-1")
+        for s, e, p, expected in tests:
+            got = util.calc_text_pos(text, s, e, p)
             assert got == expected, f"{s, e, p!r} got:{got!r} expected:{expected!r}"
 
     def test1(self):
         text = "hello world out there"
         tests = [
-            (0,21,0, (0,0)),
-            (0,21,5, (5,5)),
-            (0,21,21, (21,21)),
-            (0,21,50, (21,21)),
-            (2,15,50, (15,13)),
-            (6,21,0, (6,0)),
-            (6,21,3, (9,3)),
-            ]
+            (0, 21, 0, (0, 0)),
+            (0, 21, 5, (5, 5)),
+            (0, 21, 21, (21, 21)),
+            (0, 21, 50, (21, 21)),
+            (2, 15, 50, (15, 13)),
+            (6, 21, 0, (6, 0)),
+            (6, 21, 3, (9, 3)),
+        ]
         self.ctptest(text, tests)
 
     def test2_wide(self):
         util.set_encoding("euc-jp")
         text = "hel\xA1\xA1 world out there"
         tests = [
-            (0,21,0, (0,0)),
-            (0,21,4, (3,3)),
-            (2,21,2, (3,1)),
-            (2,21,3, (5,3)),
-            (6,21,0, (6,0)),
-            ]
+            (0, 21, 0, (0, 0)),
+            (0, 21, 4, (3, 3)),
+            (2, 21, 2, (3, 1)),
+            (2, 21, 3, (5, 3)),
+            (6, 21, 0, (6, 0)),
+        ]
         self.ctptest(text, tests)
 
     def test3_utf8(self):
         util.set_encoding("utf-8")
         text = "hel\xc4\x83 world \xe2\x81\x81 there"
         tests = [
-            (0,21,0, (0,0)),
-            (0,21,4, (5,4)),
-            (2,21,1, (3,1)),
-            (2,21,2, (5,2)),
-            (2,21,3, (6,3)),
-            (6,21,7, (15,7)),
-            (6,21,8, (16,8)),
-            ]
+            (0, 21, 0, (0, 0)),
+            (0, 21, 4, (5, 4)),
+            (2, 21, 1, (3, 1)),
+            (2, 21, 2, (5, 2)),
+            (2, 21, 3, (6, 3)),
+            (6, 21, 7, (15, 7)),
+            (6, 21, 8, (16, 8)),
+        ]
         self.ctptest(text, tests)
 
     def test4_utf8(self):
         util.set_encoding("utf-8")
         text = "he\xcc\x80llo \xe6\x9b\xbf world"
         tests = [
-            (0,15,0, (0,0)),
-            (0,15,1, (1,1)),
-            (0,15,2, (4,2)),
-            (0,15,4, (6,4)),
-            (8,15,0, (8,0)),
-            (8,15,1, (8,0)),
-            (8,15,2, (11,2)),
-            (8,15,5, (14,5)),
-            ]
+            (0, 15, 0, (0, 0)),
+            (0, 15, 1, (1, 1)),
+            (0, 15, 2, (4, 2)),
+            (0, 15, 4, (6, 4)),
+            (8, 15, 0, (8, 0)),
+            (8, 15, 1, (8, 0)),
+            (8, 15, 2, (11, 2)),
+            (8, 15, 5, (14, 5)),
+        ]
         self.ctptest(text, tests)
 
 
 class TagMarkupTest(unittest.TestCase):
     mytests = [
         ("simple one", "simple one", []),
-        (('blue',"john"), "john", [('blue',4)]),
-        (["a ","litt","le list"], "a little list", []),
-        (["mix",[" it",('high',[" up",('ital'," a")])]," little"],
+        (("blue", "john"), "john", [("blue", 4)]),
+        (["a ", "litt", "le list"], "a little list", []),
+        (
+            ["mix", [" it", ("high", [" up", ("ital", " a")])], " little"],
             "mix it up a little",
-            [(None, 6), ('high', 3), ('ital', 2)]),
+            [(None, 6), ("high", 3), ("ital", 2)],
+        ),
         (["££", "x££"], "££x££", []),
         ([b"\xc2\x80", b"\xc2\x80"], b"\xc2\x80\xc2\x80", []),
-        ]
+    ]
 
     def test(self):
         for input, text, attr in self.mytests:
-            restext,resattr = urwid.decompose_tagmarkup( input )
+            restext, resattr = urwid.decompose_tagmarkup(input)
             assert restext == text, f"got: {restext!r} expected: {text!r}"
             assert resattr == attr, f"got: {resattr!r} expected: {attr!r}"
 
     def test_bad_tuple(self):
-        self.assertRaises(urwid.TagMarkupException, lambda:
-            urwid.decompose_tagmarkup((1,2,3)))
+        self.assertRaises(urwid.TagMarkupException, lambda: urwid.decompose_tagmarkup((1, 2, 3)))
 
     def test_bad_type(self):
-        self.assertRaises(urwid.TagMarkupException, lambda:
-            urwid.decompose_tagmarkup(5))
+        self.assertRaises(urwid.TagMarkupException, lambda: urwid.decompose_tagmarkup(5))
+
 
 class RleTest(unittest.TestCase):
     def test_rle_prepend(self):
-        rle0 = [('A', 10), ('B', 15)]
+        rle0 = [("A", 10), ("B", 15)]
         # the rle functions are mutating, so make a few copies of rle0
         rle1, rle2 = rle0[:], rle0[:]
-        util.rle_prepend_modify(rle1, ('A', 3))
-        util.rle_prepend_modify(rle2, ('X', 2))
-        self.assertListEqual(rle1, [('A', 13), ('B', 15)])
-        self.assertListEqual(rle2, [('X', 2), ('A', 10), ('B', 15)])
+        util.rle_prepend_modify(rle1, ("A", 3))
+        util.rle_prepend_modify(rle2, ("X", 2))
+        self.assertListEqual(rle1, [("A", 13), ("B", 15)])
+        self.assertListEqual(rle2, [("X", 2), ("A", 10), ("B", 15)])
 
     def test_rle_append(self):
-        rle0 = [('A', 10), ('B', 15)]
+        rle0 = [("A", 10), ("B", 15)]
         rle3, rle4 = rle0[:], rle0[:]
-        util.rle_append_modify(rle3, ('B', 5))
-        util.rle_append_modify(rle4, ('K', 1))
-        self.assertListEqual(rle3, [('A', 10), ('B', 20)])
-        self.assertListEqual(rle4, [('A', 10), ('B', 15), ('K', 1)])
+        util.rle_append_modify(rle3, ("B", 5))
+        util.rle_append_modify(rle4, ("K", 1))
+        self.assertListEqual(rle3, [("A", 10), ("B", 20)])
+        self.assertListEqual(rle4, [("A", 10), ("B", 15), ("K", 1)])
 
 
 class PortabilityTest(unittest.TestCase):
@@ -225,7 +225,7 @@ class PortabilityTest(unittest.TestCase):
         self.assertEqual(locale.getlocale(), (None, None))
 
         try:
-            locale.setlocale(locale.LC_ALL, ('en_US', 'UTF-8'))
+            locale.setlocale(locale.LC_ALL, ("en_US", "UTF-8"))
         except locale.Error as exc:
             if "unsupported locale setting" not in str(exc):
                 raise
@@ -237,7 +237,7 @@ class PortabilityTest(unittest.TestCase):
             return
 
         util.detect_encoding()
-        self.assertEqual(locale.getlocale(), ('en_US', 'UTF-8'))
+        self.assertEqual(locale.getlocale(), ("en_US", "UTF-8"))
 
         try:
             locale.setlocale(locale.LC_ALL, initial)
@@ -253,6 +253,6 @@ class PortabilityTest(unittest.TestCase):
 
 class TestEmptyMarkup(unittest.TestCase):
     def test_001_empty(self):
-        text = urwid.Text('')
+        text = urwid.Text("")
         text.set_text(text.get_text())
         self.assertEqual("", text.text)

--- a/urwid/widget/container.py
+++ b/urwid/widget/container.py
@@ -8,7 +8,7 @@ import warnings
 from .constants import Sizing, WHSettings
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Iterable, Iterator
 
     from .widget import Widget
 
@@ -68,7 +68,7 @@ class WidgetContainerMixin:
         """
         return self.contents[position][0].base_widget
 
-    def get_focus_path(self):
+    def get_focus_path(self) -> list[int | str]:
         """
         Return the .focus_position values starting from this container
         and proceeding along each child widget until reaching a leaf
@@ -84,7 +84,7 @@ class WidgetContainerMixin:
             out.append(p)
             w = w.focus.base_widget
 
-    def set_focus_path(self, positions):
+    def set_focus_path(self, positions: Iterable[int | str]) -> None:
         """
         Set the .focus_position property starting from this container
         widget and proceeding along newly focused child widgets.  Any

--- a/urwid/widget/frame.py
+++ b/urwid/widget/frame.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import abc
 import typing
 import warnings
 
@@ -8,6 +7,7 @@ from urwid.canvas import CanvasCombine, CompositeCanvas
 from urwid.util import is_mouse_press
 
 from .constants import Sizing
+from .container import WidgetContainerMixin
 from .filler import Filler
 from .widget import Widget, WidgetError
 
@@ -15,183 +15,6 @@ if typing.TYPE_CHECKING:
     from collections.abc import Iterator, MutableMapping
 
     from typing_extensions import Literal
-
-
-class WidgetContainerMixin:
-    """
-    Mixin class for widget containers implementing common container methods
-    """
-
-    def __getitem__(self, position) -> Widget:
-        """
-        Container short-cut for self.contents[position][0].base_widget
-        which means "give me the child widget at position without any
-        widget decorations".
-
-        This allows for concise traversal of nested container widgets
-        such as:
-
-            my_widget[position0][position1][position2] ...
-        """
-        return self.contents[position][0].base_widget
-
-    def get_focus_path(self):
-        """
-        Return the .focus_position values starting from this container
-        and proceeding along each child widget until reaching a leaf
-        (non-container) widget.
-        """
-        out = []
-        w = self
-        while True:
-            try:
-                p = w.focus_position
-            except IndexError:
-                return out
-            out.append(p)
-            w = w.focus.base_widget
-
-    def set_focus_path(self, positions):
-        """
-        Set the .focus_position property starting from this container
-        widget and proceeding along newly focused child widgets.  Any
-        failed assignment due do incompatible position types or invalid
-        positions will raise an IndexError.
-
-        This method may be used to restore a particular widget to the
-        focus by passing in the value returned from an earlier call to
-        get_focus_path().
-
-        positions -- sequence of positions
-        """
-        w = self
-        for p in positions:
-            if p != w.focus_position:
-                w.focus_position = p  # modifies w.focus
-            w = w.focus.base_widget
-
-    def get_focus_widgets(self) -> list[Widget]:
-        """
-        Return the .focus values starting from this container
-        and proceeding along each child widget until reaching a leaf
-        (non-container) widget.
-
-        Note that the list does not contain the topmost container widget
-        (i.e., on which this method is called), but does include the
-        lowest leaf widget.
-        """
-        out = []
-        w = self
-        while True:
-            w = w.base_widget.focus
-            if w is None:
-                return out
-            out.append(w)
-
-    @property
-    @abc.abstractmethod
-    def focus(self) -> Widget:
-        """
-        Read-only property returning the child widget in focus for
-        container widgets.  This default implementation
-        always returns ``None``, indicating that this widget has no children.
-        """
-
-    def _get_focus(self) -> Widget:
-        warnings.warn(
-            f"method `{self.__class__.__name__}._get_focus` is deprecated, "
-            f"please use `{self.__class__.__name__}.focus` property",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-        return self.focus
-
-
-class WidgetContainerListContentsMixin:
-    """
-    Mixin class for widget containers whose positions are indexes into
-    a list available as self.contents.
-    """
-
-    def __iter__(self) -> Iterator[int]:
-        """
-        Return an iterable of positions for this container from first
-        to last.
-        """
-        return iter(range(len(self.contents)))
-
-    def __reversed__(self) -> Iterator[int]:
-        """
-        Return an iterable of positions for this container from last
-        to first.
-        """
-        return iter(range(len(self.contents) - 1, -1, -1))
-
-    def __len__(self) -> int:
-        return len(self.contents)
-
-    @property
-    @abc.abstractmethod
-    def contents(self) -> list[tuple[Widget, typing.Any]]:
-        """The contents of container as a list of (widget, options)"""
-
-    @contents.setter
-    def contents(self, new_contents: list[tuple[Widget, typing.Any]]) -> None:
-        """The contents of container as a list of (widget, options)"""
-
-    def _get_contents(self) -> list[tuple[Widget, typing.Any]]:
-        warnings.warn(
-            f"method `{self.__class__.__name__}._get_contents` is deprecated, "
-            f"please use `{self.__class__.__name__}.contents` property",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.contents
-
-    def _set_contents(self, c: list[tuple[Widget, typing.Any]]) -> None:
-        warnings.warn(
-            f"method `{self.__class__.__name__}._set_contents` is deprecated, "
-            f"please use `{self.__class__.__name__}.contents` property",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        self.contents = c
-
-    @property
-    @abc.abstractmethod
-    def focus_position(self) -> int | None:
-        """
-        index of child widget in focus.
-        """
-
-    @focus_position.setter
-    def focus_position(self, position: int) -> None:
-        """
-        index of child widget in focus.
-        """
-
-    def _get_focus_position(self) -> int | None:
-        warnings.warn(
-            f"method `{self.__class__.__name__}._get_focus_position` is deprecated, "
-            f"please use `{self.__class__.__name__}.focus_position` property",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-        return self.focus_position
-
-    def _set_focus_position(self, position: int) -> None:
-        """
-        Set the widget in focus.
-
-        position -- index of child widget to be made focus
-        """
-        warnings.warn(
-            f"method `{self.__class__.__name__}._set_focus_position` is deprecated, "
-            f"please use `{self.__class__.__name__}.focus_position` property",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-        self.focus_position = position
 
 
 class FrameError(WidgetError):
@@ -411,7 +234,7 @@ class Frame(Widget, WidgetContainerMixin):
         return {"header": self._header, "footer": self._footer, "body": self._body}[self.focus_part]
 
     @property
-    def contents(self) -> MutableMapping[str, tuple[Widget, None]]:
+    def contents(self) -> MutableMapping[Literal["header", "footer", "body"], tuple[Widget, None]]:
         """
         a dict-like object similar to::
 
@@ -428,7 +251,7 @@ class Frame(Widget, WidgetContainerMixin):
         constrained to keys for each of the three usual parts of a Frame.
         When other keys are used a :exc:`KeyError` will be raised.
 
-        Currently all options are `None`, but using the :meth:`options` method
+        Currently, all options are `None`, but using the :meth:`options` method
         to create the options value is recommended for forwards
         compatibility.
         """
@@ -438,25 +261,6 @@ class Frame(Widget, WidgetContainerMixin):
             def __len__(inner_self) -> int:
                 return len(inner_self.keys())
 
-            def items(inner_self):
-                return [(k, inner_self[k]) for k in inner_self]
-
-            def values(inner_self):
-                return [inner_self[k] for k in inner_self]
-
-            def update(inner_self, E=None, **F):
-                if E:
-                    keys = getattr(E, "keys", None)
-                    if keys:
-                        for k in E:
-                            inner_self[k] = E[k]
-                    else:
-                        for k, v in E:
-                            inner_self[k] = v
-                for k in F:
-                    inner_self[k] = F[k]
-
-            keys = self._contents_keys
             __getitem__ = self._contents__getitem__
             __setitem__ = self._contents__setitem__
             __delitem__ = self._contents__delitem__


### PR DESCRIPTION
* `WidgetContainerMixin` & `WidgetContainerListContentsMixin` copy/paste with `container module`
* `FrameContents` subclasses `MutableMapping` do not make useless overloads

Unrelated: partial auto-format of functional tests

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

