### PR TITLE
Typing: annotate text_layout and extend `Text`/`Edit`

### DIFF
--- a/urwid/canvas.py
+++ b/urwid/canvas.py
@@ -213,22 +213,9 @@ class Canvas:
     _finalized_error = CanvasError(
         "This canvas has been finalized. Use CompositeCanvas to wrap this canvas if you need to make changes."
     )
-    _renamed_error = CanvasError(
-        "The old Canvas class is now called TextCanvas. Canvas is now the base class for all canvas classes."
-    )
 
-    def __init__(
-        self,
-        value1: typing.Any = None,
-        value2: typing.Any = None,
-        value3: typing.Any = None,
-    ) -> None:
-        """
-        value1, value2, value3 -- if not None, raise a helpful error:
-            the old Canvas class is now called TextCanvas.
-        """
-        if value1 is not None:
-            raise self._renamed_error
+    def __init__(self) -> None:
+        """Base Canvas class"""
         self._widget_info = None
         self.coords: dict[str, tuple[int, int, tuple[Widget, int, int]]] = {}
         self.shortcuts: dict[str, str] = {}
@@ -391,8 +378,8 @@ class TextCanvas(Canvas):
     def __init__(
         self,
         text: Sequence[bytes] | None = None,
-        attr=None,
-        cs=None,
+        attr: Hashable | None = None,
+        cs: Literal["0", "U"] | None = None,
         cursor: tuple[int, int] | None = None,
         maxcol: int | None = None,
         check_width: bool = True,
@@ -1326,7 +1313,12 @@ def CanvasJoin(canvas_info: Iterable[tuple[Canvas, typing.Any, bool, int]]) -> C
     return joined_canvas
 
 
-def apply_text_layout(text: bytes, attr, ls, maxcol: int) -> TextCanvas:
+def apply_text_layout(
+    text: bytes,
+    attr: list[tuple[Hashable, int]],
+    ls: list[list[tuple[int, int, int | bytes] | tuple[int, int | None]]],
+    maxcol: int,
+) -> TextCanvas:
     t = []
     a = []
     c = []
@@ -1338,7 +1330,7 @@ def apply_text_layout(text: bytes, attr, ls, maxcol: int) -> TextCanvas:
     aw.k = 0  # counter for moving through elements of a
     aw.off = 0  # current offset into text of attr[ak]
 
-    def arange(start_offs: int, end_offs: int):
+    def arange(start_offs: int, end_offs: int) -> list[tuple[Hashable | None, int]]:
         """Return an attribute list for the range of text specified."""
         if start_offs < aw.off:
             aw.k = 0

--- a/urwid/widget/edit.py
+++ b/urwid/widget/edit.py
@@ -10,6 +10,8 @@ from urwid.split_repr import remove_defaults
 from urwid.util import decompose_tagmarkup, is_wide_char, move_next_char, move_prev_char
 
 if typing.TYPE_CHECKING:
+    from collections.abc import Hashable
+
     from typing_extensions import Literal
 
     from urwid.canvas import TextCanvas
@@ -62,15 +64,15 @@ class Edit(Text):
 
     def __init__(
         self,
-        caption="",
-        edit_text: str | bytes = "",
+        caption: str | tuple[Hashable, str] | list[str | tuple[Hashable, str]] = "",
+        edit_text: str = "",
         multiline: bool = False,
         align: Literal["left", "center", "right"] | Align = Align.LEFT,
         wrap: Literal["space", "any", "clip", "ellipsis"] | WrapMode = WrapMode.SPACE,
         allow_tab: bool = False,
         edit_pos: int | None = None,
-        layout=None,
-        mask: str | bytes | None = None,
+        layout: text_layout.TextLayout = None,
+        mask: str | None = None,
     ) -> None:
         """
         :param caption: markup for caption preceding edit_text, see
@@ -130,7 +132,7 @@ class Edit(Text):
         attrs = dict(super()._repr_attrs(), edit_pos=self._edit_pos)
         return remove_defaults(attrs, Edit.__init__)
 
-    def get_text(self):
+    def get_text(self) -> tuple[str | bytes, list[tuple[Hashable, int]]]:
         """
         Returns ``(text, display attributes)``. See :meth:`Text.get_text`
         for details.
@@ -150,7 +152,7 @@ class Edit(Text):
 
         return self._caption + (self._mask * len(self._edit_text)), self._attrib
 
-    def set_text(self, markup) -> None:
+    def set_text(self, markup: tuple[str, list[tuple[Hashable, int]]]) -> None:
         """
         Not supported by Edit widget.
 
@@ -206,7 +208,7 @@ class Edit(Text):
 
         return pref_col
 
-    def set_caption(self, caption) -> None:
+    def set_caption(self, caption: str | tuple[Hashable, str] | list[str | tuple[Hashable, str]]) -> None:
         """
         Set the caption markup for this widget.
 
@@ -274,7 +276,7 @@ class Edit(Text):
         """,
     )
 
-    def set_mask(self, mask: str | bytes | None) -> None:
+    def set_mask(self, mask: str | None) -> None:
         """
         Set the character for masking text away.
 
@@ -285,7 +287,7 @@ class Edit(Text):
         self._mask = mask
         self._invalidate()
 
-    def set_edit_text(self, text: str | bytes) -> None:
+    def set_edit_text(self, text: str) -> None:
         """
         Set the edit text for this widget.
 
@@ -333,7 +335,7 @@ class Edit(Text):
         """,
     )
 
-    def insert_text(self, text: str | bytes) -> None:
+    def insert_text(self, text: str) -> None:
         """
         Insert text at the cursor position and update cursor.
         This method is used by the keypress() method when inserting
@@ -371,7 +373,7 @@ class Edit(Text):
             return text.encode("ascii")  # follow python2's implicit conversion
         return text.decode("ascii")
 
-    def insert_text_result(self, text: str | bytes) -> tuple[str | bytes, int]:
+    def insert_text_result(self, text: str) -> tuple[str | bytes, int]:
         """
         Return result of insert_text(text) without actually performing the
         insertion.  Handy for pre-validation.
@@ -610,7 +612,11 @@ class Edit(Text):
         #    d.coords['highlight'] = [ hstart, hstop ]
         return canv
 
-    def get_line_translation(self, maxcol: int, ta=None):
+    def get_line_translation(
+        self,
+        maxcol: int,
+        ta: tuple[str | bytes, list[tuple[Hashable, int]]] | None = None,
+    ) -> list[list[tuple[int, int, int | bytes] | tuple[int, int | None]]]:
         trans = super().get_line_translation(maxcol, ta)
         if not self._shift_view_to_cursor:
             return trans

--- a/urwid/widget/text.py
+++ b/urwid/widget/text.py
@@ -11,6 +11,8 @@ from .constants import Align, Sizing, WrapMode
 from .widget import Widget, WidgetError
 
 if typing.TYPE_CHECKING:
+    from collections.abc import Hashable
+
     from typing_extensions import Literal
 
     from urwid.canvas import TextCanvas
@@ -32,7 +34,7 @@ class Text(Widget):
 
     def __init__(
         self,
-        markup,
+        markup: str | tuple[Hashable, str] | list[str | tuple[Hashable, str]],
         align: Literal["left", "center", "right"] | Align = Align.LEFT,
         wrap: Literal["space", "any", "clip", "ellipsis"] | WrapMode = WrapMode.SPACE,
         layout: text_layout.TextLayout | None = None,
@@ -98,7 +100,7 @@ class Text(Widget):
         self._cache_maxcol = None
         super()._invalidate()
 
-    def set_text(self, markup):
+    def set_text(self, markup: str | tuple[Hashable, str] | list[str | tuple[Hashable, str]]) -> None:
         """
         Set content of text widget.
 
@@ -118,7 +120,7 @@ class Text(Widget):
         self._text, self._attrib = decompose_tagmarkup(markup)
         self._invalidate()
 
-    def get_text(self):
+    def get_text(self) -> tuple[str | bytes, list[tuple[Hashable, int]]]:
         """
         :returns: (*text*, *display attributes*)
 
@@ -139,7 +141,7 @@ class Text(Widget):
         return self._text, self._attrib
 
     @property
-    def text(self) -> str:
+    def text(self) -> str | bytes:
         """
         Read-only property returning the complete bytes/unicode content
         of this widget
@@ -147,7 +149,7 @@ class Text(Widget):
         return self.get_text()[0]
 
     @property
-    def attrib(self):
+    def attrib(self) -> list[tuple[Hashable, int]]:
         """
         Read-only property returning the run-length encoded display
         attributes of this widget
@@ -212,7 +214,7 @@ class Text(Widget):
         self,
         align: Literal["left", "center", "right"] | Align,
         wrap: Literal["space", "any", "clip", "ellipsis"] | WrapMode,
-        layout=None,
+        layout: text_layout.TextLayout | None = None,
     ) -> None:
         """
         Set the text layout object, alignment and wrapping modes at
@@ -278,11 +280,14 @@ class Text(Widget):
         (maxcol,) = size
         return len(self.get_line_translation(maxcol))
 
-    def get_line_translation(self, maxcol: int, ta=None):
+    def get_line_translation(
+        self,
+        maxcol: int,
+        ta: tuple[str | bytes, list[tuple[Hashable, int]]] | None = None,
+    ) -> list[list[tuple[int, int, int | bytes] | tuple[int, int | None]]]:
         """
         Return layout structure used to map self.text to a canvas.
-        This method is used internally, but may be useful for
-        debugging custom layout classes.
+        This method is used internally, but may be useful for debugging custom layout classes.
 
         :param maxcol: columns available for display
         :type maxcol: int
@@ -294,7 +299,11 @@ class Text(Widget):
             self._update_cache_translation(maxcol, ta)
         return self._cache_translation
 
-    def _update_cache_translation(self, maxcol: int, ta) -> None:
+    def _update_cache_translation(
+        self,
+        maxcol: int,
+        ta: tuple[str | bytes, list[tuple[Hashable, int]]] | None,
+    ) -> None:
         if ta:
             text, _attr = ta
         else:


### PR DESCRIPTION
* `Canvas`: do not accept any arguments in the constructor. Arguments deprecated many years ago, renamed error was raise before.
* `StandardTextLayout`: split `calculate_text_segments` scenario for `clip` and `ellipsis` from `any` and `space`. Extremely long methods with 2 main branches. Use human-friendly variable naming.
* `Text`/`Edit`: In several methods intentionally do not mark `bytes` as valid argument: Due to the amount of transcoding, `str` is absolute priority

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

