### PR TITLE
Fix render regression: khal Padding widh > size

### DIFF
--- a/tests/test_padding.py
+++ b/tests/test_padding.py
@@ -161,6 +161,14 @@ class PaddingTest(unittest.TestCase):
         widget.keypress((), "right")
         self.assertEqual("Cancel", body.focus.focus.label)
 
+    def test_insufficient_space(self):
+        width = 10
+        widget = urwid.Padding(urwid.Text("Some text"), width=width)
+        with self.assertWarns(urwid.widget.PaddingWarning) as ctx:
+            canvas = widget.render((width - 1,))
+        self.assertEqual("Some text", str(canvas))
+        self.assertEqual(width - 1, canvas.cols())
+
     def ptest(self, desc, align, width, maxcol, left, right, min_width=None):
         p = urwid.Padding(None, align, width, min_width)
         l, r = p.padding_values((maxcol,), False)

--- a/urwid/widget/padding.py
+++ b/urwid/widget/padding.py
@@ -316,10 +316,17 @@ class Padding(WidgetDecoration[WrappedWidget]):
 
         if self._width_type == WHSettings.CLIP:
             canv = self._original_widget.render((), focus)
+        elif size:
+            maxcol = size[0] - (left + right)
+            if self._width_type == WHSettings.GIVEN and maxcol < self._width_amount:
+                warnings.warn(
+                    f"{self}.render(size={size}, focus={focus}): too narrow size ({maxcol!r} < {self._width_amount!r})",
+                    PaddingWarning,
+                    stacklevel=3,
+                )
+            canv = self._original_widget.render((maxcol,) + size[1:], focus)
         elif self._width_type == WHSettings.GIVEN:
             canv = self._original_widget.render((self._width_amount,) + size[1:], focus)
-        elif size:
-            canv = self._original_widget.render((size[0] - (left + right),) + size[1:], focus)
         else:
             canv = self._original_widget.render((), focus)
 


### PR DESCRIPTION
Allow to render `Padding` with GIVEN width > size. 
Warn about incorrect size

Fix: pimutils/khal#1334

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
