### PR TITLE
Unicode: use "target encoding" while transcoding for output

### DIFF
--- a/urwid/display/_raw_display_base.py
+++ b/urwid/display/_raw_display_base.py
@@ -590,7 +590,7 @@ class Screen(BaseScreen, RealTerminal):
 
         last_attributes = None  # Default = empty
 
-        output = [escape.HIDE_CURSOR, attr_to_escape(last_attributes)]
+        output: list[str] = [escape.HIDE_CURSOR, attr_to_escape(last_attributes)]
 
         def partial_display() -> bool:
             # returns True if the screen is in partial display mode ie. only some rows belong to the display
@@ -672,7 +672,7 @@ class Screen(BaseScreen, RealTerminal):
                         output.append(escape.SO)
                     last_charset_flag = cs
 
-                output.append(run)
+                output.append(run.decode(encoding, "replace"))
                 first = False
 
             if ins:
@@ -682,7 +682,7 @@ class Screen(BaseScreen, RealTerminal):
                     raise ValueError(insertcs)
 
                 if isinstance(inserttext, bytes):
-                    inserttext = inserttext.decode("utf-8")
+                    inserttext = inserttext.decode(encoding)
 
                 output.extend(("\x08" * back, ias))
 
@@ -718,7 +718,7 @@ class Screen(BaseScreen, RealTerminal):
         try:
             for line in output:
                 if isinstance(line, bytes):
-                    line = line.decode("utf-8", "replace")  # noqa: PLW2901
+                    line = line.decode(encoding, "replace")  # noqa: PLW2901
                 self.write(line)
             self.flush()
         except OSError as e:

--- a/urwid/display/curses.py
+++ b/urwid/display/curses.py
@@ -29,6 +29,8 @@ import sys
 import typing
 from contextlib import suppress
 
+from urwid import util
+
 from . import escape
 from .common import UNPRINTABLE_TRANS_TABLE, AttrSpec, BaseScreen, RealTerminal
 
@@ -592,7 +594,7 @@ class Screen(BaseScreen, RealTerminal):
                             raise ValueError(f"cs not in ('0', 'U' ,'None'): {cs!r}")
                         if not isinstance(seg, bytes):
                             raise TypeError(seg)
-                        self.s.addstr(seg.decode("utf-8"))
+                        self.s.addstr(seg.decode(util.get_encoding()))
                 except curses.error:
                     # it's ok to get out of the
                     # screen on the lower right
@@ -673,7 +675,7 @@ class _test:
             a = []
             for k in keys:
                 if isinstance(k, str):
-                    k = k.encode("utf-8")  # noqa: PLW2901
+                    k = k.encode(util.get_encoding())  # noqa: PLW2901
 
                 t += f"'{k}' "
                 a += [(None, 1), ("yellow on dark blue", len(k)), (None, 2)]

--- a/urwid/text_layout.py
+++ b/urwid/text_layout.py
@@ -379,7 +379,7 @@ class LayoutSegment:
                     raise TypeError(self.offs)
             self.text = self.end = None
 
-    def subseg(self, text: bytes, start: int, end: int) -> list[tuple[int, int] | tuple[int, int, int | bytes]]:
+    def subseg(self, text: str | bytes, start: int, end: int) -> list[tuple[int, int] | tuple[int, int, int | bytes]]:
         """
         Return a "sub-segment" list containing segment structures
         that make up a portion of this segment.
@@ -454,7 +454,7 @@ def shift_line(
 
 def trim_line(
     segs: list[tuple[int, int, int | bytes] | tuple[int, int | None]],
-    text: bytes,
+    text: str | bytes,
     start: int,
     end: int,
 ) -> list[tuple[int, int, int | bytes] | tuple[int, int | None]]:

--- a/urwid/util.py
+++ b/urwid/util.py
@@ -28,7 +28,7 @@ import warnings
 from contextlib import suppress
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import Generator, Iterable
     from types import TracebackType
 
     from typing_extensions import Protocol, Self
@@ -234,7 +234,7 @@ set_encoding(detected_encoding)
 ######################################################################
 
 
-def supports_unicode():
+def supports_unicode() -> bool:
     """
     Return True if python is able to convert non-ascii unicode strings
     to the current encoding.
@@ -242,7 +242,13 @@ def supports_unicode():
     return _target_encoding and _target_encoding != "ascii"
 
 
-def calc_trim_text(text, start_offs: int, end_offs: int, start_col: int, end_col: int):
+def calc_trim_text(
+    text: str | bytes,
+    start_offs: int,
+    end_offs: int,
+    start_col: int,
+    end_col: int,
+) -> tuple[int, int, int, int]:
     """
     Calculate the result of trimming text.
     start_offs -- offset into text to treat as screen column 0
@@ -270,7 +276,7 @@ def calc_trim_text(text, start_offs: int, end_offs: int, start_col: int, end_col
     return (spos, pos, pad_left, pad_right)
 
 
-def trim_text_attr_cs(text, attr, cs, start_col: int, end_col: int):
+def trim_text_attr_cs(text: bytes, attr, cs, start_col: int, end_col: int):
     """
     Return ( trimmed text, trimmed attr, trimmed cs ).
     """
@@ -325,7 +331,7 @@ def rle_subseg(rle, start: int, end: int):
     return sub_segment
 
 
-def rle_len(rle) -> int:
+def rle_len(rle: Iterable[tuple[typing.Any, int]]) -> int:
     """
     Return the number of characters covered by a run length
     encoded attribute list.
@@ -358,7 +364,7 @@ def rle_prepend_modify(rle, a_r) -> None:
             rle[0:0] = [(a, r)]
 
 
-def rle_append_modify(rle, a_r):
+def rle_append_modify(rle, a_r) -> None:
     """
     Append (a, r) (unpacked from *a_r*) to the rle list rle.
     Merge with last run when possible.
@@ -373,7 +379,7 @@ def rle_append_modify(rle, a_r):
     rle[-1] = (a, lr + r)
 
 
-def rle_join_modify(rle, rle2):
+def rle_join_modify(rle, rle2) -> None:
     """
     Append attribute list rle2 to rle.
     Merge last run of rle with first run of rle2 when possible.
@@ -516,7 +522,7 @@ class MetaSuper(type):
         setattr(cls, f"_{name}__super", _super)
 
 
-def int_scale(val: int, val_range: int, out_range: int):
+def int_scale(val: int, val_range: int, out_range: int) -> int:
     """
     Scale val in the range [0, val_range-1] to an integer in the range
     [0, out_range-1].  This implementation uses the "round-half-up" rounding


### PR DESCRIPTION
* apply `Canvas.content` method API normalization and annotation
* * Overloaded methods should accept arguments as base class method
* * Overloaded methods can use own defaults

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)