### PR TITLE
Feature: support widget instance as Frame focus part in constructor

### DIFF
--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,51 +1,8 @@
 from __future__ import annotations
 
 import unittest
-from unittest import mock
 
 import urwid
-
-
-class FrameTest(unittest.TestCase):
-    def ftbtest(self, desc, focus_part, header_rows, footer_rows, size, focus, top, bottom):
-        class FakeWidget:
-            def __init__(self, rows, want_focus):
-                self.ret_rows = rows
-                self.want_focus = want_focus
-
-            def rows(self, size, focus=False):
-                assert self.want_focus == focus
-                return self.ret_rows
-
-        header = footer = None
-        if header_rows:
-            header = FakeWidget(header_rows, focus and focus_part == "header")
-        if footer_rows:
-            footer = FakeWidget(footer_rows, focus and focus_part == "footer")
-
-        f = urwid.Frame(None, header, footer, focus_part)
-
-        rval = f.frame_top_bottom(size, focus)
-        exp = (top, bottom), (header_rows, footer_rows)
-        assert exp == rval, f"{desc} expected {exp!r} but got {rval!r}"
-
-    def test(self):
-        self.ftbtest("simple", "body", 0, 0, (9, 10), True, 0, 0)
-        self.ftbtest("simple h", "body", 3, 0, (9, 10), True, 3, 0)
-        self.ftbtest("simple f", "body", 0, 3, (9, 10), True, 0, 3)
-        self.ftbtest("simple hf", "body", 3, 3, (9, 10), True, 3, 3)
-        self.ftbtest("almost full hf", "body", 4, 5, (9, 10), True, 4, 5)
-        self.ftbtest("full hf", "body", 5, 5, (9, 10), True, 4, 5)
-        self.ftbtest("x full h+1f", "body", 6, 5, (9, 10), False, 4, 5)
-        self.ftbtest("full h+1f", "body", 6, 5, (9, 10), True, 4, 5)
-        self.ftbtest("full hf+1", "body", 5, 6, (9, 10), True, 3, 6)
-        self.ftbtest("F full h+1f", "footer", 6, 5, (9, 10), True, 5, 5)
-        self.ftbtest("F full hf+1", "footer", 5, 6, (9, 10), True, 4, 6)
-        self.ftbtest("F full hf+5", "footer", 5, 11, (9, 10), True, 0, 10)
-        self.ftbtest("full hf+5", "body", 5, 11, (9, 10), True, 0, 9)
-        self.ftbtest("H full hf+1", "header", 5, 6, (9, 10), True, 5, 5)
-        self.ftbtest("H full h+1f", "header", 6, 5, (9, 10), True, 6, 4)
-        self.ftbtest("H full h+5f", "header", 11, 5, (9, 10), True, 10, 0)
 
 
 class WidgetSquishTest(unittest.TestCase):
@@ -141,43 +98,6 @@ class CommonContainerTest(unittest.TestCase):
         lb.focus_position = 0
         self.assertRaises(IndexError, lambda: setattr(lb, "focus_position", -1))
         self.assertRaises(IndexError, lambda: setattr(lb, "focus_position", 2))
-
-    def test_frame(self):
-        s1 = urwid.SolidFill("1")
-
-        f = urwid.Frame(s1)
-        self.assertEqual(f.focus, s1)
-        self.assertEqual(f.focus_position, "body")
-        self.assertRaises(IndexError, lambda: setattr(f, "focus_position", None))
-        self.assertRaises(IndexError, lambda: setattr(f, "focus_position", "header"))
-
-        t1 = urwid.Text("one")
-        t2 = urwid.Text("two")
-        t3 = urwid.Text("three")
-        f = urwid.Frame(s1, t1, t2, "header")
-        self.assertEqual(f.focus, t1)
-        self.assertEqual(f.focus_position, "header")
-        f.focus_position = "footer"
-        self.assertEqual(f.focus, t2)
-        self.assertEqual(f.focus_position, "footer")
-        self.assertRaises(IndexError, lambda: setattr(f, "focus_position", -1))
-        self.assertRaises(IndexError, lambda: setattr(f, "focus_position", 2))
-        del f.contents["footer"]
-        self.assertEqual(f.footer, None)
-        self.assertEqual(f.focus_position, "body")
-        f.contents.update(footer=(t3, None), header=(t2, None))
-        self.assertEqual(f.header, t2)
-        self.assertEqual(f.footer, t3)
-
-        def set1():
-            f.contents["body"] = t1
-
-        self.assertRaises(urwid.FrameError, set1)
-
-        def set2():
-            f.contents["body"] = (t1, "given")
-
-        self.assertRaises(urwid.FrameError, set2)
 
     def test_focus_path(self):
         # big tree of containers

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import unittest
+
+import urwid
+
+
+class FrameTest(unittest.TestCase):
+    def ftbtest(self, desc: str, focus_part, header_rows, footer_rows, size, focus, top, bottom):
+        class FakeWidget:
+            def __init__(self, rows, want_focus):
+                self.ret_rows = rows
+                self.want_focus = want_focus
+
+            def rows(self, size, focus=False):
+                assert self.want_focus == focus
+                return self.ret_rows
+
+        with self.subTest(desc):
+            header = footer = None
+            if header_rows:
+                header = FakeWidget(header_rows, focus and focus_part == "header")
+            if footer_rows:
+                footer = FakeWidget(footer_rows, focus and focus_part == "footer")
+
+            f = urwid.Frame(urwid.SolidFill(), header, footer, focus_part)
+
+            rval = f.frame_top_bottom(size, focus)
+            exp = (top, bottom), (header_rows, footer_rows)
+            self.assertEqual(exp, rval)
+
+    def test(self):
+        self.ftbtest("simple", "body", 0, 0, (9, 10), True, 0, 0)
+        self.ftbtest("simple h", "body", 3, 0, (9, 10), True, 3, 0)
+        self.ftbtest("simple f", "body", 0, 3, (9, 10), True, 0, 3)
+        self.ftbtest("simple hf", "body", 3, 3, (9, 10), True, 3, 3)
+        self.ftbtest("almost full hf", "body", 4, 5, (9, 10), True, 4, 5)
+        self.ftbtest("full hf", "body", 5, 5, (9, 10), True, 4, 5)
+        self.ftbtest("x full h+1f", "body", 6, 5, (9, 10), False, 4, 5)
+        self.ftbtest("full h+1f", "body", 6, 5, (9, 10), True, 4, 5)
+        self.ftbtest("full hf+1", "body", 5, 6, (9, 10), True, 3, 6)
+        self.ftbtest("F full h+1f", "footer", 6, 5, (9, 10), True, 5, 5)
+        self.ftbtest("F full hf+1", "footer", 5, 6, (9, 10), True, 4, 6)
+        self.ftbtest("F full hf+5", "footer", 5, 11, (9, 10), True, 0, 10)
+        self.ftbtest("full hf+5", "body", 5, 11, (9, 10), True, 0, 9)
+        self.ftbtest("H full hf+1", "header", 5, 6, (9, 10), True, 5, 5)
+        self.ftbtest("H full h+1f", "header", 6, 5, (9, 10), True, 6, 4)
+        self.ftbtest("H full h+5f", "header", 11, 5, (9, 10), True, 10, 0)
+
+    def test_common(self):
+        s1 = urwid.SolidFill("1")
+
+        f = urwid.Frame(s1)
+        self.assertEqual(f.focus, s1)
+        self.assertEqual(f.focus_position, "body")
+        self.assertRaises(IndexError, lambda: setattr(f, "focus_position", None))
+        self.assertRaises(IndexError, lambda: setattr(f, "focus_position", "header"))
+
+        t1 = urwid.Text("one")
+        t2 = urwid.Text("two")
+        t3 = urwid.Text("three")
+        f = urwid.Frame(s1, t1, t2, "header")
+        self.assertEqual(f.focus, t1)
+        self.assertEqual(f.focus_position, "header")
+        f.focus_position = "footer"
+        self.assertEqual(f.focus, t2)
+        self.assertEqual(f.focus_position, "footer")
+        self.assertRaises(IndexError, lambda: setattr(f, "focus_position", -1))
+        self.assertRaises(IndexError, lambda: setattr(f, "focus_position", 2))
+        del f.contents["footer"]
+        self.assertEqual(f.footer, None)
+        self.assertEqual(f.focus_position, "body")
+        f.contents.update(footer=(t3, None), header=(t2, None))
+        self.assertEqual(f.header, t2)
+        self.assertEqual(f.footer, t3)
+
+        def set1():
+            f.contents["body"] = t1
+
+        self.assertRaises(urwid.FrameError, set1)
+
+        def set2():
+            f.contents["body"] = (t1, "given")
+
+        self.assertRaises(urwid.FrameError, set2)
+
+    def test_focus(self):
+        header = urwid.Text("header")
+        body = urwid.ListBox((urwid.Text("first"), urwid.Text("second")))
+        footer = urwid.Text("footer")
+
+        with self.subTest("default"):
+            widget = urwid.Frame(body, header, footer)
+            self.assertEqual(body, widget.focus)
+            self.assertEqual("body", widget.focus_part)
+
+        with self.subTest("body"):
+            widget = urwid.Frame(body, header, footer, focus_part=body)
+            self.assertEqual(body, widget.focus)
+            self.assertEqual("body", widget.focus_part)
+
+        with self.subTest("header"):
+            widget = urwid.Frame(body, header, footer, focus_part=header)
+            self.assertEqual(header, widget.focus)
+            self.assertEqual("header", widget.focus_part)
+
+        with self.subTest("footer"):
+            widget = urwid.Frame(body, header, footer, focus_part=footer)
+            self.assertEqual(footer, widget.focus)
+            self.assertEqual("footer", widget.focus_part)

--- a/urwid/widget/frame.py
+++ b/urwid/widget/frame.py
@@ -53,7 +53,7 @@ class Frame(Widget, WidgetContainerMixin):
         body: Widget,
         header: Widget | None = None,
         footer: Widget | None = None,
-        focus_part: Literal["header", "footer", "body"] = "body",
+        focus_part: Literal["header", "footer", "body"] | Widget = "body",
     ):
         """
         :param body: a box widget for the body of the frame
@@ -63,14 +63,24 @@ class Frame(Widget, WidgetContainerMixin):
         :param footer: a flow widget for below the body (or None)
         :type footer: Widget
         :param focus_part:  'header', 'footer' or 'body'
-        :type focus_part: str
+        :type focus_part: str | Widget
         """
         super().__init__()
 
         self._header = header
         self._body = body
         self._footer = footer
-        self.focus_part = focus_part
+        if focus_part in {"header", "footer", "body"}:
+            self.focus_part = focus_part
+        elif focus_part == header:
+            self.focus_part = "header"
+        elif focus_part == footer:
+            self.focus_part = "footer"
+        elif focus_part == body:
+            self.focus_part = "body"
+        else:
+            raise ValueError(f"Invalid focus part {focus_part!r}")
+
         _check_widget_subclass(header)
         _check_widget_subclass(body)
         _check_widget_subclass(footer)


### PR DESCRIPTION
* separate frame tests

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

