### PR TITLE
Typing: correct annotations for `Canvas.content`

### DIFF
--- a/urwid/canvas.py
+++ b/urwid/canvas.py
@@ -294,7 +294,7 @@ class Canvas:
         cols: int | None = None,
         rows: int | None = None,
         attr=None,
-    ):
+    ) -> Iterable[list[tuple[object, object, bytes]]]:
         raise NotImplementedError()
 
     def cols(self):
@@ -489,10 +489,10 @@ class TextCanvas(Canvas):
         self,
         trim_left: int = 0,
         trim_top: int = 0,
-        cols: int = 0,
-        rows: int = 0,
-        attr_map=None,
-    ):
+        cols: int | None = 0,
+        rows: int | None = 0,
+        attr=None,
+    ) -> Iterable[tuple[object, object, bytes]]:
         """
         Return the canvas content as a list of rows where each row
         is a list of (attr, cs, text) tuples.
@@ -534,8 +534,8 @@ class TextCanvas(Canvas):
             i = 0
             row = []
             for (a, cs), run in attr_cs:
-                if attr_map and a in attr_map:
-                    a = attr_map[a]  # noqa: PLW2901
+                if attr and a in attr:
+                    a = attr[a]  # noqa: PLW2901
                 row.append((a, cs, text[i : i + run]))
                 i += run
             yield row
@@ -566,10 +566,10 @@ class BlankCanvas(Canvas):
         self,
         trim_left: int = 0,
         trim_top: int = 0,
-        cols: int = 0,
-        rows: int = 0,
+        cols: int | None = 0,
+        rows: int | None = 0,
         attr=None,
-    ):
+    ) -> Iterable[list[tuple[object, object, bytes]]]:
         """
         return (cols, rows) of spaces with default attributes.
         """
@@ -621,7 +621,7 @@ class SolidCanvas(Canvas):
         cols: int | None = None,
         rows: int | None = None,
         attr=None,
-    ):
+    ) -> Iterable[list[tuple[object, object, bytes]]]:
         if cols is None:
             cols = self.size[0]
         if rows is None:
@@ -717,7 +717,14 @@ class CompositeCanvas(Canvas):
             raise TypeError(cols)
         return cols
 
-    def content(self):
+    def content(
+        self,
+        trim_left: int = 0,
+        trim_top: int = 0,
+        cols: int | None = None,
+        rows: int | None = None,
+        attr=None,
+    ) -> Iterable[list[tuple[object, object, bytes]]]:
         """
         Return the canvas content as a list of rows where each row
         is a list of (attr, cs, text) tuples.

--- a/urwid/display/_raw_display_base.py
+++ b/urwid/display/_raw_display_base.py
@@ -603,10 +603,10 @@ class Screen(BaseScreen, RealTerminal):
             if isinstance(a, AttrSpec):
                 return self._attrspec_to_escape(a)
             # undefined attributes use default/default
-            # TODO: track and report these
+            self.logger.debug(f"Undefined attribute: {a!r}")
             return self._attrspec_to_escape(AttrSpec("default", "default"))
 
-        def using_standout_or_underline(a):
+        def using_standout_or_underline(a: AttrSpec | str) -> bool:
             a = self._pal_attrspec.get(a, a)
             return isinstance(a, AttrSpec) and (a.standout or a.underline)
 

--- a/urwid/vterm.py
+++ b/urwid/vterm.py
@@ -1437,11 +1437,11 @@ class TermCanvas(Canvas):
     def content(
         self,
         trim_left: int = 0,
-        trim_right: int = 0,
+        trim_top: int = 0,
         cols: int | None = None,
         rows: int | None = None,
         attr=None,
-    ):
+    ) -> Iterable[list[tuple[object, object, bytes]]]:
         if self.scrolling_up == 0:
             yield from self.term
         else:


### PR DESCRIPTION
##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
