### PR TITLE
Fix double `Widget` inheritance in the `LineBox`

### DIFF
--- a/urwid/widget/line_box.py
+++ b/urwid/widget/line_box.py
@@ -8,16 +8,17 @@ from .divider import Divider
 from .pile import Pile
 from .solid_fill import SolidFill
 from .text import Text
-from .widget import Widget, WidgetWrap
-from .widget_decoration import WidgetDecoration
+from .widget_decoration import WidgetDecoration, delegate_to_widget_mixin
 
 if typing.TYPE_CHECKING:
     from typing_extensions import Literal
 
+    from .widget import Widget
+
 WrappedWidget = typing.TypeVar("WrappedWidget")
 
 
-class LineBox(WidgetDecoration[WrappedWidget], WidgetWrap[Pile]):
+class LineBox(WidgetDecoration[WrappedWidget], delegate_to_widget_mixin("_wrapped_widget")):
     Symbols = BOX_SYMBOLS
 
     def __init__(
@@ -157,15 +158,17 @@ class LineBox(WidgetDecoration[WrappedWidget], WidgetWrap[Pile]):
 
         pile_widgets = []
         if top:
-            pile_widgets.append(("flow", top))
+            pile_widgets.append((WHSettings.PACK, top))
         pile_widgets.append(middle)
-        focus_pos = len(pile_widgets) - 1
         if bottom:
-            pile_widgets.append(("flow", bottom))
-        pile = Pile(pile_widgets, focus_item=focus_pos)
+            pile_widgets.append((WHSettings.PACK, bottom))
 
-        WidgetDecoration.__init__(self, original_widget)
-        WidgetWrap.__init__(self, pile)
+        self._wrapped_widget = Pile(pile_widgets, focus_item=middle)
+
+        super().__init__(original_widget)
+
+    def _w(self) -> Pile:
+        return self._wrapped_widget
 
     def format_title(self, text: str) -> str:
         if text:

--- a/urwid/widget/pile.py
+++ b/urwid/widget/pile.py
@@ -853,7 +853,9 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
 
     def keypress(self, size: tuple[()] | tuple[int] | tuple[int, int], key: str) -> str | None:
         """Pass the keypress to the widget in focus.
-        Unhandled 'up' and 'down' keys may cause a focus change."""
+
+        Unhandled 'up' and 'down' keys may cause a focus change.
+        """
         if not self.contents:
             return key
 
@@ -941,8 +943,8 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         row: int,
         focus: bool,
     ) -> bool | None:
-        """
-        Pass the event to the contained widget.
+        """Pass the event to the contained widget.
+
         May change focus on button 1 press.
         """
         wrow = 0

--- a/urwid/widget/widget_decoration.py
+++ b/urwid/widget/widget_decoration.py
@@ -13,7 +13,14 @@ if typing.TYPE_CHECKING:
     from .constants import Sizing
 
 
-__all__ = ("WidgetDecoration", "WidgetDisable", "WidgetError", "WidgetPlaceholder", "WidgetWarning")
+__all__ = (
+    "WidgetDecoration",
+    "WidgetDisable",
+    "WidgetError",
+    "WidgetPlaceholder",
+    "WidgetWarning",
+    "delegate_to_widget_mixin",
+)
 
 WrappedWidget = typing.TypeVar("WrappedWidget")
 


### PR DESCRIPTION
This PR fixes MRO hell for `super` calls
due to parents receive different widgets in the `__init__`

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

Partial #726