### PR TITLE
Fix regression from 2.6.1: `ListBox` used for tree implementation.

### DIFF
--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import typing
+import unittest
+from typing import Collection
+
+import urwid
+from urwid import TreeNode
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Hashable, Iterable
+
+
+class SelfRegisteringParent(urwid.ParentNode):
+    def __init__(
+        self,
+        value: str,
+        parent: SelfRegisteringParent | None = None,
+        key: Hashable = None,
+        depth: int | None = None,
+        children: Iterable[SelfRegisteringChild | SelfRegisteringParent] = (),
+    ) -> None:
+        super().__init__(value, parent, key, depth)
+        if parent:
+            parent.set_child_node(key, self)
+
+        self._child_keys = []
+        for child in children:
+            key = child.get_key()
+            self._children[key] = child
+            self._child_keys.append(key)
+            child.set_parent(self)
+
+    def load_child_keys(self) -> Collection[Hashable]:
+        return list(self._children)
+
+    def set_child_node(self, key: Hashable, node: TreeNode) -> None:
+        super().set_child_node(key, node)
+        self._child_keys = self.load_child_keys()
+
+    def set_parent(self, parent: SelfRegisteringParent) -> None:
+        self._parent = parent
+
+
+class SelfRegisteringChild(urwid.TreeNode):
+    def __init__(
+        self,
+        value: str,
+        parent: SelfRegisteringParent | None = None,
+        key: Hashable | None = None,
+        depth: int | None = None,
+    ) -> None:
+        super().__init__(value, parent, key, depth)
+        if parent:
+            parent.set_child_node(key, self)
+
+    def set_parent(self, parent: SelfRegisteringParent) -> None:
+        self._parent = parent
+
+
+class TestTree(unittest.TestCase):
+    def test_basic(self):
+        root = SelfRegisteringParent(
+            "root",
+            key="/",
+            children=(SelfRegisteringChild(f"child_{idx}", key=str(idx)) for idx in range(1, 4)),
+        )
+
+        widget = urwid.TreeListBox(urwid.TreeWalker(root))
+        size = (15, 5)
+        self.assertEqual(
+            (
+                "- /: root      ",
+                "   1: child_1  ",
+                "   2: child_2  ",
+                "   3: child_3  ",
+                "               ",
+            ),
+            widget.render(size).decoded_text,
+        )
+        widget.keypress(size, "-")
+        self.assertEqual(
+            (
+                "+ /: root      ",
+                "               ",
+                "               ",
+                "               ",
+                "               ",
+            ),
+            widget.render(size).decoded_text,
+        )
+        widget.keypress(size, "+")
+        self.assertEqual(
+            (
+                "- /: root      ",
+                "   1: child_1  ",
+                "   2: child_2  ",
+                "   3: child_3  ",
+                "               ",
+            ),
+            widget.render(size).decoded_text,
+        )

--- a/urwid/widget/widget.py
+++ b/urwid/widget/widget.py
@@ -190,8 +190,7 @@ class Widget(metaclass=WidgetMeta):
     .. attribute:: _selectable
        :annotation: = False
 
-       The default :meth:`.selectable` method returns this
-       value.
+       The default :meth:`.selectable` method returns this value.
 
     .. attribute:: _sizing
        :annotation: = frozenset(['flow', 'box', 'fixed'])
@@ -201,8 +200,7 @@ class Widget(metaclass=WidgetMeta):
     .. attribute:: _command_map
        :annotation: = urwid.command_map
 
-       A shared :class:`CommandMap` instance. May be redefined
-       in subclasses or widget instances.
+       A shared :class:`CommandMap` instance. May be redefined in subclasses or widget instances.
 
 
     .. method:: rows(size, focus=False)
@@ -214,8 +212,7 @@ class Widget(metaclass=WidgetMeta):
 
        See :meth:`Widget.render` for parameter details.
 
-       :returns: The number of rows required for this widget given a number
-                 of columns in *size*
+       :returns: The number of rows required for this widget given a number of columns in *size*
 
        This is the method flow widgets use to communicate their size to other
        widgets without having to render a canvas. This should be a quick
@@ -250,20 +247,17 @@ class Widget(metaclass=WidgetMeta):
        if no cursor is displayed.
 
        The :class:`ListBox` widget
-       uses this method to make sure a cursor in the focus widget is not
-       scrolled out of view.  It is a separate method to avoid having to render
-       the whole widget while calculating layout.
+       uses this method to make sure a cursor in the focus widget is not scrolled out of view.
+       It is a separate method to avoid having to render the whole widget while calculating layout.
 
-       Container widgets will typically call the :meth:`.get_cursor_coords`
-       method on their focus widget.
+       Container widgets will typically call the :meth:`.get_cursor_coords` method on their focus widget.
 
 
     .. method:: get_pref_col(size)
 
        .. note::
 
-          This method is not implemented in :class:`.Widget` but
-          may be implemented by a subclass.
+          This method is not implemented in :class:`.Widget` but may be implemented by a subclass.
 
        :param size: See :meth:`Widget.render` for details.
        :type size: widget size
@@ -286,9 +280,8 @@ class Widget(metaclass=WidgetMeta):
 
        .. note::
 
-          This method is not implemented in :class:`.Widget` but
-          may be implemented by a subclass.  Not implementing this
-          method is equivalent to having a method that always returns
+          This method is not implemented in :class:`.Widget` but may be implemented by a subclass.
+          Not implementing this method is equivalent to having a method that always returns
           ``False``.
 
        :param size: See :meth:`Widget.render` for details.
@@ -298,8 +291,7 @@ class Widget(metaclass=WidgetMeta):
        :param row: new row for the cursor, 0 it the top row of this widget
        :type row: int
 
-       :returns: ``True`` if the position was set successfully anywhere on
-                 *row*, ``False`` otherwise
+       :returns: ``True`` if the position was set successfully anywhere on *row*, ``False`` otherwise
     """
 
     _selectable = False
@@ -310,17 +302,11 @@ class Widget(metaclass=WidgetMeta):
         self.logger = logging.getLogger(f"{self.__class__.__module__}.{self.__class__.__name__}")
 
     def _invalidate(self) -> None:
-        """
-        Mark cached canvases rendered by this widget as dirty so that
-        they will not be used again.
-        """
+        """Mark cached canvases rendered by this widget as dirty so that they will not be used again."""
         CanvasCache.invalidate(self)
 
     def _emit(self, name: Hashable, *args) -> None:
-        """
-        Convenience function to emit signals with self as first
-        argument.
-        """
+        """Convenience function to emit signals with self as first argument."""
         signals.emit_signal(self, name, self, *args)
 
     def selectable(self) -> bool:
@@ -418,19 +404,18 @@ class Widget(metaclass=WidgetMeta):
 
     @property
     def base_widget(self) -> Widget:
-        """
-        Read-only property that steps through decoration widgets
-        and returns the one at the base.  This default implementation
-        returns self.
+        """Read-only property that steps through decoration widgets and returns the one at the base.
+
+        This default implementation returns self.
         """
         return self
 
     @property
     def focus(self) -> Widget | None:
         """
-        Read-only property returning the child widget in focus for
-        container widgets.  This default implementation
-        always returns ``None``, indicating that this widget has no children.
+        Read-only property returning the child widget in focus for container widgets.
+
+        This default implementation always returns ``None``, indicating that this widget has no children.
         """
         return None
 
@@ -449,9 +434,9 @@ class Widget(metaclass=WidgetMeta):
     )
 
     def __repr__(self):
-        """
-        A friendly __repr__ for widgets, designed to be extended
-        by subclasses with _repr_words and _repr_attr methods.
+        """A friendly __repr__ for widgets.
+
+        Designed to be extended by subclasses with _repr_words and _repr_attr methods.
         """
         return split_repr(self)
 


### PR DESCRIPTION
* Fix TreeWalker support in render
* Cover issue with test
* Add initial test for:
* * `TreeNode`
* * `ParentNode`
* * `TreeWalker`
* * `TreeListBox`
* Add basic type annotations for tree widgets

Fix: #828

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

