### PR TITLE
Refactoring: move `monitored_list` module to the `widgets` package

### DIFF
--- a/tests/test_doctests.py
+++ b/tests/test_doctests.py
@@ -34,11 +34,11 @@ def load_tests(loader: unittest.TestLoader, tests: unittest.BaseTestSuite, ignor
         urwid.widget.widget,
         urwid.widget.widget_decoration,
         urwid.widget.wimp,
+        urwid.widget.monitored_list,
         urwid.display.common,
         urwid.display.raw,
         urwid.event_loop.main_loop,
         urwid.numedit,
-        urwid.monitored_list,
         urwid.raw_display,
         urwid.font,
         "urwid.split_repr",  # override function with same name

--- a/urwid/__init__.py
+++ b/urwid/__init__.py
@@ -94,7 +94,6 @@ from urwid.font import (
     get_all_fonts,
 )
 from urwid.listbox import ListBox, ListBoxError, ListWalker, ListWalkerError, SimpleFocusListWalker, SimpleListWalker
-from urwid.monitored_list import MonitoredFocusList, MonitoredList
 from urwid.signals import (
     MetaSignals,
     Signals,
@@ -170,6 +169,8 @@ from urwid.widget import (
     GridFlowError,
     IntEdit,
     LineBox,
+    MonitoredFocusList,
+    MonitoredList,
     Overlay,
     OverlayError,
     Padding,
@@ -252,6 +253,7 @@ _moved_warn: dict[str, str] = {
     "lcd_display": "urwid.display.lcd",
     "html_fragment": "urwid.display.html_fragment",
     "web_display": "urwid.display.web",
+    "monitored_list": "urwid.widget.monitored_list",
 }
 # Backward compatible lazy load without any warnings
 # Before DeprecationWarning need to start PendingDeprecationWarning process.

--- a/urwid/listbox.py
+++ b/urwid/listbox.py
@@ -30,10 +30,11 @@ from typing_extensions import Protocol, runtime_checkable
 from urwid import signals
 from urwid.canvas import CanvasCombine, SolidCanvas
 from urwid.command_map import Command
-from urwid.monitored_list import MonitoredFocusList, MonitoredList
 from urwid.signals import connect_signal, disconnect_signal
 from urwid.util import is_mouse_press
 from urwid.widget import (
+    MonitoredFocusList,
+    MonitoredList,
     Sizing,
     VAlign,
     WHSettings,

--- a/urwid/widget/__init__.py
+++ b/urwid/widget/__init__.py
@@ -29,6 +29,7 @@ from .filler import Filler, FillerError, calculate_top_bottom_filler
 from .frame import Frame, FrameError
 from .grid_flow import GridFlow, GridFlowError
 from .line_box import LineBox
+from .monitored_list import MonitoredFocusList, MonitoredList
 from .overlay import Overlay, OverlayError, OverlayWarning
 from .padding import Padding, PaddingError, PaddingWarning, calculate_left_right_padding
 from .pile import Pile, PileError, PileWarning
@@ -58,6 +59,8 @@ from .wimp import Button, CheckBox, CheckBoxError, RadioButton, SelectableIcon
 __all__ = (
     "ANY",
     "BOTTOM",
+    "MonitoredList",
+    "MonitoredFocusList",
     "BOX",
     "CENTER",
     "CLIP",

--- a/urwid/widget/columns.py
+++ b/urwid/widget/columns.py
@@ -7,11 +7,11 @@ from itertools import chain, repeat
 import urwid
 from urwid.canvas import Canvas, CanvasJoin, CompositeCanvas, SolidCanvas
 from urwid.command_map import Command
-from urwid.monitored_list import MonitoredFocusList, MonitoredList
 from urwid.util import is_mouse_press
 
 from .constants import Align, Sizing, WHSettings
 from .container import WidgetContainerListContentsMixin, WidgetContainerMixin, _ContainerElementSizingFlag
+from .monitored_list import MonitoredFocusList, MonitoredList
 from .widget import Widget, WidgetError, WidgetWarning
 
 if typing.TYPE_CHECKING:

--- a/urwid/widget/grid_flow.py
+++ b/urwid/widget/grid_flow.py
@@ -3,12 +3,11 @@ from __future__ import annotations
 import typing
 import warnings
 
-from urwid.monitored_list import MonitoredFocusList, MonitoredList
-
 from .columns import Columns
 from .constants import Align, Sizing, WHSettings
 from .container import WidgetContainerListContentsMixin, WidgetContainerMixin
 from .divider import Divider
+from .monitored_list import MonitoredFocusList, MonitoredList
 from .padding import Padding
 from .pile import Pile
 from .widget import Widget, WidgetError, WidgetWrap

--- a/urwid/widget/monitored_list.py
+++ b/urwid/widget/monitored_list.py
@@ -31,6 +31,8 @@ if typing.TYPE_CHECKING:
     ArgSpec = ParamSpec("ArgSpec")
     Ret = typing.TypeVar("Ret")
 
+__all__ = ("MonitoredList", "MonitoredFocusList")
+
 _T = typing.TypeVar("_T")
 
 

--- a/urwid/widget/pile.py
+++ b/urwid/widget/pile.py
@@ -6,11 +6,11 @@ from itertools import chain, repeat
 
 from urwid.canvas import CanvasCombine, CompositeCanvas, SolidCanvas
 from urwid.command_map import Command
-from urwid.monitored_list import MonitoredFocusList, MonitoredList
 from urwid.util import is_mouse_press
 
 from .constants import Sizing, WHSettings
 from .container import WidgetContainerListContentsMixin, WidgetContainerMixin, _ContainerElementSizingFlag
+from .monitored_list import MonitoredFocusList, MonitoredList
 from .widget import Widget, WidgetError, WidgetWarning
 
 if typing.TYPE_CHECKING:


### PR DESCRIPTION
This is a critical element for the container widgets.
 All classes are exported via `urwid` namespace without changes.

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

