### PR TITLE
Feature: Partial FIXED support for `Edit` widget

### DIFF
--- a/urwid/numedit.py
+++ b/urwid/numedit.py
@@ -79,7 +79,7 @@ class NumEdit(Edit):
             return self._allow_negative and ch == "-" and self.edit_pos == 0 and "-" not in self.edit_text
         return False
 
-    def keypress(self, size: tuple[int], key: str) -> str | None:
+    def keypress(self, size: tuple[int] | tuple[()], key: str) -> str | None:
         """
         Handle editing keystrokes.  Remove leading zeros.
 


### PR DESCRIPTION
Full fixed mode will look ugly due to widget size change on input,
but a size collection and render for debug purposes will be very useful.

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [X] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

