### PR TITLE
Fix ListBox `MAX_LEFT`/`MAX_RIGHT` report for `keypress` as unhandled

### DIFF
--- a/urwid/listbox.py
+++ b/urwid/listbox.py
@@ -1203,15 +1203,13 @@ class ListBox(Widget, WidgetContainerMixin):
 
         return key
 
-    def _keypress_max_left(self, size: tuple[int, int]) -> bool:
+    def _keypress_max_left(self, size: tuple[int, int]) -> None:
         self.focus_position = next(iter(self.body.positions()))
         self.set_focus_valign(VAlign.TOP)
-        return True
 
-    def _keypress_max_right(self, size: tuple[int, int]) -> bool:
+    def _keypress_max_right(self, size: tuple[int, int]) -> None:
         self.focus_position = next(iter(self.body.positions(reverse=True)))
         self.set_focus_valign(VAlign.BOTTOM)
-        return True
 
     def _keypress_up(self, size: tuple[int, int]) -> bool | None:
         (maxcol, maxrow) = size

--- a/urwid/treetools.py
+++ b/urwid/treetools.py
@@ -491,10 +491,10 @@ class TreeListBox(urwid.ListBox):
         self.change_focus(size, pos.get_parent())
 
     def _keypress_max_left(self, size: tuple[int, int]) -> None:
-        return self.focus_home(size)
+        self.focus_home(size)
 
     def _keypress_max_right(self, size: tuple[int, int]) -> None:
-        return self.focus_end(size)
+        self.focus_end(size)
 
     def focus_home(self, size: tuple[int, int]) -> None:
         """Move focus to very top."""


### PR DESCRIPTION
Fix: #305

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

