### PR TITLE
Feature: implement common symbols constants

### DIFF
--- a/examples/graph.py
+++ b/examples/graph.py
@@ -81,7 +81,7 @@ class GraphModel:
         lines = []
         d = self.data[self.current_mode]
         while r:
-            offset = offset % len(d)
+            offset %= len(d)
             segment = d[offset : offset + r]
             r -= len(segment)
             offset += len(segment)
@@ -206,7 +206,7 @@ class GraphView(urwid.WidgetWrap):
 
     def main_shadow(self, w):
         """Wrap a shadow and background around widget w."""
-        bg = urwid.AttrMap(urwid.SolidFill("\u2592"), "screen edge")
+        bg = urwid.AttrMap(urwid.SolidFill("▒"), "screen edge")
         shadow = urwid.AttrMap(urwid.SolidFill(" "), "main shadow")
 
         bg = urwid.Overlay(shadow, bg, ("fixed left", 3), ("fixed right", 1), ("fixed top", 2), ("fixed bottom", 1))

--- a/urwid/widget/bar_graph.py
+++ b/urwid/widget/bar_graph.py
@@ -5,7 +5,7 @@ import typing
 from urwid.canvas import CanvasCombine, CompositeCanvas, SolidCanvas
 from urwid.util import get_encoding_mode
 
-from .constants import Sizing
+from .constants import BAR_SYMBOLS, Sizing
 from .text import Text
 from .widget import Widget, WidgetError, WidgetMeta, nocache_widget_render, nocache_widget_render_instance
 
@@ -49,7 +49,7 @@ class BarGraph(Widget, metaclass=BarGraphMeta):
 
     ignore_focus = True
 
-    eighths = " ▁▂▃▄▅▆▇"
+    eighths = BAR_SYMBOLS.VERTICAL[:8]  # Full height is done by style
     hlines = "_⎺⎻─⎼⎽"
 
     def __init__(self, attlist, hatt=None, satt=None):

--- a/urwid/widget/constants.py
+++ b/urwid/widget/constants.py
@@ -466,3 +466,84 @@ def simplify_height(
         return height_amount
 
     return (WHSettings(height_type), height_amount)
+
+
+class _BoxSymbols(typing.NamedTuple):
+    """Box symbols for drawing.
+
+    Symbols are ordered as in Unicode.
+    """
+
+    HORIZONTAL: str
+    VERTICAL: str
+    TOP_LEFT: str
+    TOP_RIGHT: str
+    BOTTOM_LEFT: str
+    BOTTOM_RIGHT: str
+    # Joints for tables making
+    LEFT_T: str
+    RIGHT_T: str
+    TOP_T: str
+    BOTTOM_T: str
+    CROSS: str
+
+
+class _LightBoxSymbols(typing.NamedTuple):
+    """Box symbols for drawing.
+
+    The Thin version includes extra symbols.
+    Symbols are ordered as in Unicode.
+    """
+
+    # fmt: off
+
+    HORIZONTAL: str =   "─"
+    VERTICAL: str =     "│"
+    TOP_LEFT: str =     "┌"
+    TOP_RIGHT: str =    "┐"
+    BOTTOM_LEFT: str =  "└"
+    BOTTOM_RIGHT: str = "┘"
+    # Joints for tables making
+    LEFT_T: str =   "├"
+    RIGHT_T: str =  "┤"
+    TOP_T: str =    "┬"
+    BOTTOM_T: str = "┴"
+    CROSS: str =    "┼"
+    # Unique for light only
+    TOP_LEFT_ROUNDED: str =     "╭"
+    TOP_RIGHT_ROUNDED: str =    "╮"
+    BOTTOM_RIGHT_ROUNDED: str = "╯"
+    BOTTOM_LEFT_ROUNDED: str =  "╰"
+
+
+class _BoxSymbolsCollection(typing.NamedTuple):
+    """Standard Unicode box symbols for basic tables drawing.
+
+    .. note::
+        Transitions are not included: depends on line types, different kinds of transitions are available.
+        Please check Unicode table for transitions symbols if required.
+    """
+
+    # fmt: off
+
+    LIGHT = _LightBoxSymbols()
+    HEAVY =  _BoxSymbols("━", "┃", "┏", "┓", "┗", "┛", "┣", "┫", "┳", "┻", "╋")
+    DOUBLE = _BoxSymbols("═", "║", "╔", "╗", "╚", "╝", "╠", "╣", "╦", "╩", "╬")
+
+
+BOX_SYMBOLS = _BoxSymbolsCollection()
+
+
+class BAR_SYMBOLS(str, enum.Enum):
+    """Standard Unicode bar symbols excluding empty space.
+
+    Start from space (0), then 1/8 till full block (1/1).
+    Typically used only 8 from this symbol collection depends on use-case:
+    * empty - 7/8 and styles for BG different on both sides (like standard `ProgressBar` and `BarGraph`)
+    * 1/8 - full block and single style for BG on the right side
+    """
+
+    # fmt: off
+
+    HORISONTAL = " ▏▎▍▌▋▊▉█"
+    VERTICAL =   " ▁▂▃▄▅▆▇█"

--- a/urwid/widget/line_box.py
+++ b/urwid/widget/line_box.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import typing
 
 from .columns import Columns
-from .constants import Align, WHSettings
+from .constants import BOX_SYMBOLS, Align, WHSettings
 from .divider import Divider
 from .pile import Pile
 from .solid_fill import SolidFill
@@ -16,20 +16,22 @@ if typing.TYPE_CHECKING:
 
 
 class LineBox(WidgetDecoration, WidgetWrap):
+    Symbols = BOX_SYMBOLS
+
     def __init__(
         self,
         original_widget: Widget,
         title: str = "",
         title_align: Literal["left", "center", "right"] | Align = Align.CENTER,
         title_attr=None,
-        tlcorner: str = "┌",
-        tline: str = "─",
-        lline: str = "│",
-        trcorner: str = "┐",
-        blcorner: str = "└",
-        rline: str = "│",
-        bline: str = "─",
-        brcorner: str = "┘",
+        tlcorner: str = BOX_SYMBOLS.LIGHT.TOP_LEFT,
+        tline: str = BOX_SYMBOLS.LIGHT.HORIZONTAL,
+        lline: str = BOX_SYMBOLS.LIGHT.VERTICAL,
+        trcorner: str = BOX_SYMBOLS.LIGHT.TOP_RIGHT,
+        blcorner: str = BOX_SYMBOLS.LIGHT.BOTTOM_LEFT,
+        rline: str = BOX_SYMBOLS.LIGHT.VERTICAL,
+        bline: str = BOX_SYMBOLS.LIGHT.HORIZONTAL,
+        brcorner: str = BOX_SYMBOLS.LIGHT.BOTTOM_RIGHT,
     ) -> None:
         """
         Draw a line around original_widget.
@@ -55,6 +57,44 @@ class LineBox(WidgetDecoration, WidgetWrap):
         If empty string is specified for one of the lines/corners, then no character will be output there.
         If no top/bottom/left/right lines - whole lines will be omitted.
         This allows for seamless use of adjoining LineBoxes.
+
+        Class attribute `Symbols` can be used as source for standard lines:
+
+        >>> print(LineBox(Text("Some text")).render(()))
+        ┌─────────┐
+        │Some text│
+        └─────────┘
+        >>> print(
+        ...   LineBox(
+        ...     Text("Some text"),
+        ...     tlcorner=LineBox.Symbols.LIGHT.TOP_LEFT_ROUNDED,
+        ...     trcorner=LineBox.Symbols.LIGHT.TOP_RIGHT_ROUNDED,
+        ...     blcorner=LineBox.Symbols.LIGHT.BOTTOM_LEFT_ROUNDED,
+        ...     brcorner=LineBox.Symbols.LIGHT.BOTTOM_RIGHT_ROUNDED,
+        ...   ).render(())
+        ... )
+        ╭─────────╮
+        │Some text│
+        ╰─────────╯
+        >>> print(
+        ...   LineBox(
+        ...     Text("Some text"),
+        ...     tline=LineBox.Symbols.HEAVY.HORIZONTAL,
+        ...     bline=LineBox.Symbols.HEAVY.HORIZONTAL,
+        ...     lline=LineBox.Symbols.HEAVY.VERTICAL,
+        ...     rline=LineBox.Symbols.HEAVY.VERTICAL,
+        ...     tlcorner=LineBox.Symbols.HEAVY.TOP_LEFT,
+        ...     trcorner=LineBox.Symbols.HEAVY.TOP_RIGHT,
+        ...     blcorner=LineBox.Symbols.HEAVY.BOTTOM_LEFT,
+        ...     brcorner=LineBox.Symbols.HEAVY.BOTTOM_RIGHT,
+        ...   ).render(())
+        ... )
+        ┏━━━━━━━━━┓
+        ┃Some text┃
+        ┗━━━━━━━━━┛
+
+        To make Table constructions, some lineboxes need to be drawn without sides
+        and T or CROSS symbols used for corners of cells.
         """
 
         w_lline = SolidFill(lline)

--- a/urwid/widget/progress_bar.py
+++ b/urwid/widget/progress_bar.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import typing
 import warnings
 
-from .constants import Align, Sizing, WrapMode
+from .constants import BAR_SYMBOLS, Align, Sizing, WrapMode
 from .text import Text
 from .widget import Widget
 
@@ -14,7 +14,7 @@ if typing.TYPE_CHECKING:
 class ProgressBar(Widget):
     _sizing = frozenset([Sizing.FLOW])
 
-    eighths = " ▏▎▍▌▋▊▉"
+    eighths = BAR_SYMBOLS.HORISONTAL[:8]  # Full width line is made by style
 
     text_align = Align.CENTER
 
@@ -26,9 +26,10 @@ class ProgressBar(Widget):
         :param done: progress amount at 100%
         :param satt: display attribute for smoothed part of bar where the
                      foreground of satt corresponds to the normal part and the
-                     background corresponds to the complete part.  If satt
-                     is ``None`` then no smoothing will be done.
+                     background corresponds to the complete part.
+                     If satt is ``None`` then no smoothing will be done.
 
+        >>> from urwid import LineBox
         >>> pb = ProgressBar('a', 'b')
         >>> pb
         <ProgressBar flow widget>
@@ -50,6 +51,12 @@ class ProgressBar(Widget):
         >>> for x in range(101):
         ...     cpb2.set_completion(x)
         ...     s = cpb2.render((10, ))
+        >>> pb = ProgressBar('a', 'b', satt='c')
+        >>> pb.set_completion(34.56)
+        >>> print(LineBox(pb).render((20,)))
+        ┌──────────────────┐
+        │      ▏34 %       │
+        └──────────────────┘
         """
         super().__init__()
         self.normal = normal
@@ -58,7 +65,7 @@ class ProgressBar(Widget):
         self._done = done
         self.satt = satt
 
-    def set_completion(self, current):
+    def set_completion(self, current: int) -> None:
         """
         current -- current progress
         """


### PR DESCRIPTION
* BOX_SYMBOLS for drawings
* * expose in `LineBox` as `LineBox.Symbols`
* * use in `LineBox` `__init__` instead of symbols
* * Add usage example to the `LineBox` docstring
* BAR_SYMBOLS for bars
* * use in `ProgressBar` and `BarGraph` instead of "magic" strings

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [X] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

