### PR TITLE
Extend typing annotations

### DIFF
--- a/urwid/monitored_list.py
+++ b/urwid/monitored_list.py
@@ -46,7 +46,7 @@ def _call_modified(
     return call_modified_wrapper
 
 
-class MonitoredList(list):
+class MonitoredList(typing.List[_T], typing.Generic[_T]):
     """
     This class can trigger a callback any time its contents are changed
     with the usual list operations append, extend, etc.
@@ -105,7 +105,7 @@ class MonitoredList(list):
         clear = _call_modified(list.clear)  # type: ignore[assignment]  # magic like old __super__
 
 
-class MonitoredFocusList(MonitoredList, typing.Generic[_T]):
+class MonitoredFocusList(MonitoredList[_T], typing.Generic[_T]):
     """
     This class can trigger a callback any time its contents are modified,
     before and/or after modification, and any time the focus index is changed.

--- a/urwid/widget/filler.py
+++ b/urwid/widget/filler.py
@@ -97,13 +97,22 @@ class Filler(WidgetDecoration):
                     raise FillerError("fixed bottom height may only be used with fixed top valign")
                 bottom = height[1]
                 height = RELATIVE_100
+
         if isinstance(valign, tuple):
             if valign[0] == "fixed top":
                 top = valign[1]
-                valign = VAlign.TOP
+                normalized_valign = VAlign.TOP
             elif valign[0] == "fixed bottom":
                 bottom = valign[1]
-                valign = VAlign.BOTTOM
+                normalized_valign = VAlign.BOTTOM
+            else:
+                normalized_valign = valign
+
+        elif not isinstance(valign, (VAlign, str)):
+            raise FillerError(f"invalid valign: {valign!r}")
+
+        else:
+            normalized_valign = VAlign(valign)
 
         # convert old flow mode parameter height=None to height='flow'
         if height is None or height == Sizing.FLOW:
@@ -111,7 +120,7 @@ class Filler(WidgetDecoration):
 
         self.top = top
         self.bottom = bottom
-        self.valign_type, self.valign_amount = normalize_valign(valign, FillerError)
+        self.valign_type, self.valign_amount = normalize_valign(normalized_valign, FillerError)
         self.height_type, self.height_amount = normalize_height(height, FillerError)
 
         if self.height_type not in {WHSettings.GIVEN, WHSettings.PACK}:

--- a/urwid/widget/overlay.py
+++ b/urwid/widget/overlay.py
@@ -425,6 +425,10 @@ class Overlay(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
                 normalized_valign = VAlign.BOTTOM
             else:
                 normalized_valign = valign
+
+        elif not isinstance(valign, (VAlign, str)):
+            raise OverlayError(f"invalid valign: {valign!r}")
+
         else:
             normalized_valign = VAlign(valign)
 


### PR DESCRIPTION
* `Filler` & `Overlay` - in-place atomic valign validation (help static checkers)
* `MonitoredList` - make generic for subtype correct annotations

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [X] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
