### PR TITLE
Feature: extend validation for `Columns` and `Pile`

### DIFF
--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -746,6 +746,15 @@ class ColumnsTest(unittest.TestCase):
             self.assertRaises(urwid.ColumnsError, lambda: c.contents.append(t1))
             self.assertRaises(urwid.ColumnsError, lambda: c.contents.append((t1, None)))
             self.assertRaises(urwid.ColumnsError, lambda: c.contents.append((t1, "given")))
+            self.assertRaises(urwid.ColumnsError, lambda: c.contents.append((t1, ("given", None))))
+            # Incorrect kind
+            self.assertRaises(urwid.ColumnsError, lambda: c.contents.append((t1, ("what", 1, False))))
+            # Incorrect box field
+            self.assertRaises(urwid.ColumnsError, lambda: c.contents.append((t1, ("given", 1, None))))
+            # Incorrect size type
+            self.assertRaises(urwid.ColumnsError, lambda: c.contents.append((t1, ("given", (), False))))
+            # Incorrect size
+            self.assertRaises(urwid.ColumnsError, lambda: c.contents.append((t1, ("given", -1, False))))
 
     def test_focus_position(self):
         t1 = urwid.Text("one")

--- a/tests/test_pile.py
+++ b/tests/test_pile.py
@@ -408,6 +408,14 @@ class PileTest(unittest.TestCase):
             self.assertRaises(urwid.PileError, lambda: p.contents.append(t1))
             self.assertRaises(urwid.PileError, lambda: p.contents.append((t1, None)))
             self.assertRaises(urwid.PileError, lambda: p.contents.append((t1, "given")))
+            self.assertRaises(urwid.PileError, lambda: p.contents.append((t1, ("given",))))
+            # Incorrect kind
+            self.assertRaises(urwid.PileError, lambda: p.contents.append((t1, ("what", 0))))
+            # incorrect size type
+            self.assertRaises(urwid.PileError, lambda: p.contents.append((t1, ("given", ()))))
+            # incorrect size
+            self.assertRaises(urwid.PileError, lambda: p.contents.append((t1, ("given", -1))))
+
 
     def test_focus_position(self):
         t1 = urwid.Text("one")


### PR DESCRIPTION
##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

