### PR TITLE
Typing: Make `WidgetWrap` and `WidgetDecoration` `Generic`

### DIFF
--- a/urwid/vterm.py
+++ b/urwid/vterm.py
@@ -1669,7 +1669,7 @@ class Terminal(Widget):
         elif hasattr(self, "old_tios"):
             RealTerminal().tty_signal_keys(*self.old_tios)
 
-    def render(self, size: tuple[int, int], focus: bool = False):
+    def render(self, size: tuple[int, int], focus: bool = False) -> TermCanvas:
         if not self.terminated:
             self.change_focus(focus)
 

--- a/urwid/widget/attr_map.py
+++ b/urwid/widget/attr_map.py
@@ -5,22 +5,24 @@ from collections.abc import Hashable, Mapping
 
 from urwid.canvas import CompositeCanvas
 
-from .widget import Widget, WidgetError, delegate_to_widget_mixin
+from .widget import WidgetError, delegate_to_widget_mixin
 from .widget_decoration import WidgetDecoration
+
+WrappedWidget = typing.TypeVar("WrappedWidget")
 
 
 class AttrMapError(WidgetError):
     pass
 
 
-class AttrMap(delegate_to_widget_mixin("_original_widget"), WidgetDecoration):
+class AttrMap(delegate_to_widget_mixin("_original_widget"), WidgetDecoration[WrappedWidget]):
     """
     AttrMap is a decoration that maps one set of attributes to another.
     This object will pass all function calls and variable references to the
     wrapped widget.
     """
 
-    def __init__(self, w: Widget, attr_map, focus_map=None) -> None:
+    def __init__(self, w: WrappedWidget, attr_map, focus_map=None) -> None:
         """
         :param w: widget to wrap (stored as self.original_widget)
         :type w: widget

--- a/urwid/widget/bar_graph.py
+++ b/urwid/widget/bar_graph.py
@@ -52,7 +52,7 @@ class BarGraph(Widget, metaclass=BarGraphMeta):
     eighths = BAR_SYMBOLS.VERTICAL[:8]  # Full height is done by style
     hlines = "_⎺⎻─⎼⎽"
 
-    def __init__(self, attlist, hatt=None, satt=None):
+    def __init__(self, attlist, hatt=None, satt=None) -> None:
         """
         Create a bar graph with the passed display characteristics.
         see set_segment_attributes for a description of the parameters.
@@ -134,7 +134,7 @@ class BarGraph(Widget, metaclass=BarGraphMeta):
                 raise BarGraphError(f"fg ({fg}) not > bg ({bg})")
         self.satt = satt
 
-    def set_data(self, bardata, top, hlines=None):
+    def set_data(self, bardata, top: float, hlines=None) -> None:
         """
         Store bar data, bargraph top and horizontal line positions.
 
@@ -428,7 +428,7 @@ class BarGraph(Widget, metaclass=BarGraphMeta):
         return canv
 
 
-def calculate_bargraph_display(bardata, top, bar_widths, maxrow: int):
+def calculate_bargraph_display(bardata, top: float, bar_widths: list[int], maxrow: int):
     """
     Calculate a rendering of the bar graph described by data, bar_widths
     and height.
@@ -574,7 +574,7 @@ def calculate_bargraph_display(bardata, top, bar_widths, maxrow: int):
 class GraphVScale(Widget):
     _sizing = frozenset([Sizing.BOX])
 
-    def __init__(self, labels, top):
+    def __init__(self, labels, top: float) -> None:
         """
         GraphVScale( [(label1 position, label1 markup),...], top )
         label position -- 0 < position < top for the y position
@@ -587,7 +587,7 @@ class GraphVScale(Widget):
         super().__init__()
         self.set_scale(labels, top)
 
-    def set_scale(self, labels, top):
+    def set_scale(self, labels, top: float) -> None:
         """
         set_scale( [(label1 position, label1 markup),...], top )
         label position -- 0 < position < top for the y position
@@ -610,7 +610,7 @@ class GraphVScale(Widget):
         """
         return False
 
-    def render(self, size: tuple[int, int], focus: bool = False):
+    def render(self, size: tuple[int, int], focus: bool = False) -> SolidCanvas | CompositeCanvas:
         """
         Render GraphVScale.
         """
@@ -641,7 +641,7 @@ class GraphVScale(Widget):
         return c
 
 
-def scale_bar_values(bar, top, maxrow: int):
+def scale_bar_values(bar, top: float, maxrow: int) -> list[int]:
     """
     Return a list of bar values aliased to integer values of maxrow.
     """

--- a/urwid/widget/box_adapter.py
+++ b/urwid/widget/box_adapter.py
@@ -8,22 +8,21 @@ from urwid.canvas import CompositeCanvas
 from .constants import Sizing
 from .widget_decoration import WidgetDecoration, WidgetError
 
-if typing.TYPE_CHECKING:
-    from .widget import Widget
+WrappedWidget = typing.TypeVar("WrappedWidget")
 
 
 class BoxAdapterError(WidgetError):
     pass
 
 
-class BoxAdapter(WidgetDecoration):
+class BoxAdapter(WidgetDecoration[WrappedWidget]):
     """
     Adapter for using a box widget where a flow widget would usually go
     """
 
     no_cache: typing.ClassVar[list[str]] = ["rows"]
 
-    def __init__(self, box_widget, height):
+    def __init__(self, box_widget: WrappedWidget, height: int) -> None:
         """
         Create a flow widget that contains a box widget
 
@@ -47,7 +46,7 @@ class BoxAdapter(WidgetDecoration):
 
     # originally stored as box_widget, keep for compatibility
     @property
-    def box_widget(self) -> Widget:
+    def box_widget(self) -> WrappedWidget:
         warnings.warn(
             "original stored as original_widget, keep for compatibility",
             PendingDeprecationWarning,
@@ -56,7 +55,7 @@ class BoxAdapter(WidgetDecoration):
         return self.original_widget
 
     @box_widget.setter
-    def box_widget(self, widget: Widget):
+    def box_widget(self, widget: WrappedWidget) -> None:
         warnings.warn(
             "original stored as original_widget, keep for compatibility",
             PendingDeprecationWarning,
@@ -104,7 +103,7 @@ class BoxAdapter(WidgetDecoration):
     def mouse_event(
         self,
         size: tuple[int],
-        event,
+        event: str,
         button: int,
         col: int,
         row: int,

--- a/urwid/widget/columns.py
+++ b/urwid/widget/columns.py
@@ -1019,7 +1019,7 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
     def mouse_event(
         self,
         size: tuple[()] | tuple[int] | tuple[int, int],
-        event,
+        event: str,
         button: int,
         col: int,
         row: int,

--- a/urwid/widget/divider.py
+++ b/urwid/widget/divider.py
@@ -69,7 +69,7 @@ class Divider(Widget):
         self.top = top
         self.bottom = bottom
 
-    def _repr_words(self):
+    def _repr_words(self) -> list[str]:
         return super()._repr_words() + [repr(self.div_char)] * (self.div_char != " ")
 
     def _repr_attrs(self) -> dict[str, typing.Any]:
@@ -92,7 +92,7 @@ class Divider(Widget):
         (_maxcol,) = size
         return self.top + 1 + self.bottom
 
-    def render(self, size: tuple[int], focus: bool = False):
+    def render(self, size: tuple[int], focus: bool = False) -> CompositeCanvas:
         """
         Render the divider as a canvas and return it.
 

--- a/urwid/widget/edit.py
+++ b/urwid/widget/edit.py
@@ -550,7 +550,7 @@ class Edit(Text):
         self._invalidate()
         return True
 
-    def mouse_event(self, size: tuple[int], event, button: int, x: int, y: int, focus: bool) -> bool | None:
+    def mouse_event(self, size: tuple[int], event: str, button: int, x: int, y: int, focus: bool) -> bool | None:
         """
         Move the cursor to the location clicked for button 1.
 

--- a/urwid/widget/filler.py
+++ b/urwid/widget/filler.py
@@ -22,17 +22,18 @@ from .widget_decoration import WidgetDecoration, WidgetError
 if typing.TYPE_CHECKING:
     from typing_extensions import Literal
 
-    from .widget import Widget
+
+WrappedWidget = typing.TypeVar("WrappedWidget")
 
 
 class FillerError(WidgetError):
     pass
 
 
-class Filler(WidgetDecoration):
+class Filler(WidgetDecoration[WrappedWidget]):
     def __init__(
         self,
-        body: Widget,
+        body: WrappedWidget,
         valign: (
             Literal["top", "middle", "bottom"] | VAlign | tuple[Literal["relative", WHSettings.RELATIVE], int]
         ) = VAlign.MIDDLE,
@@ -159,7 +160,7 @@ class Filler(WidgetDecoration):
         return remove_defaults(attrs, Filler.__init__)
 
     @property
-    def body(self):
+    def body(self) -> WrappedWidget:
         """backwards compatibility, widget used to be stored as body"""
         warnings.warn(
             "backwards compatibility, widget used to be stored as body",
@@ -169,7 +170,7 @@ class Filler(WidgetDecoration):
         return self.original_widget
 
     @body.setter
-    def body(self, new_body):
+    def body(self, new_body: WrappedWidget) -> None:
         warnings.warn(
             "backwards compatibility, widget used to be stored as body",
             PendingDeprecationWarning,
@@ -177,7 +178,7 @@ class Filler(WidgetDecoration):
         )
         self.original_widget = new_body
 
-    def get_body(self):
+    def get_body(self) -> WrappedWidget:
         """backwards compatibility, widget used to be stored as body"""
         warnings.warn(
             "backwards compatibility, widget used to be stored as body",
@@ -186,7 +187,7 @@ class Filler(WidgetDecoration):
         )
         return self.original_widget
 
-    def set_body(self, new_body):
+    def set_body(self, new_body: WrappedWidget) -> None:
         warnings.warn(
             "backwards compatibility, widget used to be stored as body",
             DeprecationWarning,

--- a/urwid/widget/frame.py
+++ b/urwid/widget/frame.py
@@ -448,7 +448,15 @@ class Frame(Widget, WidgetContainerMixin):
             return key
         return self.body.keypress((maxcol, remaining), key)
 
-    def mouse_event(self, size: tuple[int, int], event, button: int, col: int, row: int, focus: bool) -> bool | None:
+    def mouse_event(
+        self,
+        size: tuple[int, int],
+        event: str,
+        button: int,
+        col: int,
+        row: int,
+        focus: bool,
+    ) -> bool | None:
         """
         Pass mouse event to appropriate part of frame.
         Focus may be changed on button 1 press.

--- a/urwid/widget/grid_flow.py
+++ b/urwid/widget/grid_flow.py
@@ -23,7 +23,7 @@ class GridFlowError(WidgetError):
     pass
 
 
-class GridFlow(WidgetWrap, WidgetContainerMixin, WidgetContainerListContentsMixin):
+class GridFlow(WidgetWrap[Pile], WidgetContainerMixin, WidgetContainerListContentsMixin):
     """
     The GridFlow widget is a flow widget that renders all the widgets it
     contains the same width and it arranges them from left to right and top to
@@ -73,10 +73,8 @@ class GridFlow(WidgetWrap, WidgetContainerMixin, WidgetContainerListContentsMixi
         self.h_sep = h_sep
         self.v_sep = v_sep
         self.align = align
-        self._cache_maxcol = None
-        super().__init__(None)
-        # set self._w to something other than None
-        self.get_display_widget(((h_sep + cell_width) * len(self._contents),))
+        self._cache_maxcol = self._get_maxcol(())
+        super().__init__(self.generate_display_widget((self._cache_maxcol,)))
 
     def _invalidate(self) -> None:
         self._cache_maxcol = None
@@ -525,7 +523,7 @@ class GridFlow(WidgetWrap, WidgetContainerMixin, WidgetContainerListContentsMixi
     def mouse_event(
         self,
         size: tuple[int] | tuple[()],
-        event,
+        event: str,
         button: int,
         col: int,
         row: int,

--- a/urwid/widget/line_box.py
+++ b/urwid/widget/line_box.py
@@ -14,13 +14,15 @@ from .widget_decoration import WidgetDecoration
 if typing.TYPE_CHECKING:
     from typing_extensions import Literal
 
+WrappedWidget = typing.TypeVar("WrappedWidget")
 
-class LineBox(WidgetDecoration, WidgetWrap):
+
+class LineBox(WidgetDecoration[WrappedWidget], WidgetWrap[Pile]):
     Symbols = BOX_SYMBOLS
 
     def __init__(
         self,
-        original_widget: Widget,
+        original_widget: WrappedWidget,
         title: str = "",
         title_align: Literal["left", "center", "right"] | Align = Align.CENTER,
         title_attr=None,

--- a/urwid/widget/overlay.py
+++ b/urwid/widget/overlay.py
@@ -801,7 +801,7 @@ class Overlay(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
     def mouse_event(
         self,
         size: tuple[()] | tuple[int] | tuple[int, int],
-        event,
+        event: str,
         button: int,
         col: int,
         row: int,

--- a/urwid/widget/padding.py
+++ b/urwid/widget/padding.py
@@ -22,7 +22,8 @@ from .widget_decoration import WidgetDecoration, WidgetError, WidgetWarning
 if typing.TYPE_CHECKING:
     from typing_extensions import Literal
 
-    from .widget import Widget
+
+WrappedWidget = typing.TypeVar("WrappedWidget")
 
 
 class PaddingError(WidgetError):
@@ -33,10 +34,10 @@ class PaddingWarning(WidgetWarning):
     """Padding related warnings."""
 
 
-class Padding(WidgetDecoration):
+class Padding(WidgetDecoration[WrappedWidget]):
     def __init__(
         self,
-        w: Widget,
+        w: WrappedWidget,
         align: (
             Literal["left", "center", "right"] | Align | tuple[Literal["relative", WHSettings.RELATIVE], int]
         ) = Align.LEFT,
@@ -48,7 +49,7 @@ class Padding(WidgetDecoration):
         min_width: int | None = None,
         left: int = 0,
         right: int = 0,
-    ):
+    ) -> None:
         """
         :param w: a box, flow or fixed widget to pad on the left and/or right
             this widget is stored as self.original_widget
@@ -473,7 +474,7 @@ class Padding(WidgetDecoration):
     def mouse_event(
         self,
         size: tuple[()] | tuple[int] | tuple[int, int],
-        event,
+        event: str,
         button: int,
         x: int,
         y: int,

--- a/urwid/widget/pile.py
+++ b/urwid/widget/pile.py
@@ -934,7 +934,7 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
     def mouse_event(
         self,
         size: tuple[()] | tuple[int] | tuple[int, int],
-        event,
+        event: str,
         button: int,
         col: int,
         row: int,

--- a/urwid/widget/popup.py
+++ b/urwid/widget/popup.py
@@ -34,13 +34,15 @@ if typing.TYPE_CHECKING:
 
     from .widget import Widget
 
+WrappedWidget = typing.TypeVar("WrappedWidget")
 
-class PopUpLauncher(delegate_to_widget_mixin("_original_widget"), WidgetDecoration):
-    def __init__(self, original_widget: Widget) -> None:
+
+class PopUpLauncher(delegate_to_widget_mixin("_original_widget"), WidgetDecoration[WrappedWidget]):
+    def __init__(self, original_widget: [WrappedWidget]) -> None:
         super().__init__(original_widget)
         self._pop_up_widget = None
 
-    def create_pop_up(self):
+    def create_pop_up(self) -> Widget:
         """
         Subclass must override this method and return a widget
         to be used for the pop-up.  This method is called once each time
@@ -74,13 +76,13 @@ class PopUpLauncher(delegate_to_widget_mixin("_original_widget"), WidgetDecorati
         return canv
 
 
-class PopUpTarget(WidgetDecoration):
+class PopUpTarget(WidgetDecoration[WrappedWidget]):
     # FIXME: this whole class is a terrible hack and must be fixed
     # when layout and rendering are separated
     _sizing = frozenset((Sizing.BOX,))
     _selectable = True
 
-    def __init__(self, original_widget: Widget) -> None:
+    def __init__(self, original_widget: WrappedWidget) -> None:
         super().__init__(original_widget)
         self._pop_up = None
         self._current_widget = self._original_widget
@@ -132,7 +134,15 @@ class PopUpTarget(WidgetDecoration):
         self._update_overlay(size, True)
         return self._current_widget.move_cursor_to_coords(size, x, y)
 
-    def mouse_event(self, size: tuple[int, int], event, button: int, x: int, y: int, focus: bool) -> bool | None:
+    def mouse_event(
+        self,
+        size: tuple[int, int],
+        event: str,
+        button: int,
+        x: int,
+        y: int,
+        focus: bool,
+    ) -> bool | None:
         self._update_overlay(size, focus)
         return self._current_widget.mouse_event(size, event, button, x, y, focus)
 

--- a/urwid/widget/progress_bar.py
+++ b/urwid/widget/progress_bar.py
@@ -95,7 +95,7 @@ class ProgressBar(Widget):
         )
         self.done = done
 
-    def rows(self, size, focus: bool = False) -> int:
+    def rows(self, size: tuple[int], focus: bool = False) -> int:
         return 1
 
     def get_text(self) -> str:

--- a/urwid/widget/scrollable.py
+++ b/urwid/widget/scrollable.py
@@ -43,6 +43,9 @@ if typing.TYPE_CHECKING:
 __all__ = ("ScrollbarSymbols", "ScrollBar", "Scrollable", "ScrollableError")
 
 
+WrappedWidget = typing.TypeVar("WrappedWidget")
+
+
 class ScrollableError(WidgetError):
     """Scrollable specific widget errors."""
 
@@ -119,14 +122,14 @@ class SupportsScroll(Protocol):
     def rows_max(self, size: tuple[int, int] | None = None, focus: bool = False) -> int: ...
 
 
-class Scrollable(WidgetDecoration):
+class Scrollable(WidgetDecoration[WrappedWidget]):
     def sizing(self) -> frozenset[Sizing]:
         return frozenset((Sizing.BOX,))
 
     def selectable(self) -> bool:
         return True
 
-    def __init__(self, widget: Widget, force_forward_keypress: bool = False) -> None:
+    def __init__(self, widget: WrappedWidget, force_forward_keypress: bool = False) -> None:
         """Box widget that makes a fixed or flow widget vertically scrollable
 
         .. note::
@@ -420,7 +423,7 @@ class Scrollable(WidgetDecoration):
         return self._rows_max_cached
 
 
-class ScrollBar(WidgetDecoration):
+class ScrollBar(WidgetDecoration[WrappedWidget]):
     Symbols = ScrollbarSymbols
 
     def sizing(self):
@@ -431,7 +434,7 @@ class ScrollBar(WidgetDecoration):
 
     def __init__(
         self,
-        widget: SupportsScroll,
+        widget: WrappedWidget,
         thumb_char: str = ScrollbarSymbols.FULL_BLOCK,
         trough_char: str = " ",
         side: Literal["left", "right"] = SCROLLBAR_RIGHT,

--- a/urwid/widget/text.py
+++ b/urwid/widget/text.py
@@ -294,7 +294,7 @@ class Text(Widget):
             self._update_cache_translation(maxcol, ta)
         return self._cache_translation
 
-    def _update_cache_translation(self, maxcol: int, ta):
+    def _update_cache_translation(self, maxcol: int, ta) -> None:
         if ta:
             text, _attr = ta
         else:

--- a/urwid/widget/widget.py
+++ b/urwid/widget/widget.py
@@ -37,7 +37,7 @@ from .constants import Sizing
 if typing.TYPE_CHECKING:
     from collections.abc import Callable, Hashable
 
-
+WrappedWidget = typing.TypeVar("WrappedWidget")
 LOGGER = logging.getLogger(__name__)
 
 
@@ -172,7 +172,7 @@ def cache_widget_rows(cls):
     fn = cls.rows
 
     @functools.wraps(fn)
-    def cached_rows(self, size, focus=False):
+    def cached_rows(self, size: tuple[int], focus: bool = False) -> int:
         focus = focus and not ignore_focus
         canv = CanvasCache.fetch(self, cls, size, focus)
         if canv:
@@ -455,7 +455,7 @@ class Widget(metaclass=WidgetMeta):
         """
         return split_repr(self)
 
-    def _repr_words(self):
+    def _repr_words(self) -> list[str]:
         words = []
         if self.selectable():
             words = ["selectable", *words]
@@ -766,8 +766,8 @@ class WidgetWrapError(Exception):
     pass
 
 
-class WidgetWrap(delegate_to_widget_mixin("_wrapped_widget")):
-    def __init__(self, w: Widget):
+class WidgetWrap(delegate_to_widget_mixin("_wrapped_widget"), typing.Generic[WrappedWidget]):
+    def __init__(self, w: WrappedWidget) -> None:
         """
         w -- widget to wrap, stored as self._w
 
@@ -792,11 +792,11 @@ class WidgetWrap(delegate_to_widget_mixin("_wrapped_widget")):
         self._wrapped_widget = w
 
     @property
-    def _w(self) -> Widget:
+    def _w(self) -> WrappedWidget:
         return self._wrapped_widget
 
     @_w.setter
-    def _w(self, new_widget: Widget) -> None:
+    def _w(self, new_widget: WrappedWidget) -> None:
         """
         Change the wrapped widget.  This is meant to be called
         only by subclasses.
@@ -816,7 +816,7 @@ class WidgetWrap(delegate_to_widget_mixin("_wrapped_widget")):
         self._wrapped_widget = new_widget
         self._invalidate()
 
-    def _set_w(self, w):
+    def _set_w(self, w: WrappedWidget) -> None:
         """
         Change the wrapped widget.  This is meant to be called
         only by subclasses.

--- a/urwid/widget/wimp.py
+++ b/urwid/widget/wimp.py
@@ -134,7 +134,7 @@ class CheckBoxError(WidgetError):
     pass
 
 
-class CheckBox(WidgetWrap):
+class CheckBox(WidgetWrap[Columns]):
     states: typing.ClassVar[dict[bool | Literal["mixed"], SelectableIcon]] = {
         True: SelectableIcon("[X]", 1),
         False: SelectableIcon("[ ]", 1),
@@ -430,7 +430,7 @@ class CheckBox(WidgetWrap):
         elif self.state == "mixed":
             self.set_state(False)
 
-    def mouse_event(self, size: tuple[int], event, button: int, x: int, y: int, focus: bool) -> bool:
+    def mouse_event(self, size: tuple[int], event: str, button: int, x: int, y: int, focus: bool) -> bool:
         """
         Toggle state on button 1 press.
 
@@ -593,7 +593,7 @@ class RadioButton(CheckBox):
         self.set_state(True)
 
 
-class Button(WidgetWrap):
+class Button(WidgetWrap[Columns]):
     button_left = Text("<")
     button_right = Text(">")
 
@@ -754,7 +754,7 @@ class Button(WidgetWrap):
         self._emit("click")
         return None
 
-    def mouse_event(self, size: tuple[int], event, button: int, x: int, y: int, focus: bool) -> bool:
+    def mouse_event(self, size: tuple[int], event: str, button: int, x: int, y: int, focus: bool) -> bool:
         """
         Send 'click' signal on button 1 press.
 


### PR DESCRIPTION
* Help static checkers to find the correct type of wrapped widget
* Extend type annotations for widgets when an argument type is known

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

