### PR TITLE
Typing: Make `Frame` `Generic` for proper annotations in downstream

### DIFF
--- a/examples/bigtext.py
+++ b/examples/bigtext.py
@@ -98,7 +98,10 @@ class BigTextDisplay:
     def edit_change_event(self, widget, text: str) -> None:
         self.bigtext.set_text(text)
 
-    def setup_view(self) -> tuple[urwid.Frame, urwid.Overlay[urwid.BigText, urwid.Frame]]:
+    def setup_view(self) -> tuple[
+        urwid.Frame[urwid.AttrMap[urwid.ListBox], urwid.AttrMap[urwid.Text], None],
+        urwid.Overlay[urwid.BigText, urwid.Frame[urwid.AttrMap[urwid.ListBox], urwid.AttrMap[urwid.Text], None]],
+    ]:
         fonts = urwid.get_all_fonts()
         # setup mode radio buttons
         self.font_buttons = []
@@ -146,12 +149,13 @@ class BigTextDisplay:
         col = urwid.Columns([(16, chars), fonts], 3, focus_column=1)
         bt = urwid.Pile([bt, edit], focus_item=1)
         lines = [bt, urwid.Divider(), col]
-        w = urwid.ListBox(urwid.SimpleListWalker(lines))
+        listbox = urwid.ListBox(urwid.SimpleListWalker(lines))
 
         # Frame
-        w = urwid.AttrMap(w, "body")
-        hdr = urwid.AttrMap(urwid.Text("Urwid BigText example program - F8 exits."), "header")
-        w = urwid.Frame(header=hdr, body=w)
+        w = urwid.Frame(
+            body=urwid.AttrMap(listbox, "body"),
+            header=urwid.AttrMap(urwid.Text("Urwid BigText example program - F8 exits."), "header"),
+        )
 
         # Exit message
         exit_w = urwid.Overlay(

--- a/examples/browse.py
+++ b/examples/browse.py
@@ -274,7 +274,9 @@ class DirectoryBrowser:
         self.listbox.offset_rows = 1
         self.footer = urwid.AttrMap(urwid.Text(self.footer_text), "foot")
         self.view = urwid.Frame(
-            urwid.AttrMap(self.listbox, "body"), header=urwid.AttrMap(self.header, "head"), footer=self.footer
+            urwid.AttrMap(self.listbox, "body"),
+            header=urwid.AttrMap(self.header, "head"),
+            footer=self.footer,
         )
 
     def main(self) -> None:

--- a/urwid/widget/attr_map.py
+++ b/urwid/widget/attr_map.py
@@ -5,17 +5,17 @@ from collections.abc import Hashable, Mapping
 
 from urwid.canvas import CompositeCanvas
 
-from .widget import WidgetError, delegate_to_widget_mixin
+from .widget import Widget, WidgetError, delegate_to_widget_mixin
 from .widget_decoration import WidgetDecoration
 
-WrappedWidget = typing.TypeVar("WrappedWidget")
+WrappedWidget_co = typing.TypeVar("WrappedWidget_co", bound=Widget, covariant=True)
 
 
 class AttrMapError(WidgetError):
     pass
 
 
-class AttrMap(delegate_to_widget_mixin("_original_widget"), WidgetDecoration[WrappedWidget]):
+class AttrMap(delegate_to_widget_mixin("_original_widget"), WidgetDecoration[WrappedWidget_co]):
     """
     AttrMap is a decoration that maps one set of attributes to another.
     This object will pass all function calls and variable references to the
@@ -24,7 +24,7 @@ class AttrMap(delegate_to_widget_mixin("_original_widget"), WidgetDecoration[Wra
 
     def __init__(
         self,
-        w: WrappedWidget,
+        w: WrappedWidget_co,
         attr_map: Hashable | Mapping[Hashable | None, Hashable] | None,
         focus_map: Hashable | Mapping[Hashable | None, Hashable] | None = None,
     ) -> None:

--- a/urwid/widget/box_adapter.py
+++ b/urwid/widget/box_adapter.py
@@ -8,21 +8,24 @@ from urwid.canvas import CompositeCanvas
 from .constants import Sizing
 from .widget_decoration import WidgetDecoration, WidgetError
 
-WrappedWidget = typing.TypeVar("WrappedWidget")
+if typing.TYPE_CHECKING:
+    from .widget import Widget
+
+WrappedWidget_co = typing.TypeVar("WrappedWidget_co", bound="Widget", covariant=True)
 
 
 class BoxAdapterError(WidgetError):
     pass
 
 
-class BoxAdapter(WidgetDecoration[WrappedWidget]):
+class BoxAdapter(WidgetDecoration[WrappedWidget_co]):
     """
     Adapter for using a box widget where a flow widget would usually go
     """
 
     no_cache: typing.ClassVar[list[str]] = ["rows"]
 
-    def __init__(self, box_widget: WrappedWidget, height: int) -> None:
+    def __init__(self, box_widget: WrappedWidget_co, height: int) -> None:
         """
         Create a flow widget that contains a box widget
 
@@ -46,7 +49,7 @@ class BoxAdapter(WidgetDecoration[WrappedWidget]):
 
     # originally stored as box_widget, keep for compatibility
     @property
-    def box_widget(self) -> WrappedWidget:
+    def box_widget(self) -> WrappedWidget_co:
         warnings.warn(
             "original stored as original_widget, keep for compatibility",
             PendingDeprecationWarning,
@@ -55,7 +58,7 @@ class BoxAdapter(WidgetDecoration[WrappedWidget]):
         return self.original_widget
 
     @box_widget.setter
-    def box_widget(self, widget: WrappedWidget) -> None:
+    def box_widget(self, widget: WrappedWidget_co) -> None:
         warnings.warn(
             "original stored as original_widget, keep for compatibility",
             PendingDeprecationWarning,

--- a/urwid/widget/filler.py
+++ b/urwid/widget/filler.py
@@ -22,18 +22,20 @@ from .widget_decoration import WidgetDecoration, WidgetError
 if typing.TYPE_CHECKING:
     from typing_extensions import Literal
 
+    from .widget import Widget
 
-WrappedWidget = typing.TypeVar("WrappedWidget")
+
+WrappedWidget_co = typing.TypeVar("WrappedWidget_co", bound="Widget", covariant=True)
 
 
 class FillerError(WidgetError):
     pass
 
 
-class Filler(WidgetDecoration[WrappedWidget]):
+class Filler(WidgetDecoration[WrappedWidget_co]):
     def __init__(
         self,
-        body: WrappedWidget,
+        body: WrappedWidget_co,
         valign: (
             Literal["top", "middle", "bottom"] | VAlign | tuple[Literal["relative", WHSettings.RELATIVE], int]
         ) = VAlign.MIDDLE,
@@ -160,7 +162,7 @@ class Filler(WidgetDecoration[WrappedWidget]):
         return remove_defaults(attrs, Filler.__init__)
 
     @property
-    def body(self) -> WrappedWidget:
+    def body(self) -> WrappedWidget_co:
         """backwards compatibility, widget used to be stored as body"""
         warnings.warn(
             "backwards compatibility, widget used to be stored as body",
@@ -170,7 +172,7 @@ class Filler(WidgetDecoration[WrappedWidget]):
         return self.original_widget
 
     @body.setter
-    def body(self, new_body: WrappedWidget) -> None:
+    def body(self, new_body: WrappedWidget_co) -> None:
         warnings.warn(
             "backwards compatibility, widget used to be stored as body",
             PendingDeprecationWarning,
@@ -178,7 +180,7 @@ class Filler(WidgetDecoration[WrappedWidget]):
         )
         self.original_widget = new_body
 
-    def get_body(self) -> WrappedWidget:
+    def get_body(self) -> WrappedWidget_co:
         """backwards compatibility, widget used to be stored as body"""
         warnings.warn(
             "backwards compatibility, widget used to be stored as body",
@@ -187,7 +189,7 @@ class Filler(WidgetDecoration[WrappedWidget]):
         )
         return self.original_widget
 
-    def set_body(self, new_body: WrappedWidget) -> None:
+    def set_body(self, new_body: WrappedWidget_co) -> None:
         warnings.warn(
             "backwards compatibility, widget used to be stored as body",
             DeprecationWarning,

--- a/urwid/widget/line_box.py
+++ b/urwid/widget/line_box.py
@@ -15,15 +15,15 @@ if typing.TYPE_CHECKING:
 
     from .widget import Widget
 
-WrappedWidget = typing.TypeVar("WrappedWidget")
+WrappedWidget_co = typing.TypeVar("WrappedWidget_co", bound="Widget", covariant=True)
 
 
-class LineBox(WidgetDecoration[WrappedWidget], delegate_to_widget_mixin("_wrapped_widget")):
+class LineBox(WidgetDecoration[WrappedWidget_co], delegate_to_widget_mixin("_wrapped_widget")):
     Symbols = BOX_SYMBOLS
 
     def __init__(
         self,
-        original_widget: WrappedWidget,
+        original_widget: WrappedWidget_co,
         title: str = "",
         title_align: Literal["left", "center", "right"] | Align = Align.CENTER,
         title_attr=None,

--- a/urwid/widget/overlay.py
+++ b/urwid/widget/overlay.py
@@ -32,8 +32,8 @@ if typing.TYPE_CHECKING:
     from typing_extensions import Literal
 
 
-TopWidget = typing.TypeVar("TopWidget", bound=Widget)
-BottomWidget = typing.TypeVar("BottomWidget", bound=Widget)
+TopWidget_co = typing.TypeVar("TopWidget_co", bound=Widget, covariant=True)
+BottomWidget_co = typing.TypeVar("BottomWidget_co", bound=Widget, covariant=True)
 
 
 class OverlayError(WidgetError):
@@ -71,7 +71,9 @@ class OverlayOptions(typing.NamedTuple):
     bottom: int
 
 
-class Overlay(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin, typing.Generic[TopWidget, BottomWidget]):
+class Overlay(
+    Widget, WidgetContainerMixin, WidgetContainerListContentsMixin, typing.Generic[TopWidget_co, BottomWidget_co]
+):
     """
     Overlay contains two box widgets and renders one on top of the other
     """
@@ -97,8 +99,8 @@ class Overlay(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin, ty
 
     def __init__(
         self,
-        top_w: TopWidget,
-        bottom_w: BottomWidget,
+        top_w: TopWidget_co,
+        bottom_w: BottomWidget_co,
         align: (
             Literal["left", "center", "right"]
             | Align
@@ -491,7 +493,7 @@ class Overlay(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin, ty
         )
 
     @property
-    def focus(self) -> TopWidget:
+    def focus(self) -> TopWidget_co:
         """
         Read-only property returning the child widget in focus for
         container widgets.  This default implementation
@@ -499,7 +501,7 @@ class Overlay(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin, ty
         """
         return self.top_w
 
-    def _get_focus(self) -> TopWidget:
+    def _get_focus(self) -> TopWidget_co:
         warnings.warn(
             f"method `{self.__class__.__name__}._get_focus` is deprecated, "
             f"please use `{self.__class__.__name__}.focus` property",
@@ -574,7 +576,9 @@ class Overlay(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin, ty
         """
 
         # noinspection PyMethodParameters
-        class OverlayContents(typing.Sequence[typing.Tuple[typing.Union[TopWidget, BottomWidget], OverlayOptions]]):
+        class OverlayContents(
+            typing.Sequence[typing.Tuple[typing.Union[TopWidget_co, BottomWidget_co], OverlayOptions]]
+        ):
             # pylint: disable=no-self-argument
             def __len__(inner_self) -> int:
                 return 2
@@ -605,7 +609,7 @@ class Overlay(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin, ty
     def _contents__getitem__(
         self,
         index: Literal[0, 1],
-    ) -> tuple[TopWidget | BottomWidget, OverlayOptions]:
+    ) -> tuple[TopWidget_co | BottomWidget_co, OverlayOptions]:
         if index == 0:
             return (self.bottom_w, self._DEFAULT_BOTTOM_OPTIONS)
 
@@ -634,7 +638,7 @@ class Overlay(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin, ty
     def _contents__setitem__(
         self,
         index: Literal[0, 1],
-        value: tuple[TopWidget | BottomWidget, OverlayOptions],
+        value: tuple[TopWidget_co | BottomWidget_co, OverlayOptions],
     ) -> None:
         try:
             value_w, value_options = value

--- a/urwid/widget/padding.py
+++ b/urwid/widget/padding.py
@@ -22,8 +22,10 @@ from .widget_decoration import WidgetDecoration, WidgetError, WidgetWarning
 if typing.TYPE_CHECKING:
     from typing_extensions import Literal
 
+    from .widget import Widget
 
-WrappedWidget = typing.TypeVar("WrappedWidget")
+
+WrappedWidget_co = typing.TypeVar("WrappedWidget_co", bound="Widget", covariant=True)
 
 
 class PaddingError(WidgetError):
@@ -34,10 +36,10 @@ class PaddingWarning(WidgetWarning):
     """Padding related warnings."""
 
 
-class Padding(WidgetDecoration[WrappedWidget], typing.Generic[WrappedWidget]):
+class Padding(WidgetDecoration[WrappedWidget_co], typing.Generic[WrappedWidget_co]):
     def __init__(
         self,
-        w: WrappedWidget,
+        w: WrappedWidget_co,
         align: (
             Literal["left", "center", "right"] | Align | tuple[Literal["relative", WHSettings.RELATIVE], int]
         ) = Align.LEFT,

--- a/urwid/widget/popup.py
+++ b/urwid/widget/popup.py
@@ -43,11 +43,11 @@ if typing.TYPE_CHECKING:
         overlay_height: int
 
 
-WrappedWidget = typing.TypeVar("WrappedWidget")
+WrappedWidget_co = typing.TypeVar("WrappedWidget_co", bound="Widget", covariant=True)
 
 
-class PopUpLauncher(delegate_to_widget_mixin("_original_widget"), WidgetDecoration[WrappedWidget]):
-    def __init__(self, original_widget: [WrappedWidget]) -> None:
+class PopUpLauncher(delegate_to_widget_mixin("_original_widget"), WidgetDecoration[WrappedWidget_co]):
+    def __init__(self, original_widget: [WrappedWidget_co]) -> None:
         super().__init__(original_widget)
         self._pop_up_widget = None
 
@@ -85,13 +85,13 @@ class PopUpLauncher(delegate_to_widget_mixin("_original_widget"), WidgetDecorati
         return canv
 
 
-class PopUpTarget(WidgetDecoration[WrappedWidget]):
+class PopUpTarget(WidgetDecoration[WrappedWidget_co]):
     # FIXME: this whole class is a terrible hack and must be fixed
     # when layout and rendering are separated
     _sizing = frozenset((Sizing.BOX,))
     _selectable = True
 
-    def __init__(self, original_widget: WrappedWidget) -> None:
+    def __init__(self, original_widget: WrappedWidget_co) -> None:
         super().__init__(original_widget)
         self._pop_up = None
         self._current_widget = self._original_widget

--- a/urwid/widget/scrollable.py
+++ b/urwid/widget/scrollable.py
@@ -43,7 +43,7 @@ if typing.TYPE_CHECKING:
 __all__ = ("ScrollBar", "Scrollable", "ScrollableError", "ScrollbarSymbols")
 
 
-WrappedWidget = typing.TypeVar("WrappedWidget")
+WrappedWidget_co = typing.TypeVar("WrappedWidget_co", bound="Widget", covariant=True)
 
 
 class ScrollableError(WidgetError):
@@ -122,14 +122,14 @@ class SupportsScroll(Protocol):
     def rows_max(self, size: tuple[int, int] | None = None, focus: bool = False) -> int: ...
 
 
-class Scrollable(WidgetDecoration[WrappedWidget]):
+class Scrollable(WidgetDecoration[WrappedWidget_co]):
     def sizing(self) -> frozenset[Sizing]:
         return frozenset((Sizing.BOX,))
 
     def selectable(self) -> bool:
         return True
 
-    def __init__(self, widget: WrappedWidget, force_forward_keypress: bool = False) -> None:
+    def __init__(self, widget: WrappedWidget_co, force_forward_keypress: bool = False) -> None:
         """Box widget that makes a fixed or flow widget vertically scrollable
 
         .. note::
@@ -424,7 +424,7 @@ class Scrollable(WidgetDecoration[WrappedWidget]):
         return self._rows_max_cached
 
 
-class ScrollBar(WidgetDecoration[WrappedWidget]):
+class ScrollBar(WidgetDecoration[WrappedWidget_co]):
     Symbols = ScrollbarSymbols
 
     def sizing(self):
@@ -435,7 +435,7 @@ class ScrollBar(WidgetDecoration[WrappedWidget]):
 
     def __init__(
         self,
-        widget: WrappedWidget,
+        widget: WrappedWidget_co,
         thumb_char: str = ScrollbarSymbols.FULL_BLOCK,
         trough_char: str = " ",
         side: Literal["left", "right"] = SCROLLBAR_RIGHT,

--- a/urwid/widget/widget.py
+++ b/urwid/widget/widget.py
@@ -37,7 +37,7 @@ from .constants import Sizing
 if typing.TYPE_CHECKING:
     from collections.abc import Callable, Hashable
 
-WrappedWidget = typing.TypeVar("WrappedWidget")
+WrappedWidget_co = typing.TypeVar("WrappedWidget_co", bound="Widget", covariant=True)
 LOGGER = logging.getLogger(__name__)
 
 
@@ -751,8 +751,8 @@ class WidgetWrapError(Exception):
     pass
 
 
-class WidgetWrap(delegate_to_widget_mixin("_wrapped_widget"), typing.Generic[WrappedWidget]):
-    def __init__(self, w: WrappedWidget) -> None:
+class WidgetWrap(delegate_to_widget_mixin("_wrapped_widget"), typing.Generic[WrappedWidget_co]):
+    def __init__(self, w: WrappedWidget_co) -> None:
         """
         w -- widget to wrap, stored as self._w
 
@@ -777,11 +777,11 @@ class WidgetWrap(delegate_to_widget_mixin("_wrapped_widget"), typing.Generic[Wra
         self._wrapped_widget = w
 
     @property
-    def _w(self) -> WrappedWidget:
+    def _w(self) -> WrappedWidget_co:
         return self._wrapped_widget
 
     @_w.setter
-    def _w(self, new_widget: WrappedWidget) -> None:
+    def _w(self, new_widget: WrappedWidget_co) -> None:
         """
         Change the wrapped widget.  This is meant to be called
         only by subclasses.
@@ -801,7 +801,7 @@ class WidgetWrap(delegate_to_widget_mixin("_wrapped_widget"), typing.Generic[Wra
         self._wrapped_widget = new_widget
         self._invalidate()
 
-    def _set_w(self, w: WrappedWidget) -> None:
+    def _set_w(self, w: WrappedWidget_co) -> None:
         """
         Change the wrapped widget.  This is meant to be called
         only by subclasses.

--- a/urwid/widget/widget_decoration.py
+++ b/urwid/widget/widget_decoration.py
@@ -22,10 +22,10 @@ __all__ = (
     "delegate_to_widget_mixin",
 )
 
-WrappedWidget = typing.TypeVar("WrappedWidget")
+WrappedWidget_co = typing.TypeVar("WrappedWidget_co", bound=Widget, covariant=True)
 
 
-class WidgetDecoration(Widget, typing.Generic[WrappedWidget]):  # pylint: disable=abstract-method
+class WidgetDecoration(Widget, typing.Generic[WrappedWidget_co]):  # pylint: disable=abstract-method
     """
     original_widget -- the widget being decorated
 
@@ -45,7 +45,7 @@ class WidgetDecoration(Widget, typing.Generic[WrappedWidget]):  # pylint: disabl
         Implement it or forward to the widget in the subclass.
     """
 
-    def __init__(self, original_widget: WrappedWidget) -> None:
+    def __init__(self, original_widget: WrappedWidget_co) -> None:
         # TODO(Aleksei): reduce amount of multiple inheritance usage
         # Special case: subclasses with multiple inheritance causes `super` call wrong way
         # Call parent __init__ explicit
@@ -63,15 +63,15 @@ class WidgetDecoration(Widget, typing.Generic[WrappedWidget]):  # pylint: disabl
         return [*super()._repr_words(), repr(self._original_widget)]
 
     @property
-    def original_widget(self) -> WrappedWidget:
+    def original_widget(self) -> WrappedWidget_co:
         return self._original_widget
 
     @original_widget.setter
-    def original_widget(self, original_widget: WrappedWidget) -> None:
+    def original_widget(self, original_widget: WrappedWidget_co) -> None:
         self._original_widget = original_widget
         self._invalidate()
 
-    def _get_original_widget(self) -> WrappedWidget:
+    def _get_original_widget(self) -> WrappedWidget_co:
         warnings.warn(
             f"Method `{self.__class__.__name__}._get_original_widget` is deprecated, "
             f"please use property `{self.__class__.__name__}.original_widget`",
@@ -80,7 +80,7 @@ class WidgetDecoration(Widget, typing.Generic[WrappedWidget]):  # pylint: disabl
         )
         return self.original_widget
 
-    def _set_original_widget(self, original_widget: WrappedWidget) -> None:
+    def _set_original_widget(self, original_widget: WrappedWidget_co) -> None:
         warnings.warn(
             f"Method `{self.__class__.__name__}._set_original_widget` is deprecated, "
             f"please use property `{self.__class__.__name__}.original_widget`",
@@ -126,7 +126,7 @@ class WidgetDecoration(Widget, typing.Generic[WrappedWidget]):  # pylint: disabl
         return self._original_widget.sizing()
 
 
-class WidgetPlaceholder(delegate_to_widget_mixin("_original_widget"), WidgetDecoration[WrappedWidget]):
+class WidgetPlaceholder(delegate_to_widget_mixin("_original_widget"), WidgetDecoration[WrappedWidget_co]):
     """
     This is a do-nothing decoration widget that can be used for swapping
     between widgets without modifying the container of this widget.
@@ -139,7 +139,7 @@ class WidgetPlaceholder(delegate_to_widget_mixin("_original_widget"), WidgetDeco
     """
 
 
-class WidgetDisable(WidgetDecoration[WrappedWidget]):
+class WidgetDisable(WidgetDecoration[WrappedWidget_co]):
     """
     A decoration widget that disables interaction with the widget it
     wraps.  This widget always passes focus=False to the wrapped widget,


### PR DESCRIPTION
Update generic types for wrapped widgets marking as covariant `Widget`.

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

