### PR TITLE
Fix regression in the `LineBox._w`: should be a property

### DIFF
--- a/urwid/widget/line_box.py
+++ b/urwid/widget/line_box.py
@@ -167,6 +167,7 @@ class LineBox(WidgetDecoration[WrappedWidget], delegate_to_widget_mixin("_wrappe
 
         super().__init__(original_widget)
 
+    @property
     def _w(self) -> Pile:
         return self._wrapped_widget
 


### PR DESCRIPTION
##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

