### PR TITLE
Enable `refurb` check in tox

### DIFF
--- a/examples/calc.py
+++ b/examples/calc.py
@@ -705,9 +705,7 @@ class CalcDisplay:
     def column_empty(self, letter) -> bool:
         """Return True if the column passed is empty."""
 
-        i = COLUMN_KEYS.index(letter)
-        col = self.columns.contents[i][0]
-        return col.is_empty()
+        return self.columns.contents[COLUMN_KEYS.index(letter)][0].is_empty()
 
     def delete_column(self, letter) -> None:
         """Delete the column with the given letter."""

--- a/examples/dialog.py
+++ b/examples/dialog.py
@@ -49,7 +49,7 @@ class DialogDisplay:
         ("focustext", "light gray", "dark blue"),
     ]
 
-    def __init__(self, text, height: int, width: int, body=None) -> None:
+    def __init__(self, text, height: int | str, width: int | str, body=None) -> None:
         width = int(width)
         if width <= 0:
             width = (urwid.RELATIVE, 80)
@@ -108,7 +108,7 @@ class DialogDisplay:
 
 
 class InputDialogDisplay(DialogDisplay):
-    def __init__(self, text, height: int, width: int) -> None:
+    def __init__(self, text, height: int | str, width: int | str) -> None:
         self.edit = urwid.Edit()
         body = urwid.ListBox(urwid.SimpleListWalker([self.edit]))
         body = urwid.AttrMap(body, "selectable", "focustext")
@@ -132,7 +132,7 @@ class InputDialogDisplay(DialogDisplay):
 
 
 class TextDialogDisplay(DialogDisplay):
-    def __init__(self, file: str, height: int, width: int) -> None:
+    def __init__(self, file: str, height: int | str, width: int | str) -> None:
         with open(file, encoding="utf-8") as f:
             lines = [urwid.Text(line.rstrip()) for line in f]
         # read the whole file (being slow, not lazy this time)
@@ -153,8 +153,8 @@ class ListDialogDisplay(DialogDisplay):
     def __init__(
         self,
         text,
-        height: int,
-        width: int,
+        height: int | str,
+        width: int | str,
         constr,
         items,
         has_default: bool,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -292,3 +292,19 @@ good-dunder-names = [
   "_contents__setitem__",
   "_contents__delitem__",
 ]
+
+[tool.refurb]
+python_version = "3.7"
+ignore = ["FURB104", "FURB144", "FURB146"]
+
+[[tool.refurb.amend]]
+path = "urwid/__init__.py"
+ignore = ["FURB107"]
+
+[[tool.refurb.amend]]
+path = "urwid/display/__init__.py"
+ignore = ["FURB107"]
+
+[[tool.refurb.amend]]
+path = "urwid/event_loop/__init__.py"
+ignore = ["FURB107"]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3{7,8,9,10,11},pypy3,isort,black,ruff
+envlist = py3{7,8,9,10,11},pypy3,isort,black,ruff,pylint,refurb
 skip_missing_interpreters = True
 
 [testenv]
@@ -54,3 +54,8 @@ deps =
     PyGObject
     pylint
 commands = pylint urwid
+
+[testenv:refurb]
+depends = black,isort
+deps = refurb
+commands = refurb urwid examples

--- a/urwid/canvas.py
+++ b/urwid/canvas.py
@@ -811,7 +811,7 @@ class CompositeCanvas(Canvas):
             if left > 0:
                 new_top_cviews = [(0, 0, left, rows, None, blank_canvas), *top_cviews]
             else:
-                new_top_cviews = top_cviews[:]  # copy
+                new_top_cviews = top_cviews.copy()
 
             if right > 0:
                 new_top_cviews.append((0, 0, right, rows, None, blank_canvas))
@@ -911,7 +911,7 @@ class CompositeCanvas(Canvas):
                 if cv[4] is None:
                     new_cviews.append(cv[:4] + (mapping,) + cv[5:])
                 else:
-                    combined = dict(mapping)
+                    combined = mapping.copy()
                     combined.update([(k, mapping.get(v, v)) for k, v in cv[4].items()])
                     new_cviews.append(cv[:4] + (combined,) + cv[5:])
             shards.append((num_rows, new_cviews))

--- a/urwid/display/_raw_display_base.py
+++ b/urwid/display/_raw_display_base.py
@@ -173,7 +173,7 @@ class Screen(BaseScreen, RealTerminal):
         After calling this function get_input will include mouse
         click events along with keystrokes.
         """
-        enable = bool(enable)
+        enable = bool(enable)  # noqa: FURB123,RUF100
         if enable == self._mouse_tracking_enabled:
             return
 

--- a/urwid/display/curses.py
+++ b/urwid/display/curses.py
@@ -124,7 +124,7 @@ class Screen(BaseScreen, RealTerminal):
         After calling this function get_input will include mouse
         click events along with keystrokes.
         """
-        enable = bool(enable)
+        enable = bool(enable)  # noqa: FURB123,RUF100
         if enable == self._mouse_tracking_enabled:
             return
 

--- a/urwid/display/escape.py
+++ b/urwid/display/escape.py
@@ -203,7 +203,7 @@ class KeyqueueTrie:
         s: str,
         result: str,
     ) -> None:
-        if not isinstance(root, MutableMapping) or len(s) <= 0:
+        if not isinstance(root, MutableMapping) or not s:
             raise RuntimeError("trie conflict detected")
 
         if ord(s[0]) in root:
@@ -215,7 +215,6 @@ class KeyqueueTrie:
             self.add(d, s[1:], result)
             return
         root[ord(s)] = result
-        return
 
     def get(self, keys, more_available: bool):
         result = self.get_recurse(self.data, keys, more_available)

--- a/urwid/display/html_fragment.py
+++ b/urwid/display/html_fragment.py
@@ -24,6 +24,7 @@ HTML PRE-based UI implementation
 
 from __future__ import annotations
 
+import html
 import typing
 
 from urwid import util
@@ -185,10 +186,7 @@ def html_span(s, aspec, cursor: int = -1):
 
 def html_escape(text: str) -> str:
     """Escape text so that it will be displayed safely within HTML"""
-    text = text.replace("&", "&amp;")
-    text = text.replace("<", "&lt;")
-    text = text.replace(">", "&gt;")
-    return text
+    return html.escape(text)
 
 
 def screenshot_init(sizes: list[tuple[int, int]], keys: list[list[str]]) -> None:

--- a/urwid/display/web.py
+++ b/urwid/display/web.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import dataclasses
 import glob
+import html
 import os
 import pathlib
 import random
@@ -318,7 +319,7 @@ class Screen(BaseScreen):
         y = -1
         for row in canvas.content():
             y += 1
-            l_row = list(row)
+            l_row = row.copy()
 
             line = []
 
@@ -485,10 +486,7 @@ def code_span(s, fg, bg, cursor=-1):
 
 def html_escape(text):
     """Escape text so that it will be displayed safely within HTML"""
-    text = text.replace("&", "&amp;")
-    text = text.replace("<", "&lt;")
-    text = text.replace(">", "&gt;")
-    return text
+    return html.escape(text)
 
 
 def is_web_request():

--- a/urwid/event_loop/main_loop.py
+++ b/urwid/event_loop/main_loop.py
@@ -286,8 +286,7 @@ class MainLoop:
 
             def cb() -> None:
                 data = os.read(pipe_rd, PIPE_BUFFER_READ_SIZE)
-                rval = callback(data)
-                if rval is False:
+                if not callback(data):
                     self.event_loop.remove_watch_file(watch_handle)
                     os.close(pipe_rd)
 

--- a/urwid/monitored_list.py
+++ b/urwid/monitored_list.py
@@ -185,11 +185,11 @@ class MonitoredFocusList(MonitoredList[_T], typing.Generic[_T]):
         if not self:
             self._focus = 0
             return
+        if not isinstance(index, int):
+            raise TypeError("index must be an integer")
         if index < 0 or index >= len(self):
             raise IndexError(f"focus index is out of range: {index}")
-        if index != int(index):
-            raise IndexError(f"invalid focus index: {index}")
-        index = int(index)
+
         if index != self._focus:
             self._focus_changed(index)
         self._focus = index

--- a/urwid/signals.py
+++ b/urwid/signals.py
@@ -180,8 +180,7 @@ class Signals:
         # Just generate an arbitrary (but unique) key
         key = Key()
 
-        signals = setdefaultattr(obj, self._signal_attr, {})
-        handlers = signals.setdefault(name, [])
+        handlers = setdefaultattr(obj, self._signal_attr, {}).setdefault(name, [])
 
         # Remove the signal handler when any of the weakref'd arguments
         # are garbage collected. Note that this means that the handlers
@@ -277,8 +276,7 @@ class Signals:
         If the callback is not connected or already disconnected, this
         function will simply do nothing.
         """
-        signals = setdefaultattr(obj, self._signal_attr, {})
-        handlers = signals.get(name, [])
+        handlers = setdefaultattr(obj, self._signal_attr, {}).get(name, [])
         handlers[:] = [h for h in handlers if h[0] is not key]
 
     def emit(self, obj, name: Hashable, *args) -> bool:
@@ -295,8 +293,7 @@ class Signals:
         This function returns True if any of the callbacks returned True.
         """
         result = False
-        signals = getattr(obj, self._signal_attr, {})
-        handlers = signals.get(name, [])
+        handlers = getattr(obj, self._signal_attr, {}).get(name, [])
         for _key, callback, user_arg, (weak_args, user_args) in handlers:
             result |= self._call_callback(callback, user_arg, weak_args, user_args, args)
         return result

--- a/urwid/treetools.py
+++ b/urwid/treetools.py
@@ -249,9 +249,7 @@ class TreeNode:
         if self.get_depth() == 0:
             return None
 
-        key = self.get_key()
-        parent = self.get_parent()
-        return parent.get_child_index(key)
+        return self.get_parent().get_child_index(self.get_key())
 
     def get_key(self):
         return self._key
@@ -326,8 +324,7 @@ class ParentNode(TreeNode):
     def get_child_widget(self, key) -> TreeWidget:
         """Return the widget for a given key.  Create if necessary."""
 
-        child = self.get_child_node(key)
-        return child.get_widget()
+        return self.get_child_node(key).get_widget()
 
     def get_child_node(self, key, reload: bool = False) -> TreeNode:
         """Return the child node for a given key. Create if necessary."""
@@ -425,16 +422,14 @@ class TreeWalker(urwid.ListWalker):
 
     # pylint: disable=arguments-renamed  # its bad, but we should not change API
     def get_next(self, start_from) -> tuple[TreeWidget, TreeNode] | tuple[None, None]:
-        widget = start_from.get_widget()
-        target = widget.next_inorder()
+        target = start_from.get_widget().next_inorder()
         if target is None:
             return None, None
 
         return target, target.get_node()
 
     def get_prev(self, start_from) -> tuple[TreeWidget, TreeNode] | tuple[None, None]:
-        widget = start_from.get_widget()
-        target = widget.prev_inorder()
+        target = start_from.get_widget().prev_inorder()
         if target is None:
             return None, None
 
@@ -513,9 +508,7 @@ class TreeListBox(urwid.ListBox):
 
         maxrow, _maxcol = size
         _widget, pos = self.body.get_focus()
-        rootnode = pos.get_root()
-        rootwidget = rootnode.get_widget()
-        lastwidget = rootwidget.last_child()
+        lastwidget = pos.get_root().get_widget().last_child()
         if lastwidget:
             lastnode = lastwidget.get_node()
 

--- a/urwid/widget/attr_map.py
+++ b/urwid/widget/attr_map.py
@@ -76,7 +76,7 @@ class AttrMap(delegate_to_widget_mixin("_original_widget"), WidgetDecoration[Wra
 
     def _repr_attrs(self) -> dict[str, typing.Any]:
         # only include the focus_attr when it takes effect (not None)
-        d = dict(super()._repr_attrs(), attr_map=self._attr_map)
+        d = {**super()._repr_attrs(), "attr_map": self._attr_map}
         if self._focus_map is not None:
             d["focus_map"] = self._focus_map
         return d

--- a/urwid/widget/attr_wrap.py
+++ b/urwid/widget/attr_wrap.py
@@ -43,7 +43,7 @@ class AttrWrap(AttrMap):
 
     def _repr_attrs(self) -> dict[str, typing.Any]:
         # only include the focus_attr when it takes effect (not None)
-        d = dict(super()._repr_attrs(), attr=self.attr)
+        d = {**super()._repr_attrs(), "attr": self.attr}
         del d["attr_map"]
         if "focus_map" in d:
             del d["focus_map"]

--- a/urwid/widget/box_adapter.py
+++ b/urwid/widget/box_adapter.py
@@ -42,7 +42,7 @@ class BoxAdapter(WidgetDecoration[WrappedWidget]):
         self.height = height
 
     def _repr_attrs(self) -> dict[str, typing.Any]:
-        return dict(super()._repr_attrs(), height=self.height)
+        return {**super()._repr_attrs(), "height": self.height}
 
     # originally stored as box_widget, keep for compatibility
     @property

--- a/urwid/widget/edit.py
+++ b/urwid/widget/edit.py
@@ -129,7 +129,7 @@ class Edit(Text):
         )
 
     def _repr_attrs(self) -> dict[str, typing.Any]:
-        attrs = dict(super()._repr_attrs(), edit_pos=self._edit_pos)
+        attrs = {**super()._repr_attrs(), "edit_pos": self._edit_pos}
         return remove_defaults(attrs, Edit.__init__)
 
     def get_text(self) -> tuple[str | bytes, list[tuple[Hashable, int]]]:
@@ -592,7 +592,7 @@ class Edit(Text):
         >>> c.cursor
         (5, 0)
         """
-        self._shift_view_to_cursor = bool(focus)
+        self._shift_view_to_cursor = bool(focus)  # noqa: FURB123,RUF100
 
         canv: TextCanvas | CompositeCanvas = super().render(size, focus)
         if focus:

--- a/urwid/widget/filler.py
+++ b/urwid/widget/filler.py
@@ -149,14 +149,14 @@ class Filler(WidgetDecoration[WrappedWidget]):
         raise FillerError("Method 'rows' not supported for BOX widgets")  # pragma: no cover
 
     def _repr_attrs(self) -> dict[str, typing.Any]:
-        attrs = dict(
-            super()._repr_attrs(),
-            valign=simplify_valign(self.valign_type, self.valign_amount),
-            height=simplify_height(self.height_type, self.height_amount),
-            top=self.top,
-            bottom=self.bottom,
-            min_height=self.min_height,
-        )
+        attrs = {
+            **super()._repr_attrs(),
+            "valign": simplify_valign(self.valign_type, self.valign_amount),
+            "height": simplify_height(self.height_type, self.height_amount),
+            "top": self.top,
+            "bottom": self.bottom,
+            "min_height": self.min_height,
+        }
         return remove_defaults(attrs, Filler.__init__)
 
     @property
@@ -379,8 +379,7 @@ def calculate_top_bottom_filler(
     else:
         height = height_amount
 
-    standard_alignments = {VAlign.TOP: 0, VAlign.MIDDLE: 50, VAlign.BOTTOM: 100}
-    valign = standard_alignments.get(valign_type, valign_amount)
+    valign = {VAlign.TOP: 0, VAlign.MIDDLE: 50, VAlign.BOTTOM: 100}.get(valign_type, valign_amount)
 
     # add the remainder of top/bottom to the filler
     filler = maxrow - height - top - bottom

--- a/urwid/widget/grid_flow.py
+++ b/urwid/widget/grid_flow.py
@@ -57,7 +57,7 @@ class GridFlow(WidgetWrap[Pile], WidgetContainerMixin, WidgetContainerListConten
 
         for idx, widget in enumerate(cells):
             prepared_contents.append((widget, (WHSettings.GIVEN, cell_width)))
-            if focus_position < 0 and (widget == focus or idx == focus or (focus is None and widget.selectable())):
+            if focus_position < 0 and (focus in {widget, idx} or (focus is None and widget.selectable())):
                 focus_position = idx
 
         focus_position = max(focus_position, 0)

--- a/urwid/widget/padding.py
+++ b/urwid/widget/padding.py
@@ -175,14 +175,14 @@ class Padding(WidgetDecoration[WrappedWidget]):
         return frozenset(sizing)
 
     def _repr_attrs(self) -> dict[str, typing.Any]:
-        attrs = dict(
-            super()._repr_attrs(),
-            align=self.align,
-            width=self.width,
-            left=self.left,
-            right=self.right,
-            min_width=self.min_width,
-        )
+        attrs = {
+            **super()._repr_attrs(),
+            "align": self.align,
+            "width": self.width,
+            "left": self.left,
+            "right": self.right,
+            "min_width": self.min_width,
+        }
         return remove_defaults(attrs, Padding.__init__)
 
     @property
@@ -572,8 +572,7 @@ def calculate_left_right_padding(
     else:
         width = width_amount
 
-    standard_alignments = {Align.LEFT: 0, Align.CENTER: 50, Align.RIGHT: 100}
-    align = standard_alignments.get(align_type, align_amount)
+    align = {Align.LEFT: 0, Align.CENTER: 50, Align.RIGHT: 100}.get(align_type, align_amount)
 
     # add the remainder of left/right the padding
     padding = maxcol - width - left - right

--- a/urwid/widget/progress_bar.py
+++ b/urwid/widget/progress_bar.py
@@ -112,8 +112,7 @@ class ProgressBar(Widget):
         """
         # pylint: disable=protected-access
         (maxcol,) = size
-        txt = Text(self.get_text(), self.text_align, WrapMode.CLIP)
-        c = txt.render((maxcol,))
+        c = Text(self.get_text(), self.text_align, WrapMode.CLIP).render((maxcol,))
 
         cf = float(self.current) * maxcol / self.done
         ccol_dirty = int(cf)

--- a/urwid/widget/text.py
+++ b/urwid/widget/text.py
@@ -89,11 +89,11 @@ class Text(Widget):
         return [*first, rest]
 
     def _repr_attrs(self) -> dict[str, typing.Any]:
-        attrs = dict(
-            super()._repr_attrs(),
-            align=self._align_mode,
-            wrap=self._wrap_mode,
-        )
+        attrs = {
+            **super()._repr_attrs(),
+            "align": self._align_mode,
+            "wrap": self._wrap_mode,
+        }
         return remove_defaults(attrs, Text.__init__)
 
     def _invalidate(self) -> None:

--- a/urwid/widget/wimp.py
+++ b/urwid/widget/wimp.py
@@ -289,8 +289,8 @@ class CheckBox(WidgetWrap[Columns]):
     def _repr_words(self) -> list[str]:
         return [*super()._repr_words(), repr(self.label)]
 
-    def _repr_attrs(self):
-        return dict(super()._repr_attrs(), state=self.state)
+    def _repr_attrs(self) -> dict[str, typing.Any]:
+        return {**super()._repr_attrs(), "state": self.state}
 
     def set_label(self, label: str | tuple[Hashable, str] | list[str | tuple[Hashable, str]]):
         """


### PR DESCRIPTION
* remove manual HTML escaping in favor of stdlib
* useless `return`
* dict comprehensions

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
*(P. S. If this pull requests fixes an existing issue, please specify which one.)*

