### PR TITLE
Fix MyPy error: MyPy not allow covariant arguments

### DIFF
--- a/urwid/canvas.py
+++ b/urwid/canvas.py
@@ -580,7 +580,7 @@ class SolidCanvas(Canvas):
     A canvas filled completely with a single character.
     """
 
-    def __init__(self, fill_char: str, cols: int, rows: int) -> None:
+    def __init__(self, fill_char: str | bytes, cols: int, rows: int) -> None:
         super().__init__()
         end, col = calc_text_pos(fill_char, 0, len(fill_char), 1)
         if col != 1:

--- a/urwid/widget/attr_map.py
+++ b/urwid/widget/attr_map.py
@@ -5,17 +5,17 @@ from collections.abc import Hashable, Mapping
 
 from urwid.canvas import CompositeCanvas
 
-from .widget import Widget, WidgetError, delegate_to_widget_mixin
+from .widget import WidgetError, delegate_to_widget_mixin
 from .widget_decoration import WidgetDecoration
 
-WrappedWidget_co = typing.TypeVar("WrappedWidget_co", bound=Widget, covariant=True)
+WrappedWidget = typing.TypeVar("WrappedWidget")
 
 
 class AttrMapError(WidgetError):
     pass
 
 
-class AttrMap(delegate_to_widget_mixin("_original_widget"), WidgetDecoration[WrappedWidget_co]):
+class AttrMap(delegate_to_widget_mixin("_original_widget"), WidgetDecoration[WrappedWidget]):
     """
     AttrMap is a decoration that maps one set of attributes to another.
     This object will pass all function calls and variable references to the
@@ -24,7 +24,7 @@ class AttrMap(delegate_to_widget_mixin("_original_widget"), WidgetDecoration[Wra
 
     def __init__(
         self,
-        w: WrappedWidget_co,
+        w: WrappedWidget,
         attr_map: Hashable | Mapping[Hashable | None, Hashable] | None,
         focus_map: Hashable | Mapping[Hashable | None, Hashable] | None = None,
     ) -> None:

--- a/urwid/widget/bar_graph.py
+++ b/urwid/widget/bar_graph.py
@@ -636,10 +636,10 @@ class GraphVScale(Widget):
         if not combinelist:
             return SolidCanvas(" ", size[0], size[1])
 
-        c = CanvasCombine(combinelist)
+        canvas = CanvasCombine(combinelist)
         if maxrow - rows:
-            c.pad_trim_top_bottom(0, maxrow - rows)
-        return c
+            canvas.pad_trim_top_bottom(0, maxrow - rows)
+        return canvas
 
 
 def scale_bar_values(bar, top: float, maxrow: int) -> list[int]:

--- a/urwid/widget/big_text.py
+++ b/urwid/widget/big_text.py
@@ -9,6 +9,8 @@ from .constants import Sizing
 from .widget import Widget, fixed_size
 
 if typing.TYPE_CHECKING:
+    from collections.abc import Hashable
+
     from urwid import Font
 
 
@@ -50,7 +52,7 @@ class BigText(Widget):
 
     def render(self, size: tuple[()], focus: bool = False) -> CompositeCanvas:
         fixed_size(size)  # complain if parameter is wrong
-        a = None
+        a: Hashable | None = None
         ai = ak = 0
         o = []
         rows = self.font.height
@@ -64,7 +66,7 @@ class BigText(Widget):
             if not width:
                 # ignore invalid characters
                 continue
-            c = self.font.render(ch)
+            c: TextCanvas | CompositeCanvas = self.font.render(ch)
             if a is not None:
                 c = CompositeCanvas(c)
                 c.fill_attr(a)

--- a/urwid/widget/box_adapter.py
+++ b/urwid/widget/box_adapter.py
@@ -8,24 +8,21 @@ from urwid.canvas import CompositeCanvas
 from .constants import Sizing
 from .widget_decoration import WidgetDecoration, WidgetError
 
-if typing.TYPE_CHECKING:
-    from .widget import Widget
-
-WrappedWidget_co = typing.TypeVar("WrappedWidget_co", bound="Widget", covariant=True)
+WrappedWidget = typing.TypeVar("WrappedWidget")
 
 
 class BoxAdapterError(WidgetError):
     pass
 
 
-class BoxAdapter(WidgetDecoration[WrappedWidget_co]):
+class BoxAdapter(WidgetDecoration[WrappedWidget]):
     """
     Adapter for using a box widget where a flow widget would usually go
     """
 
     no_cache: typing.ClassVar[list[str]] = ["rows"]
 
-    def __init__(self, box_widget: WrappedWidget_co, height: int) -> None:
+    def __init__(self, box_widget: WrappedWidget, height: int) -> None:
         """
         Create a flow widget that contains a box widget
 
@@ -49,7 +46,7 @@ class BoxAdapter(WidgetDecoration[WrappedWidget_co]):
 
     # originally stored as box_widget, keep for compatibility
     @property
-    def box_widget(self) -> WrappedWidget_co:
+    def box_widget(self) -> WrappedWidget:
         warnings.warn(
             "original stored as original_widget, keep for compatibility",
             PendingDeprecationWarning,
@@ -58,7 +55,7 @@ class BoxAdapter(WidgetDecoration[WrappedWidget_co]):
         return self.original_widget
 
     @box_widget.setter
-    def box_widget(self, widget: WrappedWidget_co) -> None:
+    def box_widget(self, widget: WrappedWidget) -> None:
         warnings.warn(
             "original stored as original_widget, keep for compatibility",
             PendingDeprecationWarning,

--- a/urwid/widget/columns.py
+++ b/urwid/widget/columns.py
@@ -238,10 +238,12 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         self._cache_column_widths: list[int] = []
         super().__init__()
         self._contents: MonitoredFocusList[
-            Widget,
-            tuple[Literal[WHSettings.PACK], None, bool]
-            | tuple[Literal[WHSettings.GIVEN], int, bool]
-            | tuple[Literal[WHSettings.WEIGHT], int | float, bool],
+            tuple[
+                Widget,
+                tuple[Literal[WHSettings.PACK], None, bool]
+                | tuple[Literal[WHSettings.GIVEN], int, bool]
+                | tuple[Literal[WHSettings.WEIGHT], int | float, bool],
+            ],
         ] = MonitoredFocusList()
         self._contents.set_modified_callback(self._contents_modified)
         self._contents.set_focus_changed_callback(lambda f: self._invalidate())
@@ -442,10 +444,12 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
     def contents(
         self,
     ) -> MonitoredFocusList[
-        Widget,
-        tuple[Literal[WHSettings.PACK], None, bool]
-        | tuple[Literal[WHSettings.GIVEN], int, bool]
-        | tuple[Literal[WHSettings.WEIGHT], int | float, bool],
+        tuple[
+            Widget,
+            tuple[Literal[WHSettings.PACK], None, bool]
+            | tuple[Literal[WHSettings.GIVEN], int, bool]
+            | tuple[Literal[WHSettings.WEIGHT], int | float, bool],
+        ],
     ]:
         """
         The contents of this Columns as a list of `(widget, options)` tuples.

--- a/urwid/widget/filler.py
+++ b/urwid/widget/filler.py
@@ -22,20 +22,17 @@ from .widget_decoration import WidgetDecoration, WidgetError
 if typing.TYPE_CHECKING:
     from typing_extensions import Literal
 
-    from .widget import Widget
-
-
-WrappedWidget_co = typing.TypeVar("WrappedWidget_co", bound="Widget", covariant=True)
+WrappedWidget = typing.TypeVar("WrappedWidget")
 
 
 class FillerError(WidgetError):
     pass
 
 
-class Filler(WidgetDecoration[WrappedWidget_co]):
+class Filler(WidgetDecoration[WrappedWidget]):
     def __init__(
         self,
-        body: WrappedWidget_co,
+        body: WrappedWidget,
         valign: (
             Literal["top", "middle", "bottom"] | VAlign | tuple[Literal["relative", WHSettings.RELATIVE], int]
         ) = VAlign.MIDDLE,
@@ -162,7 +159,7 @@ class Filler(WidgetDecoration[WrappedWidget_co]):
         return remove_defaults(attrs, Filler.__init__)
 
     @property
-    def body(self) -> WrappedWidget_co:
+    def body(self) -> WrappedWidget:
         """backwards compatibility, widget used to be stored as body"""
         warnings.warn(
             "backwards compatibility, widget used to be stored as body",
@@ -172,7 +169,7 @@ class Filler(WidgetDecoration[WrappedWidget_co]):
         return self.original_widget
 
     @body.setter
-    def body(self, new_body: WrappedWidget_co) -> None:
+    def body(self, new_body: WrappedWidget) -> None:
         warnings.warn(
             "backwards compatibility, widget used to be stored as body",
             PendingDeprecationWarning,
@@ -180,7 +177,7 @@ class Filler(WidgetDecoration[WrappedWidget_co]):
         )
         self.original_widget = new_body
 
-    def get_body(self) -> WrappedWidget_co:
+    def get_body(self) -> WrappedWidget:
         """backwards compatibility, widget used to be stored as body"""
         warnings.warn(
             "backwards compatibility, widget used to be stored as body",
@@ -189,7 +186,7 @@ class Filler(WidgetDecoration[WrappedWidget_co]):
         )
         return self.original_widget
 
-    def set_body(self, new_body: WrappedWidget_co) -> None:
+    def set_body(self, new_body: WrappedWidget) -> None:
         warnings.warn(
             "backwards compatibility, widget used to be stored as body",
             DeprecationWarning,

--- a/urwid/widget/frame.py
+++ b/urwid/widget/frame.py
@@ -17,9 +17,9 @@ if typing.TYPE_CHECKING:
     from typing_extensions import Literal
 
 
-BodyWidget_co = typing.TypeVar("BodyWidget_co", bound=Widget, covariant=True)
-HeaderWidget_co = typing.TypeVar("HeaderWidget_co", Widget, None, covariant=True)
-FooterWidget_co = typing.TypeVar("FooterWidget_co", Widget, None, covariant=True)
+BodyWidget = typing.TypeVar("BodyWidget")
+HeaderWidget = typing.TypeVar("HeaderWidget")
+FooterWidget = typing.TypeVar("FooterWidget")
 
 
 class FrameError(WidgetError):
@@ -39,7 +39,7 @@ def _check_widget_subclass(widget: Widget | None) -> None:
         )
 
 
-class Frame(Widget, WidgetContainerMixin, typing.Generic[BodyWidget_co, HeaderWidget_co, FooterWidget_co]):
+class Frame(Widget, WidgetContainerMixin, typing.Generic[BodyWidget, HeaderWidget, FooterWidget]):
     """
     Frame widget is a box widget with optional header and footer
     flow widgets placed above and below the box widget.
@@ -54,9 +54,9 @@ class Frame(Widget, WidgetContainerMixin, typing.Generic[BodyWidget_co, HeaderWi
 
     def __init__(
         self,
-        body: BodyWidget_co,
-        header: HeaderWidget_co = None,
-        footer: FooterWidget_co = None,
+        body: BodyWidget,
+        header: HeaderWidget = None,
+        footer: FooterWidget = None,
         focus_part: Literal["header", "footer", "body"] | Widget = "body",
     ):
         """
@@ -90,18 +90,18 @@ class Frame(Widget, WidgetContainerMixin, typing.Generic[BodyWidget_co, HeaderWi
         _check_widget_subclass(footer)
 
     @property
-    def header(self) -> HeaderWidget_co:
+    def header(self) -> HeaderWidget:
         return self._header
 
     @header.setter
-    def header(self, header: HeaderWidget_co) -> None:
+    def header(self, header: HeaderWidget) -> None:
         _check_widget_subclass(header)
         self._header = header
         if header is None and self.focus_part == "header":
             self.focus_part = "body"
         self._invalidate()
 
-    def get_header(self) -> HeaderWidget_co:
+    def get_header(self) -> HeaderWidget:
         warnings.warn(
             f"method `{self.__class__.__name__}.get_header` is deprecated, "
             f"standard property `{self.__class__.__name__}.header` should be used instead",
@@ -110,7 +110,7 @@ class Frame(Widget, WidgetContainerMixin, typing.Generic[BodyWidget_co, HeaderWi
         )
         return self.header
 
-    def set_header(self, header: HeaderWidget_co) -> None:
+    def set_header(self, header: HeaderWidget) -> None:
         warnings.warn(
             f"method `{self.__class__.__name__}.set_header` is deprecated, "
             f"standard property `{self.__class__.__name__}.header` should be used instead",
@@ -120,16 +120,16 @@ class Frame(Widget, WidgetContainerMixin, typing.Generic[BodyWidget_co, HeaderWi
         self.header = header
 
     @property
-    def body(self) -> BodyWidget_co:
+    def body(self) -> BodyWidget:
         return self._body
 
     @body.setter
-    def body(self, body: BodyWidget_co) -> None:
+    def body(self, body: BodyWidget) -> None:
         _check_widget_subclass(body)
         self._body = body
         self._invalidate()
 
-    def get_body(self) -> BodyWidget_co:
+    def get_body(self) -> BodyWidget:
         warnings.warn(
             f"method `{self.__class__.__name__}.get_body` is deprecated, "
             f"standard property {self.__class__.__name__}.body should be used instead",
@@ -138,7 +138,7 @@ class Frame(Widget, WidgetContainerMixin, typing.Generic[BodyWidget_co, HeaderWi
         )
         return self.body
 
-    def set_body(self, body: BodyWidget_co) -> None:
+    def set_body(self, body: BodyWidget) -> None:
         warnings.warn(
             f"method `{self.__class__.__name__}.set_body` is deprecated, "
             f"standard property `{self.__class__.__name__}.body` should be used instead",
@@ -148,18 +148,18 @@ class Frame(Widget, WidgetContainerMixin, typing.Generic[BodyWidget_co, HeaderWi
         self.body = body
 
     @property
-    def footer(self) -> FooterWidget_co:
+    def footer(self) -> FooterWidget:
         return self._footer
 
     @footer.setter
-    def footer(self, footer: FooterWidget_co) -> None:
+    def footer(self, footer: FooterWidget) -> None:
         _check_widget_subclass(footer)
         self._footer = footer
         if footer is None and self.focus_part == "footer":
             self.focus_part = "body"
         self._invalidate()
 
-    def get_footer(self) -> FooterWidget_co:
+    def get_footer(self) -> FooterWidget:
         warnings.warn(
             f"method `{self.__class__.__name__}.get_footer` is deprecated, "
             f"standard property `{self.__class__.__name__}.footer` should be used instead",
@@ -168,7 +168,7 @@ class Frame(Widget, WidgetContainerMixin, typing.Generic[BodyWidget_co, HeaderWi
         )
         return self.footer
 
-    def set_footer(self, footer: FooterWidget_co) -> None:
+    def set_footer(self, footer: FooterWidget) -> None:
         warnings.warn(
             f"method `{self.__class__.__name__}.set_footer` is deprecated, "
             f"standard property `{self.__class__.__name__}.footer` should be used instead",
@@ -232,13 +232,13 @@ class Frame(Widget, WidgetContainerMixin, typing.Generic[BodyWidget_co, HeaderWi
         self.focus_position = part
 
     @property
-    def focus(self) -> BodyWidget_co | HeaderWidget_co | FooterWidget_co:
+    def focus(self) -> BodyWidget | HeaderWidget | FooterWidget:
         """
         child :class:`Widget` in focus: the body, header or footer widget.
         This is a read-only property."""
         return {"header": self._header, "footer": self._footer, "body": self._body}[self.focus_part]
 
-    def _get_focus(self) -> BodyWidget_co | HeaderWidget_co | FooterWidget_co:
+    def _get_focus(self) -> BodyWidget | HeaderWidget | FooterWidget:
         warnings.warn(
             f"method `{self.__class__.__name__}._get_focus` is deprecated, "
             f"please use `{self.__class__.__name__}.focus` property",
@@ -252,7 +252,7 @@ class Frame(Widget, WidgetContainerMixin, typing.Generic[BodyWidget_co, HeaderWi
         self,
     ) -> MutableMapping[
         Literal["header", "footer", "body"],
-        tuple[BodyWidget_co | HeaderWidget_co | FooterWidget_co, None],
+        tuple[BodyWidget | HeaderWidget | FooterWidget, None],
     ]:
         """
         a dict-like object similar to::
@@ -279,7 +279,7 @@ class Frame(Widget, WidgetContainerMixin, typing.Generic[BodyWidget_co, HeaderWi
         class FrameContents(
             typing.MutableMapping[
                 str,
-                typing.Tuple[typing.Union[BodyWidget_co, HeaderWidget_co, FooterWidget_co], None],
+                typing.Tuple[typing.Union[BodyWidget, HeaderWidget, FooterWidget], None],
             ]
         ):
             # pylint: disable=no-self-argument
@@ -313,17 +313,17 @@ class Frame(Widget, WidgetContainerMixin, typing.Generic[BodyWidget_co, HeaderWi
         return keys
 
     @typing.overload
-    def _contents__getitem__(self, key: Literal["body"]) -> tuple[BodyWidget_co, None]: ...
+    def _contents__getitem__(self, key: Literal["body"]) -> tuple[BodyWidget, None]: ...
 
     @typing.overload
-    def _contents__getitem__(self, key: Literal["header"]) -> tuple[HeaderWidget_co, None]: ...
+    def _contents__getitem__(self, key: Literal["header"]) -> tuple[HeaderWidget, None]: ...
 
     @typing.overload
-    def _contents__getitem__(self, key: Literal["footer"]) -> tuple[FooterWidget_co, None]: ...
+    def _contents__getitem__(self, key: Literal["footer"]) -> tuple[FooterWidget, None]: ...
 
     def _contents__getitem__(
         self, key: Literal["body", "header", "footer"]
-    ) -> tuple[BodyWidget_co | HeaderWidget_co | FooterWidget_co, None]:
+    ) -> tuple[BodyWidget | HeaderWidget | FooterWidget, None]:
         if key == "body":
             return (self._body, None)
         if key == "header" and self._header:
@@ -333,18 +333,18 @@ class Frame(Widget, WidgetContainerMixin, typing.Generic[BodyWidget_co, HeaderWi
         raise KeyError(f"Frame.contents has no key: {key!r}")
 
     @typing.overload
-    def _contents__setitem__(self, key: Literal["body"], value: tuple[BodyWidget_co, None]) -> None: ...
+    def _contents__setitem__(self, key: Literal["body"], value: tuple[BodyWidget, None]) -> None: ...
 
     @typing.overload
-    def _contents__setitem__(self, key: Literal["header"], value: tuple[HeaderWidget_co, None]) -> None: ...
+    def _contents__setitem__(self, key: Literal["header"], value: tuple[HeaderWidget, None]) -> None: ...
 
     @typing.overload
-    def _contents__setitem__(self, key: Literal["footer"], value: tuple[FooterWidget_co, None]) -> None: ...
+    def _contents__setitem__(self, key: Literal["footer"], value: tuple[FooterWidget, None]) -> None: ...
 
     def _contents__setitem__(
         self,
         key: Literal["body", "header", "footer"],
-        value: tuple[BodyWidget_co | HeaderWidget_co | FooterWidget_co, None],
+        value: tuple[BodyWidget | HeaderWidget | FooterWidget, None],
     ) -> None:
         if key not in {"body", "header", "footer"}:
             raise KeyError(f"Frame.contents has no key: {key!r}")

--- a/urwid/widget/line_box.py
+++ b/urwid/widget/line_box.py
@@ -15,15 +15,15 @@ if typing.TYPE_CHECKING:
 
     from .widget import Widget
 
-WrappedWidget_co = typing.TypeVar("WrappedWidget_co", bound="Widget", covariant=True)
+WrappedWidget = typing.TypeVar("WrappedWidget")
 
 
-class LineBox(WidgetDecoration[WrappedWidget_co], delegate_to_widget_mixin("_wrapped_widget")):
+class LineBox(WidgetDecoration[WrappedWidget], delegate_to_widget_mixin("_wrapped_widget")):
     Symbols = BOX_SYMBOLS
 
     def __init__(
         self,
-        original_widget: WrappedWidget_co,
+        original_widget: WrappedWidget,
         title: str = "",
         title_align: Literal["left", "center", "right"] | Align = Align.CENTER,
         title_attr=None,

--- a/urwid/widget/overlay.py
+++ b/urwid/widget/overlay.py
@@ -32,8 +32,8 @@ if typing.TYPE_CHECKING:
     from typing_extensions import Literal
 
 
-TopWidget_co = typing.TypeVar("TopWidget_co", bound=Widget, covariant=True)
-BottomWidget_co = typing.TypeVar("BottomWidget_co", bound=Widget, covariant=True)
+TopWidget = typing.TypeVar("TopWidget")
+BottomWidget = typing.TypeVar("BottomWidget")
 
 
 class OverlayError(WidgetError):
@@ -71,9 +71,7 @@ class OverlayOptions(typing.NamedTuple):
     bottom: int
 
 
-class Overlay(
-    Widget, WidgetContainerMixin, WidgetContainerListContentsMixin, typing.Generic[TopWidget_co, BottomWidget_co]
-):
+class Overlay(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin, typing.Generic[TopWidget, BottomWidget]):
     """
     Overlay contains two box widgets and renders one on top of the other
     """
@@ -99,8 +97,8 @@ class Overlay(
 
     def __init__(
         self,
-        top_w: TopWidget_co,
-        bottom_w: BottomWidget_co,
+        top_w: TopWidget,
+        bottom_w: BottomWidget,
         align: (
             Literal["left", "center", "right"]
             | Align
@@ -493,7 +491,7 @@ class Overlay(
         )
 
     @property
-    def focus(self) -> TopWidget_co:
+    def focus(self) -> TopWidget:
         """
         Read-only property returning the child widget in focus for
         container widgets.  This default implementation
@@ -501,7 +499,7 @@ class Overlay(
         """
         return self.top_w
 
-    def _get_focus(self) -> TopWidget_co:
+    def _get_focus(self) -> TopWidget:
         warnings.warn(
             f"method `{self.__class__.__name__}._get_focus` is deprecated, "
             f"please use `{self.__class__.__name__}.focus` property",
@@ -576,9 +574,7 @@ class Overlay(
         """
 
         # noinspection PyMethodParameters
-        class OverlayContents(
-            typing.Sequence[typing.Tuple[typing.Union[TopWidget_co, BottomWidget_co], OverlayOptions]]
-        ):
+        class OverlayContents(typing.Sequence[typing.Tuple[typing.Union[TopWidget, BottomWidget], OverlayOptions]]):
             # pylint: disable=no-self-argument
             def __len__(inner_self) -> int:
                 return 2
@@ -609,7 +605,7 @@ class Overlay(
     def _contents__getitem__(
         self,
         index: Literal[0, 1],
-    ) -> tuple[TopWidget_co | BottomWidget_co, OverlayOptions]:
+    ) -> tuple[TopWidget | BottomWidget, OverlayOptions]:
         if index == 0:
             return (self.bottom_w, self._DEFAULT_BOTTOM_OPTIONS)
 
@@ -638,7 +634,7 @@ class Overlay(
     def _contents__setitem__(
         self,
         index: Literal[0, 1],
-        value: tuple[TopWidget_co | BottomWidget_co, OverlayOptions],
+        value: tuple[TopWidget | BottomWidget, OverlayOptions],
     ) -> None:
         try:
             value_w, value_options = value

--- a/urwid/widget/padding.py
+++ b/urwid/widget/padding.py
@@ -22,10 +22,7 @@ from .widget_decoration import WidgetDecoration, WidgetError, WidgetWarning
 if typing.TYPE_CHECKING:
     from typing_extensions import Literal
 
-    from .widget import Widget
-
-
-WrappedWidget_co = typing.TypeVar("WrappedWidget_co", bound="Widget", covariant=True)
+WrappedWidget = typing.TypeVar("WrappedWidget")
 
 
 class PaddingError(WidgetError):
@@ -36,10 +33,10 @@ class PaddingWarning(WidgetWarning):
     """Padding related warnings."""
 
 
-class Padding(WidgetDecoration[WrappedWidget_co], typing.Generic[WrappedWidget_co]):
+class Padding(WidgetDecoration[WrappedWidget], typing.Generic[WrappedWidget]):
     def __init__(
         self,
-        w: WrappedWidget_co,
+        w: WrappedWidget,
         align: (
             Literal["left", "center", "right"] | Align | tuple[Literal["relative", WHSettings.RELATIVE], int]
         ) = Align.LEFT,

--- a/urwid/widget/popup.py
+++ b/urwid/widget/popup.py
@@ -43,11 +43,11 @@ if typing.TYPE_CHECKING:
         overlay_height: int
 
 
-WrappedWidget_co = typing.TypeVar("WrappedWidget_co", bound="Widget", covariant=True)
+WrappedWidget = typing.TypeVar("WrappedWidget")
 
 
-class PopUpLauncher(delegate_to_widget_mixin("_original_widget"), WidgetDecoration[WrappedWidget_co]):
-    def __init__(self, original_widget: [WrappedWidget_co]) -> None:
+class PopUpLauncher(delegate_to_widget_mixin("_original_widget"), WidgetDecoration[WrappedWidget]):
+    def __init__(self, original_widget: [WrappedWidget]) -> None:
         super().__init__(original_widget)
         self._pop_up_widget = None
 
@@ -85,13 +85,13 @@ class PopUpLauncher(delegate_to_widget_mixin("_original_widget"), WidgetDecorati
         return canv
 
 
-class PopUpTarget(WidgetDecoration[WrappedWidget_co]):
+class PopUpTarget(WidgetDecoration[WrappedWidget]):
     # FIXME: this whole class is a terrible hack and must be fixed
     # when layout and rendering are separated
     _sizing = frozenset((Sizing.BOX,))
     _selectable = True
 
-    def __init__(self, original_widget: WrappedWidget_co) -> None:
+    def __init__(self, original_widget: WrappedWidget) -> None:
         super().__init__(original_widget)
         self._pop_up = None
         self._current_widget = self._original_widget

--- a/urwid/widget/scrollable.py
+++ b/urwid/widget/scrollable.py
@@ -43,7 +43,7 @@ if typing.TYPE_CHECKING:
 __all__ = ("ScrollBar", "Scrollable", "ScrollableError", "ScrollbarSymbols")
 
 
-WrappedWidget_co = typing.TypeVar("WrappedWidget_co", bound="Widget", covariant=True)
+WrappedWidget = typing.TypeVar("WrappedWidget")
 
 
 class ScrollableError(WidgetError):
@@ -122,14 +122,14 @@ class SupportsScroll(Protocol):
     def rows_max(self, size: tuple[int, int] | None = None, focus: bool = False) -> int: ...
 
 
-class Scrollable(WidgetDecoration[WrappedWidget_co]):
+class Scrollable(WidgetDecoration[WrappedWidget]):
     def sizing(self) -> frozenset[Sizing]:
         return frozenset((Sizing.BOX,))
 
     def selectable(self) -> bool:
         return True
 
-    def __init__(self, widget: WrappedWidget_co, force_forward_keypress: bool = False) -> None:
+    def __init__(self, widget: WrappedWidget, force_forward_keypress: bool = False) -> None:
         """Box widget that makes a fixed or flow widget vertically scrollable
 
         .. note::
@@ -424,7 +424,7 @@ class Scrollable(WidgetDecoration[WrappedWidget_co]):
         return self._rows_max_cached
 
 
-class ScrollBar(WidgetDecoration[WrappedWidget_co]):
+class ScrollBar(WidgetDecoration[WrappedWidget]):
     Symbols = ScrollbarSymbols
 
     def sizing(self):
@@ -435,7 +435,7 @@ class ScrollBar(WidgetDecoration[WrappedWidget_co]):
 
     def __init__(
         self,
-        widget: WrappedWidget_co,
+        widget: WrappedWidget,
         thumb_char: str = ScrollbarSymbols.FULL_BLOCK,
         trough_char: str = " ",
         side: Literal["left", "right"] = SCROLLBAR_RIGHT,

--- a/urwid/widget/text.py
+++ b/urwid/widget/text.py
@@ -72,7 +72,7 @@ class Text(Widget):
         [('bold', 5)]
         """
         super().__init__()
-        self._cache_maxcol = None
+        self._cache_maxcol: int | None = None
         self.set_text(markup)
         self.set_layout(align, wrap, layout)
 

--- a/urwid/widget/widget.py
+++ b/urwid/widget/widget.py
@@ -37,7 +37,7 @@ from .constants import Sizing
 if typing.TYPE_CHECKING:
     from collections.abc import Callable, Hashable
 
-WrappedWidget_co = typing.TypeVar("WrappedWidget_co", bound="Widget", covariant=True)
+WrappedWidget = typing.TypeVar("WrappedWidget")
 LOGGER = logging.getLogger(__name__)
 
 
@@ -751,8 +751,8 @@ class WidgetWrapError(Exception):
     pass
 
 
-class WidgetWrap(delegate_to_widget_mixin("_wrapped_widget"), typing.Generic[WrappedWidget_co]):
-    def __init__(self, w: WrappedWidget_co) -> None:
+class WidgetWrap(delegate_to_widget_mixin("_wrapped_widget"), typing.Generic[WrappedWidget]):
+    def __init__(self, w: WrappedWidget) -> None:
         """
         w -- widget to wrap, stored as self._w
 
@@ -777,11 +777,11 @@ class WidgetWrap(delegate_to_widget_mixin("_wrapped_widget"), typing.Generic[Wra
         self._wrapped_widget = w
 
     @property
-    def _w(self) -> WrappedWidget_co:
+    def _w(self) -> WrappedWidget:
         return self._wrapped_widget
 
     @_w.setter
-    def _w(self, new_widget: WrappedWidget_co) -> None:
+    def _w(self, new_widget: WrappedWidget) -> None:
         """
         Change the wrapped widget.  This is meant to be called
         only by subclasses.
@@ -801,7 +801,7 @@ class WidgetWrap(delegate_to_widget_mixin("_wrapped_widget"), typing.Generic[Wra
         self._wrapped_widget = new_widget
         self._invalidate()
 
-    def _set_w(self, w: WrappedWidget_co) -> None:
+    def _set_w(self, w: WrappedWidget) -> None:
         """
         Change the wrapped widget.  This is meant to be called
         only by subclasses.

--- a/urwid/widget/widget_decoration.py
+++ b/urwid/widget/widget_decoration.py
@@ -22,10 +22,10 @@ __all__ = (
     "delegate_to_widget_mixin",
 )
 
-WrappedWidget_co = typing.TypeVar("WrappedWidget_co", bound=Widget, covariant=True)
+WrappedWidget = typing.TypeVar("WrappedWidget")
 
 
-class WidgetDecoration(Widget, typing.Generic[WrappedWidget_co]):  # pylint: disable=abstract-method
+class WidgetDecoration(Widget, typing.Generic[WrappedWidget]):  # pylint: disable=abstract-method
     """
     original_widget -- the widget being decorated
 
@@ -45,7 +45,7 @@ class WidgetDecoration(Widget, typing.Generic[WrappedWidget_co]):  # pylint: dis
         Implement it or forward to the widget in the subclass.
     """
 
-    def __init__(self, original_widget: WrappedWidget_co) -> None:
+    def __init__(self, original_widget: WrappedWidget) -> None:
         # TODO(Aleksei): reduce amount of multiple inheritance usage
         # Special case: subclasses with multiple inheritance causes `super` call wrong way
         # Call parent __init__ explicit
@@ -63,15 +63,15 @@ class WidgetDecoration(Widget, typing.Generic[WrappedWidget_co]):  # pylint: dis
         return [*super()._repr_words(), repr(self._original_widget)]
 
     @property
-    def original_widget(self) -> WrappedWidget_co:
+    def original_widget(self) -> WrappedWidget:
         return self._original_widget
 
     @original_widget.setter
-    def original_widget(self, original_widget: WrappedWidget_co) -> None:
+    def original_widget(self, original_widget: WrappedWidget) -> None:
         self._original_widget = original_widget
         self._invalidate()
 
-    def _get_original_widget(self) -> WrappedWidget_co:
+    def _get_original_widget(self) -> WrappedWidget:
         warnings.warn(
             f"Method `{self.__class__.__name__}._get_original_widget` is deprecated, "
             f"please use property `{self.__class__.__name__}.original_widget`",
@@ -80,7 +80,7 @@ class WidgetDecoration(Widget, typing.Generic[WrappedWidget_co]):  # pylint: dis
         )
         return self.original_widget
 
-    def _set_original_widget(self, original_widget: WrappedWidget_co) -> None:
+    def _set_original_widget(self, original_widget: WrappedWidget) -> None:
         warnings.warn(
             f"Method `{self.__class__.__name__}._set_original_widget` is deprecated, "
             f"please use property `{self.__class__.__name__}.original_widget`",
@@ -126,7 +126,7 @@ class WidgetDecoration(Widget, typing.Generic[WrappedWidget_co]):  # pylint: dis
         return self._original_widget.sizing()
 
 
-class WidgetPlaceholder(delegate_to_widget_mixin("_original_widget"), WidgetDecoration[WrappedWidget_co]):
+class WidgetPlaceholder(delegate_to_widget_mixin("_original_widget"), WidgetDecoration[WrappedWidget]):
     """
     This is a do-nothing decoration widget that can be used for swapping
     between widgets without modifying the container of this widget.
@@ -139,7 +139,7 @@ class WidgetPlaceholder(delegate_to_widget_mixin("_original_widget"), WidgetDeco
     """
 
 
-class WidgetDisable(WidgetDecoration[WrappedWidget_co]):
+class WidgetDisable(WidgetDecoration[WrappedWidget]):
     """
     A decoration widget that disables interaction with the widget it
     wraps.  This widget always passes focus=False to the wrapped widget,


### PR DESCRIPTION
* cheaper to reduce type information than having MyPy war
* fix `Columns.contents` typing annotation
