### PR TITLE
Fix: columns rendered with a non-first Selectable widget

### DIFF
--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -191,6 +191,18 @@ class ColumnsTest(unittest.TestCase):
         self.assertEqual((32, 1), widget.pack(()))
         self.assertEqual([b"<   OK   > < Cancel > <  Help  >"], widget.render(()).text)
 
+    def test_render_fixed_consistency(self) -> None:
+        """Widgets supporting FIXED should be rendered with PACK side the same way as not FIXED."""
+        widget = urwid.Columns(((urwid.PACK, urwid.Text("Prefix:")), (urwid.PACK, urwid.Button("Btn"))), dividechars=1)
+
+        cols, _ = widget.pack(())
+
+        self.assertEqual(((7, 7), (1, 1), ((), ())), widget.get_column_sizes(()))
+        self.assertEqual(((7, 7), (1, 1), ((7,), (7,))), widget.get_column_sizes((cols,)))
+
+        self.assertEqual(("Prefix: < Btn >",), widget.render(()).decoded_text)
+        self.assertEqual(("Prefix: < Btn >",), widget.render((cols,)).decoded_text)
+
     def test_pack_render_broken_sizing(self) -> None:
         use_sizing = frozenset((urwid.BOX,))
 

--- a/urwid/widget/columns.py
+++ b/urwid/widget/columns.py
@@ -4,6 +4,7 @@ import typing
 import warnings
 from itertools import chain, repeat
 
+import urwid
 from urwid.canvas import Canvas, CanvasJoin, CompositeCanvas, SolidCanvas
 from urwid.monitored_list import MonitoredFocusList, MonitoredList
 from urwid.util import is_mouse_press
@@ -691,12 +692,19 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
             if t == WHSettings.GIVEN:
                 static_w = width
             elif t == WHSettings.PACK:
-                w_sizing = w.sizing()
-                if Sizing.FLOW in w_sizing:
+                if isinstance(w, Widget):
+                    w_sizing = w.sizing()
+                else:
+                    warnings.warn(f"{w!r} is not a Widget", ColumnsWarning, stacklevel=3)
+                    w_sizing = frozenset((urwid.BOX, urwid.FLOW))
+
+                if Sizing.FIXED in w_sizing:
+                    w_size = ()
+
+                elif Sizing.FLOW in w_sizing:
                     # FIXME: should be able to pack with a different maxcol value
                     w_size = (maxcol,)
-                elif Sizing.FIXED in w_sizing:
-                    w_size = ()
+
                 else:
                     warnings.warn(
                         f"Unusual widget {w} sizing for {t} (box={b}). "


### PR DESCRIPTION
* In case of first elements fit, it should be included in the rendered widget.
* Render columns with FIXED mode should be the same as FLOW mode with cols collected from `widget.pack()`

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

