### PR TITLE
Fix ellipsis encoding in the text layout

### DIFF
--- a/tests/test_text_layout.py
+++ b/tests/test_text_layout.py
@@ -387,3 +387,18 @@ class Pos2CoordsTest(unittest.TestCase):
             for pos, a in zip(self.pos_list, answer):
                 r = text_layout.calc_coords(self.text, t, pos)
                 self.assertEqual(a, r, f"{t!r} got: {r!r} expected: {a!r}")
+
+
+class TestEllipsis(unittest.TestCase):
+    def test_ellipsis_encoding_support(self):
+        widget = urwid.Text("Test label", wrap=urwid.WrapMode.ELLIPSIS)
+
+        with self.subTest("Unicode"), set_temporary_encoding("utf-8"):
+            widget._invalidate()
+            canvas = widget.render((5,))
+            self.assertEqual("Test…", str(canvas))
+
+        with self.subTest("ascii"), set_temporary_encoding("ascii"):
+            widget._invalidate()
+            canvas = widget.render((5,))
+            self.assertEqual("Te...", str(canvas))


### PR DESCRIPTION
* Use `...` substitution in case of `…` encoding fails and cache result
* * do not encode multiple times the same value
* * handle unsupported encodings
Fix: #496

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

