### PR TITLE
Feature: `EventLoop.run_in_executor` should accept **kwargs

### DIFF
--- a/urwid/event_loop/abstract_loop.py
+++ b/urwid/event_loop/abstract_loop.py
@@ -64,6 +64,7 @@ class EventLoop(abc.ABC):
         executor: Executor,
         func: Callable[_Spec, _T],
         *args: _Spec.args,
+        **kwargs: _Spec.kwargs,
     ) -> Future[_T] | asyncio.Future[_T]:
         """Run callable in executor if supported.
 
@@ -73,6 +74,8 @@ class EventLoop(abc.ABC):
         :type func: Callable
         :param args: arguments to function (positional only)
         :type args: object
+        :param kwargs: keyword arguments to function (keyword only)
+        :type kwargs: object
         :return: future object for the function call outcome.
                  (exact future type depends on the event loop type)
         :rtype: concurrent.futures.Future | asyncio.Future

--- a/urwid/event_loop/asyncio_loop.py
+++ b/urwid/event_loop/asyncio_loop.py
@@ -120,6 +120,7 @@ class AsyncioEventLoop(EventLoop):
         executor: Executor | None,
         func: Callable[_Spec, _T],
         *args: _Spec.args,
+        **kwargs: _Spec.kwargs,
     ) -> asyncio.Future[_T]:
         """Run callable in executor.
 
@@ -129,10 +130,12 @@ class AsyncioEventLoop(EventLoop):
         :type func: Callable
         :param args: arguments to function (positional only)
         :type args: object
+        :param kwargs: keyword arguments to function (keyword only)
+        :type kwargs: object
         :return: future object for the function call outcome.
         :rtype: asyncio.Future
         """
-        return self._loop.run_in_executor(executor, func, *args)
+        return self._loop.run_in_executor(executor, functools.partial(func, *args, **kwargs))
 
     def alarm(self, seconds: float, callback: Callable[[], typing.Any]) -> asyncio.TimerHandle:
         """

--- a/urwid/event_loop/twisted_loop.py
+++ b/urwid/event_loop/twisted_loop.py
@@ -118,6 +118,7 @@ class TwistedEventLoop(EventLoop):
         executor: Executor,
         func: Callable[..., _T],
         *args: object,
+        **kwargs: object,
     ) -> Future[_T]:
         raise NotImplementedError(
             "Twisted implement it's own ThreadPool executor. Please use native API for call:\n"

--- a/urwid/event_loop/zmq_loop.py
+++ b/urwid/event_loop/zmq_loop.py
@@ -68,9 +68,9 @@ class ZMQEventLoop(EventLoop):
         self._did_something = True
         self._alarms = []
         self._poller = zmq.Poller()
-        self._queue_callbacks = {}
+        self._queue_callbacks: dict[int, Callable[[], typing.Any]] = {}
         self._idle_handle = 0
-        self._idle_callbacks = {}
+        self._idle_callbacks: dict[int, Callable[[], typing.Any]] = {}
 
     def run_in_executor(
         self,
@@ -251,6 +251,7 @@ class ZMQEventLoop(EventLoop):
         A single iteration of the event loop.
         """
         if self._alarms or self._did_something:
+            timeout = 0
             if self._alarms:
                 state = "alarm"
                 timeout = max(0, self._alarms[0][0] - time.time())


### PR DESCRIPTION
* Use `functools.partial` as noticed in upstream implementation code
* Tornado loop: undeprecate initialization

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

