### PR TITLE
Fix: listbox render crash if empty elements in tail

### DIFF
--- a/tests/test_listbox.py
+++ b/tests/test_listbox.py
@@ -848,3 +848,18 @@ class TestListWalkerFromIterable(unittest.TestCase):
     def test_02_simple_focus_list_walker(self):
         walker = urwid.SimpleFocusListWalker(str(num) for num in range(5))
         self.assertEqual(5, len(walker))
+
+
+class TestSkipRender(unittest.TestCase):
+    def test_empty_containers(self):
+        listbox = urwid.ListBox([
+            urwid.Text("hi"),
+            urwid.Pile([]),
+            urwid.Pile([]),
+            urwid.Pile([]),
+            urwid.Pile([]),
+            urwid.Pile([]),
+            urwid.Pile([]),
+        ])
+        canvas = listbox.render((3, 3))
+        self.assertEqual(('hi ', '   ', '   '), canvas.decoded_text)


### PR DESCRIPTION
Fix: #253

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

