### PR TITLE
Columns special case: FIXED pack with not enough info

### DIFF
--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -321,6 +321,39 @@ class ColumnsTest(unittest.TestCase):
             widget.keypress((), "left")
             self.assertEqual(1, widget.focus_position)
 
+    def test_pack_not_enough_info(self):
+        """Test special case for not official fixed pack and render support."""
+        widget = urwid.Columns(
+            (
+                (urwid.WEIGHT, 16, urwid.SolidFill(urwid.SolidFill.Symbols.LITE_SHADE)),
+                (10, urwid.Button("First")),
+                urwid.SolidFill(urwid.SolidFill.Symbols.LITE_SHADE),
+                (10, urwid.Button("Second")),
+                (urwid.WEIGHT, 16, urwid.SolidFill(urwid.SolidFill.Symbols.LITE_SHADE)),
+            ),
+            box_columns=(0, 2, 4),
+        )
+        cols, rows = 53, 1
+        self.assertEqual(frozenset((urwid.FLOW,)), widget.sizing())
+        self.assertEqual((cols, rows), widget.pack(()))
+        self.assertEqual(
+            ("░░░░░░░░░░░░░░░░< First  >░< Second >░░░░░░░░░░░░░░░░",),
+            widget.render(()).decoded_text,
+        )
+
+    def test_no_height(self):
+        widget = urwid.Columns(
+            (
+                (urwid.WEIGHT, 16, urwid.SolidFill(urwid.SolidFill.Symbols.LITE_SHADE)),
+                urwid.SolidFill(urwid.SolidFill.Symbols.LITE_SHADE),
+                (urwid.WEIGHT, 16, urwid.SolidFill(urwid.SolidFill.Symbols.LITE_SHADE)),
+            ),
+            box_columns=(0, 1, 2),
+        )
+        self.assertEqual(frozenset((urwid.BOX,)), widget.sizing())
+        with self.assertRaises(urwid.widget.ColumnsError):
+            widget.pack(())
+
     def assert_column_widths(
         self,
         expected: Collection[int],

--- a/urwid/widget/columns.py
+++ b/urwid/widget/columns.py
@@ -796,13 +796,16 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
                 else:
                     w_h_args[i] = (0,)
 
-            elif Sizing.FIXED in w_sizing and (Sizing.FLOW in w_sizing or is_box):
-                width, height = widget.pack((), focused)
+            elif Sizing.FLOW in w_sizing or is_box:
+                if Sizing.FIXED in w_sizing:
+                    width, height = widget.pack((), focused)
+                else:
+                    width = self.min_width
+
                 weighted.setdefault(size_weight, []).append((widget, i, is_box, focused))
                 weights.append(size_weight)
                 weight_max_sizes.setdefault(size_weight, width)
                 weight_max_sizes[size_weight] = max(weight_max_sizes[size_weight], width)
-
             else:
                 raise ColumnsError(f"Unsupported combination of {size_kind} box={is_box!r} for {widget}")
 
@@ -819,6 +822,9 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
                         w_h_args[i] = (width,)
                     else:
                         box.append(i)
+
+        if not heights:
+            raise ColumnsError(f"No height information for pack {self!r} as FIXED")
 
         max_height = max(heights.values())
         for idx in box:

--- a/urwid/widget/solid_fill.py
+++ b/urwid/widget/solid_fill.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from urwid.canvas import SolidCanvas
 
-from .constants import Sizing
+from .constants import SHADE_SYMBOLS, Sizing
 from .widget import Widget
 
 
@@ -14,6 +14,8 @@ class SolidFill(Widget):
     _selectable = False
     ignore_focus = True
     _sizing = frozenset([Sizing.BOX])
+
+    Symbols = SHADE_SYMBOLS
 
     def __init__(self, fill_char: str = " ") -> None:
         """


### PR DESCRIPTION
In the case of weighted items without a size source, `min_width` can be used as width source.
Note: This behavior is only a special case.

**This behavior should never be exposed in `sizing` to prevent incorrect render of widgets**

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
