### PR TITLE
Scrollable: Extent `Blocks` collection

### DIFF
--- a/tests/test_scrollable.py
+++ b/tests/test_scrollable.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import unittest
 
 import urwid
-from urwid.widget import scrollable
 
 LGPL_HEADER = """
 Copyright (C) <year>  <name of author>
@@ -142,7 +141,7 @@ class TestScrollBar(unittest.TestCase):
         reduced_size = (40, 5)
         widget = urwid.widget.ScrollBar(
             urwid.widget.Scrollable(long_content),
-            trough_char=scrollable.Blocks.LITE_SHADE,
+            trough_char=urwid.widget.ScrollBar.Symbols.LITE_SHADE,
         )
 
         self.assertEqual(
@@ -160,15 +159,15 @@ class TestScrollBar(unittest.TestCase):
         """Test with fixed wrapped widget."""
         widget = urwid.widget.ScrollBar(
             urwid.widget.Scrollable(urwid.BigText("1", urwid.HalfBlockHeavy6x5Font())),
-            trough_char=scrollable.Blocks.LITE_SHADE,
-            thumb_char=scrollable.Blocks.DARK_SHADE,
+            trough_char=urwid.widget.ScrollBar.Symbols.LITE_SHADE,
+            thumb_char=urwid.widget.ScrollBar.Symbols.DARK_SHADE,
         )
         reduced_size = (8, 3)
 
         self.assertEqual(
             (
                 " ▐█▌   ▓",
-                " ▀█▌   ░",
+                " ▀█▌   ▓",
                 "  █▌   ░",
             ),
             widget.render(reduced_size).decoded_text,
@@ -179,7 +178,7 @@ class TestScrollBar(unittest.TestCase):
         self.assertEqual(
             (
                 "  █▌   ░",
-                "  █▌   ░",
+                "  █▌   ▓",
                 " ███▌  ▓",
             ),
             widget.render(reduced_size).decoded_text,

--- a/urwid/widget/scrollable.py
+++ b/urwid/widget/scrollable.py
@@ -40,7 +40,7 @@ if typing.TYPE_CHECKING:
     from .widget import Widget
 
 
-__all__ = ["Scrollable", "ScrollBar", "ScrollableError", "Blocks"]
+__all__ = ("ScrollbarSymbols", "ScrollBar", "Scrollable", "ScrollableError")
 
 
 class ScrollableError(WidgetError):
@@ -60,13 +60,27 @@ SCROLLBAR_LEFT = "left"
 SCROLLBAR_RIGHT = "right"
 
 
-class Blocks(str, enum.Enum):
-    """Standard normal width blocks."""
+class ScrollbarSymbols(str, enum.Enum):
+    """Standard symbols suitable for scrollbar."""
 
-    FULL = "█"
-    DARK_SHADE = "▓"
+    # fmt: off
+
+    FULL =         "█"
+    DARK_SHADE =   "▓"
     MEDIUM_SHADE = "▒"
-    LITE_SHADE = "░"
+    LITE_SHADE =   "░"
+
+    DRAWING_NORMAL =        "│"
+    DRAWING_2_DASH_NORMAL = "╎"
+    DRAWING_3_DASH_NORMAL = "┆"
+    DRAWING_4_DASH_NORMAL = "┊"
+
+    DRAWING_THICK =        "┃"
+    DRAWING_2_DASH_THICK = "╏"
+    DRAWING_3_DASH_THICK = "┇"
+    DRAWING_4_DASH_THICK = "┋"
+
+    DRAWING_DOUBLE = "║"
 
 
 @runtime_checkable
@@ -420,6 +434,8 @@ class Scrollable(WidgetDecoration):
 
 
 class ScrollBar(WidgetDecoration):
+    Symbols = ScrollbarSymbols
+
     def sizing(self):
         return frozenset((Sizing.BOX,))
 
@@ -429,7 +445,7 @@ class ScrollBar(WidgetDecoration):
     def __init__(
         self,
         widget: SupportsScroll,
-        thumb_char: str = Blocks.FULL,
+        thumb_char: str = ScrollbarSymbols.FULL,
         trough_char: str = " ",
         side: Literal["left", "right"] = SCROLLBAR_RIGHT,
         width: int = 1,
@@ -484,7 +500,7 @@ class ScrollBar(WidgetDecoration):
 
         # Thumb shrinks/grows according to the ratio of
         # <number of visible lines> / <number of total lines>
-        thumb_weight = min(1, maxrow // max(1, ow_rows_max))
+        thumb_weight = min(1.0, maxrow / max(1, ow_rows_max))
         thumb_height = max(1, round(thumb_weight * maxrow))
 
         # Thumb may only touch top/bottom if the first/last row is visible

--- a/urwid/widget/widget.py
+++ b/urwid/widget/widget.py
@@ -27,7 +27,7 @@ import warnings
 from operator import attrgetter
 
 from urwid import signals
-from urwid.canvas import CanvasCache, CompositeCanvas
+from urwid.canvas import Canvas, CanvasCache, CompositeCanvas
 from urwid.command_map import command_map
 from urwid.split_repr import split_repr
 from urwid.util import MetaSuper
@@ -203,58 +203,6 @@ class Widget(metaclass=WidgetMeta):
 
        A shared :class:`CommandMap` instance. May be redefined
        in subclasses or widget instances.
-
-    .. method:: render(size, focus=False)
-
-       .. note::
-
-          This method is not implemented in :class:`.Widget` but
-          must be implemented by any concrete subclass
-
-       :param size: One of the following,
-                    *maxcol* and *maxrow* are integers > 0:
-
-                    (*maxcol*, *maxrow*)
-                      for box sizing -- the parent chooses the exact
-                      size of this widget
-
-                    (*maxcol*,)
-                      for flow sizing -- the parent chooses only the
-                      number of columns for this widget
-
-                    ()
-                      for fixed sizing -- this widget is a fixed size
-                      which can't be adjusted by the parent
-       :type size: widget size
-       :param focus: set to ``True`` if this widget or one of its children
-                     is in focus
-       :type focus: bool
-
-       :returns: A :class:`Canvas` subclass instance containing the
-                 rendered content of this widget
-
-       :class:`Text` widgets return a :class:`TextCanvas` (arbitrary text and
-       display attributes), :class:`SolidFill` widgets return a
-       :class:`SolidCanvas` (a single character repeated across
-       the whole surface) and container widgets return a
-       :class:`CompositeCanvas` (one or more other canvases
-       arranged arbitrarily).
-
-       If *focus* is ``False``, the returned canvas may not have a cursor
-       position set.
-
-       There is some metaclass magic defined in the :class:`Widget`
-       metaclass :class:`WidgetMeta` that causes the
-       result of this method to be cached by :class:`CanvasCache`.
-       Later calls will automatically look up the value in the cache first.
-
-       As a small optimization the class variable :attr:`ignore_focus`
-       may be defined and set to ``True`` if this widget renders the same
-       canvas regardless of the value of the *focus* parameter.
-
-       Any time the content of a widget changes it should call
-       :meth:`_invalidate` to remove any cached canvases, or the widget
-       may render the cached canvas instead of creating a new one.
 
 
     .. method:: rows(size, focus=False)
@@ -580,6 +528,48 @@ class Widget(metaclass=WidgetMeta):
                 )
                 LOGGER.debug(f"Widget {self!r} is not selectable")
         return False
+
+    def render(self, size: tuple[()] | tuple[int] | tuple[int, int], focus: bool = False) -> Canvas:
+        """Render widget and produce canvas
+
+        :param size: One of the following, *maxcol* and *maxrow* are integers > 0:
+
+            (*maxcol*, *maxrow*)
+              for box sizing -- the parent chooses the exact
+              size of this widget
+
+            (*maxcol*,)
+              for flow sizing -- the parent chooses only the
+              number of columns for this widget
+
+            ()
+              for fixed sizing -- this widget is a fixed size
+              which can't be adjusted by the parent
+        :type size: widget size
+        :param focus: set to ``True`` if this widget or one of its children is in focus
+        :type focus: bool
+
+        :returns: A :class:`Canvas` subclass instance containing the rendered content of this widget
+
+        :class:`Text` widgets return a :class:`TextCanvas` (arbitrary text and display attributes),
+        :class:`SolidFill` widgets return a :class:`SolidCanvas` (a single character repeated across the whole surface)
+        and container widgets return a :class:`CompositeCanvas` (one or more other canvases arranged arbitrarily).
+
+        If *focus* is ``False``, the returned canvas may not have a cursor position set.
+
+        There is some metaclass magic defined in the :class:`Widget` metaclass :class:`WidgetMeta`
+        that causes the result of this method to be cached by :class:`CanvasCache`.
+        Later calls will automatically look up the value in the cache first.
+
+        As a small optimization the class variable :attr:`ignore_focus`
+        may be defined and set to ``True`` if this widget renders the same
+        canvas regardless of the value of the *focus* parameter.
+
+        Any time the content of a widget changes it should call
+        :meth:`_invalidate` to remove any cached canvases, or the widget
+        may render the cached canvas instead of creating a new one.
+        """
+        raise NotImplementedError
 
 
 class FlowWidget(Widget):

--- a/urwid/widget/widget_decoration.py
+++ b/urwid/widget/widget_decoration.py
@@ -13,7 +13,7 @@ if typing.TYPE_CHECKING:
     from .constants import Sizing
 
 
-__all__ = ("WidgetDecoration", "WidgetPlaceholder", "WidgetDisable", "WidgetError", "WidgetWarning")
+__all__ = ("WidgetDecoration", "WidgetDisable", "WidgetError", "WidgetPlaceholder", "WidgetWarning")
 
 
 class WidgetDecoration(Widget):  # "decorator" was already taken


### PR DESCRIPTION
* Expose `Blocks` enum as `Symbols` class field and rename enum to `ScrollbarSymbols` (enum is not exposed directly)
* Fix scrollbar height calculation: during migration was made incorrect cast to `int`

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
