### PR TITLE
Special case: Columns PACK item not fit as FIXED and support FLOW

### DIFF
--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -203,6 +203,20 @@ class ColumnsTest(unittest.TestCase):
         self.assertEqual(("Prefix: < Btn >",), widget.render(()).decoded_text)
         self.assertEqual(("Prefix: < Btn >",), widget.render((cols,)).decoded_text)
 
+    def test_render_pack_item_not_fit(self):
+        items = urwid.Text("123"), urwid.Text("456")
+        widget = urwid.Columns(((urwid.PACK, item) for item in items))
+        # Make width < widget fixed pack
+        width = items[0].pack(())[0] - 1
+        height = items[0].rows((width, ))
+        self.assertEqual((width, height), widget.pack((width,)))
+
+        canvas = widget.render((width,))
+        # Rendered should be not empty
+        self.assertEqual(items[0].render((width,)).decoded_text, canvas.decoded_text)
+        self.assertEqual(width, canvas.cols())
+
+
     def test_pack_render_broken_sizing(self) -> None:
         use_sizing = frozenset((urwid.BOX,))
 

--- a/urwid/widget/columns.py
+++ b/urwid/widget/columns.py
@@ -698,12 +698,17 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
                     warnings.warn(f"{w!r} is not a Widget", ColumnsWarning, stacklevel=3)
                     w_sizing = frozenset((urwid.BOX, urwid.FLOW))
 
-                if Sizing.FIXED in w_sizing:
-                    w_size = ()
+                if w_sizing & frozenset((Sizing.FIXED, Sizing.FLOW)):
+                    candidate_size = 0
 
-                elif Sizing.FLOW in w_sizing:
-                    # FIXME: should be able to pack with a different maxcol value
-                    w_size = (maxcol,)
+                    if Sizing.FIXED in w_sizing:
+                        candidate_size = w.pack((), focus and i == self.focus_position)[0]
+
+                    if Sizing.FLOW in w_sizing and (not candidate_size or candidate_size > maxcol):
+                        # FIXME: should be able to pack with a different maxcol value
+                        candidate_size = w.pack((maxcol,), focus and i == self.focus_position)[0]
+
+                    static_w = candidate_size
 
                 else:
                     warnings.warn(
@@ -712,8 +717,8 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
                         ColumnsWarning,
                         stacklevel=3,
                     )
-                    w_size = (maxcol,)
-                static_w = w.pack(w_size, focus and i == self.focus_position)[0]
+                    static_w = w.pack((maxcol,), focus and i == self.focus_position)[0]
+
             else:
                 static_w = self.min_width
 


### PR DESCRIPTION
Fallback to the old `maxcol` if FIXED pack not fit in `maxcol`

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

