### PR TITLE
TreeWidget: do not use deprecated API in `update_expanded_icon`

### DIFF
--- a/examples/bigtext.py
+++ b/examples/bigtext.py
@@ -34,7 +34,10 @@ if typing.TYPE_CHECKING:
     from collections.abc import Callable
 
 
-class SwitchingPadding(urwid.Padding):
+_Wrapped = typing.TypeVar("_Wrapped")
+
+
+class SwitchingPadding(urwid.Padding[_Wrapped]):
     def padding_values(self, size, focus: bool) -> tuple[int, int]:
         maxcol = size[0]
         width, _height = self.original_widget.pack(size, focus=focus)
@@ -95,7 +98,7 @@ class BigTextDisplay:
     def edit_change_event(self, widget, text: str) -> None:
         self.bigtext.set_text(text)
 
-    def setup_view(self):
+    def setup_view(self) -> tuple[urwid.Frame, urwid.Overlay[urwid.BigText, urwid.Frame]]:
         fonts = urwid.get_all_fonts()
         # setup mode radio buttons
         self.font_buttons = []
@@ -147,13 +150,18 @@ class BigTextDisplay:
 
         # Frame
         w = urwid.AttrMap(w, "body")
-        hdr = urwid.Text("Urwid BigText example program - F8 exits.")
-        hdr = urwid.AttrMap(hdr, "header")
+        hdr = urwid.AttrMap(urwid.Text("Urwid BigText example program - F8 exits."), "header")
         w = urwid.Frame(header=hdr, body=w)
 
         # Exit message
-        exit_w = urwid.BigText(("exit", " Quit? "), exit_font)
-        exit_w = urwid.Overlay(exit_w, w, urwid.CENTER, None, urwid.MIDDLE, None)
+        exit_w = urwid.Overlay(
+            urwid.BigText(("exit", " Quit? "), exit_font),
+            w,
+            urwid.CENTER,
+            None,
+            urwid.MIDDLE,
+            None,
+        )
         return w, exit_w
 
     def main(self):

--- a/urwid/treetools.py
+++ b/urwid/treetools.py
@@ -42,7 +42,7 @@ class TreeWidgetError(RuntimeError):
     pass
 
 
-class TreeWidget(urwid.WidgetWrap[urwid.Padding]):
+class TreeWidget(urwid.WidgetWrap[urwid.Padding[typing.Union[urwid.Text, urwid.Columns]]]):
     """A widget representing something in a nested tree display."""
 
     indent_cols = 3
@@ -63,7 +63,7 @@ class TreeWidget(urwid.WidgetWrap[urwid.Padding]):
         """
         return not self.is_leaf
 
-    def get_indented_widget(self) -> urwid.Padding:
+    def get_indented_widget(self) -> urwid.Padding[urwid.Text | urwid.Columns]:
         widget = self.get_inner_widget()
         if not self.is_leaf:
             widget = urwid.Columns(
@@ -76,7 +76,8 @@ class TreeWidget(urwid.WidgetWrap[urwid.Padding]):
     def update_expanded_icon(self) -> None:
         """Update display widget text for parent widgets"""
         # icon is first element in columns indented widget
-        self._w.base_widget.widget_list[0] = [self.unexpanded_icon, self.expanded_icon][self.expanded]
+        icon = [self.unexpanded_icon, self.expanded_icon][self.expanded]
+        self._w.original_widget.contents[0] = (icon, (urwid.GIVEN, 1, False))
 
     def get_indent_cols(self) -> int:
         return self.indent_cols * self.get_node().get_depth()

--- a/urwid/widget/padding.py
+++ b/urwid/widget/padding.py
@@ -34,7 +34,7 @@ class PaddingWarning(WidgetWarning):
     """Padding related warnings."""
 
 
-class Padding(WidgetDecoration[WrappedWidget]):
+class Padding(WidgetDecoration[WrappedWidget], typing.Generic[WrappedWidget]):
     def __init__(
         self,
         w: WrappedWidget,


### PR DESCRIPTION
* Typing: Make `Padding` and `Overlay` generic classes
* Extend tests for `TreeListBox`: cover a deep nested scenario

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

