### PR TITLE
Fix MyPy warnings

### DIFF
--- a/tests/test_grid_flow.py
+++ b/tests/test_grid_flow.py
@@ -84,6 +84,59 @@ class GridFlowTest(unittest.TestCase):
         gf = urwid.GridFlow([], 5, 0, 0, "left")
         self.assertEqual(gf.cell_width, 5)
 
+    def test_not_fit(self):
+        """Test scenario with maxcol < cell_width (special case, warning will be produced)."""
+        widget = urwid.GridFlow(
+            [urwid.Button("first"), urwid.Button("second")],
+            5,
+            0,
+            0,
+            "left",
+        )
+        size = (3,)
+        with self.assertWarns(urwid.widget.GridFlowWarning):
+            canvas = widget.render(size)
+
+        self.assertEqual(
+            ("< f", "  i", "  r", "  s", "  t", "< s", "  e", "  c", "  o", "  n", "  d"),
+            canvas.decoded_text,
+        )
+
+    def test_multiline(self):
+        """Test widgets fit only with multiple lines"""
+        widget = urwid.GridFlow(
+            [urwid.Button("first"), urwid.Button("second")],
+            10,
+            0,
+            0,
+            "left",
+        )
+        size = (10,)
+        canvas = widget.render(size)
+        self.assertEqual(
+            ("< first  >", "< second >"),
+            canvas.decoded_text,
+        )
+
+    def test_multiline_2(self):
+        """Test widgets fit only with multiple lines"""
+        widget = urwid.GridFlow(
+            [urwid.Button("first"), urwid.Button("second"), urwid.Button("third"), urwid.Button("forth")],
+            10,
+            0,
+            0,
+            "left",
+        )
+        size = (20,)
+        canvas = widget.render(size)
+        self.assertEqual(
+            (
+                "< first  >< second >",
+                "< third  >< forth  >",
+            ),
+            canvas.decoded_text,
+        )
+
     def test_basics(self):
         repr(urwid.GridFlow([], 5, 0, 0, "left"))  # should not fail
 

--- a/urwid/canvas.py
+++ b/urwid/canvas.py
@@ -216,7 +216,7 @@ class Canvas:
     def __init__(self) -> None:
         """Base Canvas class"""
         self._widget_info = None
-        self.coords: dict[str, tuple[int, int, tuple[Widget, int, int]]] = {}
+        self.coords: dict[str, tuple[int, int, tuple[Widget, int, int]] | tuple[int, int, None]] = {}
         self.shortcuts: dict[str, str] = {}
 
     def finalize(

--- a/urwid/display/_posix_raw_display.py
+++ b/urwid/display/_posix_raw_display.py
@@ -43,7 +43,6 @@ from . import _raw_display_base, escape
 from .common import INPUT_DESCRIPTORS_CHANGED
 
 if typing.TYPE_CHECKING:
-    import io
     import socket
     from collections.abc import Callable
     from types import FrameType
@@ -54,8 +53,8 @@ if typing.TYPE_CHECKING:
 class Screen(_raw_display_base.Screen):
     def __init__(
         self,
-        input: io.TextIOBase = sys.stdin,  # noqa: A002  # pylint: disable=redefined-builtin
-        output: io.TextIOBase = sys.stdout,
+        input: typing.TextIO = sys.stdin,  # noqa: A002  # pylint: disable=redefined-builtin
+        output: typing.TextIO = sys.stdout,
         bracketed_paste_mode=False,
     ) -> None:
         """Initialize a screen that directly prints escape codes to an output
@@ -223,7 +222,7 @@ class Screen(_raw_display_base.Screen):
 
         super()._stop()
 
-    def get_input_descriptors(self) -> list[socket.socket | io.IOBase | typing.IO | int]:
+    def get_input_descriptors(self) -> list[socket.socket | typing.IO | int]:
         """
         Return a list of integer file descriptors that should be
         polled in external event loops to check for user input.

--- a/urwid/display/_raw_display_base.py
+++ b/urwid/display/_raw_display_base.py
@@ -41,7 +41,6 @@ from . import escape
 from .common import UNPRINTABLE_TRANS_TABLE, UPDATE_PALETTE_ENTRY, AttrSpec, BaseScreen, RealTerminal
 
 if typing.TYPE_CHECKING:
-    import io
     from collections.abc import Callable, Iterable
     from types import FrameType
 
@@ -54,7 +53,7 @@ IS_WSL = (sys.platform == "linux") and ("wsl" in platform.platform().lower())
 
 
 class Screen(BaseScreen, RealTerminal):
-    def __init__(self, input: io.IOBase, output: io.IOBase):  # noqa: A002  # pylint: disable=redefined-builtin
+    def __init__(self, input: typing.IO, output: typing.IO) -> None:  # noqa: A002  # pylint: disable=redefined-builtin
         """Initialize a screen that directly prints escape codes to an output
         terminal.
         """
@@ -116,7 +115,7 @@ class Screen(BaseScreen, RealTerminal):
         self.screen_buf = None
 
     @property
-    def _term_input_io(self) -> io.IOBase | None:
+    def _term_input_io(self) -> typing.IO | None:
         if hasattr(self._term_input_file, "fileno"):
             return self._term_input_file
         return None
@@ -310,7 +309,7 @@ class Screen(BaseScreen, RealTerminal):
             return keys, raw
         return keys
 
-    def get_input_descriptors(self) -> list[socket.socket | io.IOBase | typing.IO | int]:
+    def get_input_descriptors(self) -> list[socket.socket | typing.IO | int]:
         """
         Return a list of integer file descriptors that should be
         polled in external event loops to check for user input.
@@ -323,7 +322,7 @@ class Screen(BaseScreen, RealTerminal):
         if not self._started:
             return []
 
-        fd_list = [self._resize_pipe_rd]
+        fd_list: list[socket.socket | typing.IO | int] = [self._resize_pipe_rd]
         input_io = self._term_input_io
         if input_io is not None:
             fd_list.append(input_io)

--- a/urwid/display/_win32_raw_display.py
+++ b/urwid/display/_win32_raw_display.py
@@ -41,7 +41,6 @@ from . import _raw_display_base, _win32, escape
 from .common import INPUT_DESCRIPTORS_CHANGED
 
 if typing.TYPE_CHECKING:
-    import io
     from collections.abc import Callable
 
     from urwid.event_loop import EventLoop
@@ -53,7 +52,7 @@ class Screen(_raw_display_base.Screen):
     def __init__(
         self,
         input: socket.socket | None = None,  # noqa: A002  # pylint: disable=redefined-builtin
-        output: io.TextIOBase = sys.stdout,
+        output: typing.TextIO = sys.stdout,
     ) -> None:
         """Initialize a screen that directly prints escape codes to an output
         terminal.

--- a/urwid/display/curses.py
+++ b/urwid/display/curses.py
@@ -103,7 +103,7 @@ _curses_colours = {  # pylint: disable=consider-using-namedtuple-or-dataclass  #
 
 
 class Screen(BaseScreen, RealTerminal):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.curses_pairs = [(None, None)]  # Can't be sure what pair 0 will default to
         self.palette = {}

--- a/urwid/display/html_fragment.py
+++ b/urwid/display/html_fragment.py
@@ -53,7 +53,7 @@ class HtmlGenerator(BaseScreen):
     # class variables
     fragments: typing.ClassVar[list[str]] = []
     sizes: typing.ClassVar[list[tuple[int, int]]] = []
-    keys: typing.ClassVar[list[list[str] | tuple[list[str], list[int]]]] = []
+    keys: typing.ClassVar[list[list[str]]] = []
     started = True
 
     def __init__(self) -> None:

--- a/urwid/event_loop/__init__.py
+++ b/urwid/event_loop/__init__.py
@@ -20,28 +20,28 @@ __all__ = (
 try:
     from .twisted_loop import TwistedEventLoop
 
-    __all__ += ("TwistedEventLoop",)
+    __all__ += ("TwistedEventLoop",)  # type: ignore[assignment]
 except ImportError:
     pass
 
 try:
     from .tornado_loop import TornadoEventLoop
 
-    __all__ += ("TornadoEventLoop",)
+    __all__ += ("TornadoEventLoop",)  # type: ignore[assignment]
 except ImportError:
     pass
 
 try:
     from .glib_loop import GLibEventLoop
 
-    __all__ += ("GLibEventLoop",)
+    __all__ += ("GLibEventLoop",)  # type: ignore[assignment]
 except ImportError:
     pass
 
 try:
     from .trio_loop import TrioEventLoop
 
-    __all__ += ("TrioEventLoop",)
+    __all__ += ("TrioEventLoop",)  # type: ignore[assignment]
 except ImportError:
     pass
 
@@ -50,6 +50,6 @@ if sys.platform != "win32":
     try:
         from .zmq_loop import ZMQEventLoop
 
-        __all__ += ("ZMQEventLoop",)
+        __all__ += ("ZMQEventLoop",)  # type: ignore[assignment]
     except ImportError:
         pass

--- a/urwid/event_loop/main_loop.py
+++ b/urwid/event_loop/main_loop.py
@@ -562,36 +562,41 @@ class MainLoop:
 
         something_handled = False
 
-        for k in keys:
-            if k == "window resize":
+        for key in keys:
+            if key == "window resize":
                 continue
 
-            if isinstance(k, str):
+            if isinstance(key, str):
                 if self._topmost_widget.selectable():
-                    k = self._topmost_widget.keypress(self.screen_size, k)  # noqa: PLW2901
+                    handled_key = self._topmost_widget.keypress(self.screen_size, key)
+                    if not handled_key:
+                        something_handled = True
+                        continue
 
-            elif isinstance(k, tuple):
-                if is_mouse_event(k):
-                    event, button, col, row = k
-                    if hasattr(self._topmost_widget, "mouse_event") and self._topmost_widget.mouse_event(
-                        self.screen_size,
-                        event,
-                        button,
-                        col,
-                        row,
-                        focus=True,
-                    ):
-                        k = None  # noqa: PLW2901
+                    key = handled_key  # noqa: PLW2901
+
+            elif is_mouse_event(key):
+                event, button, col, row = key
+                if hasattr(self._topmost_widget, "mouse_event") and self._topmost_widget.mouse_event(
+                    self.screen_size,
+                    event,
+                    button,
+                    col,
+                    row,
+                    focus=True,
+                ):
+                    something_handled = True
+                    continue
 
             else:
-                raise TypeError(f"{k!r} is not str | tuple[str, int, int, int]")
+                raise TypeError(f"{key!r} is not str | tuple[str, int, int, int]")
 
-            if k:
-                if command_map[k] == Command.REDRAW_SCREEN:
+            if key:
+                if command_map[key] == Command.REDRAW_SCREEN:
                     self.screen.clear()
                     something_handled = True
                 else:
-                    something_handled |= bool(self.unhandled_input(k))
+                    something_handled |= bool(self.unhandled_input(key))
             else:
                 something_handled = True
 

--- a/urwid/event_loop/zmq_loop.py
+++ b/urwid/event_loop/zmq_loop.py
@@ -62,11 +62,11 @@ class ZMQEventLoop(EventLoop):
 
     _alarm_break = count()
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
         self._did_something = True
-        self._alarms = []
+        self._alarms: list[tuple[float, int, Callable[[], typing.Any]]] = []
         self._poller = zmq.Poller()
         self._queue_callbacks: dict[int, Callable[[], typing.Any]] = {}
         self._idle_handle = 0

--- a/urwid/numedit.py
+++ b/urwid/numedit.py
@@ -79,7 +79,11 @@ class NumEdit(Edit):
             return self._allow_negative and ch == "-" and self.edit_pos == 0 and "-" not in self.edit_text
         return False
 
-    def keypress(self, size: tuple[int], key: str) -> str | None:
+    def keypress(
+        self,
+        size: tuple[int],  # type: ignore[override]
+        key: str,
+    ) -> str | None:
         """
         Handle editing keystrokes.  Remove leading zeros.
 

--- a/urwid/signals.py
+++ b/urwid/signals.py
@@ -65,7 +65,7 @@ class Key:
 class Signals:
     _signal_attr = "_urwid_signals"  # attribute to attach to signal senders
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._supported = {}
 
     def register(self, sig_cls, signals: Container[Hashable]) -> None:

--- a/urwid/text_layout.py
+++ b/urwid/text_layout.py
@@ -94,7 +94,7 @@ class CanNotDisplayText(Exception):
 
 
 class StandardTextLayout(TextLayout):
-    def __init__(self):  # , tab_stops=(), tab_stop_every=8):
+    def __init__(self) -> None:  # , tab_stops=(), tab_stop_every=8):
         pass
         # """
         # tab_stops -- list of screen column indexes for tab stops
@@ -181,7 +181,7 @@ class StandardTextLayout(TextLayout):
         """Calculate text segments for cases of a text trimmed (wrap is clip or ellipsis)."""
         segments = []
 
-        nl = "\n" if isinstance(text, str) else b"\n"
+        nl: str | bytes = "\n" if isinstance(text, str) else b"\n"
         encoding = get_encoding()
         ellipsis_string = get_ellipsis_string(encoding)
         ellipsis_width = _get_width(ellipsis_string)
@@ -508,7 +508,11 @@ def trim_line(
     return result
 
 
-def calc_line_pos(text: str | bytes, line_layout, pref_col: Literal["left", "right"] | int):
+def calc_line_pos(
+    text: str | bytes,
+    line_layout,
+    pref_col: Literal["left", "right", Align.LEFT, Align.RIGHT] | int,
+):
     """
     Calculate the closest linear position to pref_col given a
     line layout structure.  Returns None if no position found.
@@ -566,7 +570,7 @@ def calc_line_pos(text: str | bytes, line_layout, pref_col: Literal["left", "rig
 def calc_pos(
     text: str | bytes,
     layout: list[list[tuple[int, int, int | bytes] | tuple[int, int | None]]],
-    pref_col: Literal["left", "right"] | int,
+    pref_col: Literal["left", "right", Align.LEFT, Align.RIGHT] | int,
     row: int,
 ) -> int:
     """

--- a/urwid/vterm.py
+++ b/urwid/vterm.py
@@ -721,7 +721,7 @@ class TermCanvas(Canvas):
         x, y = self.term_cursor
 
         if isinstance(char, int):
-            char = chr(char)
+            char = char.to_bytes(1, "little")
 
         dc = self.modes.display_ctrl
 
@@ -986,14 +986,14 @@ class TermCanvas(Canvas):
             chars = 1
 
         if char is None:
-            char = self.empty_char()
+            char_spec = self.empty_char()
         else:
-            char = (self.attrspec, self.charset.current, char)
+            char_spec = (self.attrspec, self.charset.current, char)
 
         x, y = position
 
         while chars > 0:
-            self.term[y].insert(x, char)
+            self.term[y].insert(x, char_spec)
             self.term[y].pop()
             chars -= 1
 
@@ -1187,19 +1187,19 @@ class TermCanvas(Canvas):
                 return _color_desc_256(color)
             return _BASIC_COLORS[color]
 
-        fg = _defaulter(fg, colors)
-        bg = _defaulter(bg, colors)
+        decoded_fg = _defaulter(fg, colors)
+        decoded_bg = _defaulter(bg, colors)
 
         if attributes:
-            fg = ",".join((fg, *list(attributes)))
+            decoded_fg = ",".join((decoded_fg, *list(attributes)))
 
-        if fg == bg == "default":
+        if decoded_fg == decoded_bg == "default":
             return None
 
         if colors:
-            return AttrSpec(fg, bg, colors=colors)
+            return AttrSpec(decoded_fg, decoded_bg, colors=colors)
 
-        return AttrSpec(fg, bg)
+        return AttrSpec(decoded_fg, decoded_bg)
 
     def csi_set_attr(self, attrs: Sequence[int]) -> None:
         """

--- a/urwid/widget/__init__.py
+++ b/urwid/widget/__init__.py
@@ -27,7 +27,7 @@ from .divider import Divider
 from .edit import Edit, EditError, IntEdit
 from .filler import Filler, FillerError, calculate_top_bottom_filler
 from .frame import Frame, FrameError
-from .grid_flow import GridFlow, GridFlowError
+from .grid_flow import GridFlow, GridFlowError, GridFlowWarning
 from .line_box import LineBox
 from .listbox import ListBox, ListBoxError, ListWalker, ListWalkerError, SimpleFocusListWalker, SimpleListWalker
 from .monitored_list import MonitoredFocusList, MonitoredList
@@ -72,6 +72,7 @@ __all__ = (
     "GIVEN",
     "LEFT",
     "MIDDLE",
+    "GridFlowWarning",
     "PACK",
     "RELATIVE",
     "RELATIVE_100",

--- a/urwid/widget/bar_graph.py
+++ b/urwid/widget/bar_graph.py
@@ -611,7 +611,11 @@ class GraphVScale(Widget):
         """
         return False
 
-    def render(self, size: tuple[int, int], focus: bool = False) -> SolidCanvas | CompositeCanvas:
+    def render(
+        self,
+        size: tuple[int, int],
+        focus: bool = False,
+    ) -> SolidCanvas | CompositeCanvas:
         """
         Render GraphVScale.
         """

--- a/urwid/widget/big_text.py
+++ b/urwid/widget/big_text.py
@@ -43,14 +43,22 @@ class BigText(Widget):
         self.font = font
         self._invalidate()
 
-    def pack(self, size: tuple[()] | None = None, focus: bool = False) -> tuple[int, int]:
+    def pack(
+        self,
+        size: tuple[()] | None = (),  # type: ignore[override]
+        focus: bool = False,
+    ) -> tuple[int, int]:
         rows = self.font.height
         cols = 0
         for c in self.text:
             cols += self.font.char_width(c)
         return cols, rows
 
-    def render(self, size: tuple[()], focus: bool = False) -> CompositeCanvas:
+    def render(
+        self,
+        size: tuple[()],  # type: ignore[override]
+        focus: bool = False,
+    ) -> CompositeCanvas:
         fixed_size(size)  # complain if parameter is wrong
         a: Hashable | None = None
         ai = ak = 0

--- a/urwid/widget/box_adapter.py
+++ b/urwid/widget/box_adapter.py
@@ -90,7 +90,11 @@ class BoxAdapter(WidgetDecoration[WrappedWidget]):
             return None
         return self._original_widget.get_pref_col((maxcol, self.height))
 
-    def keypress(self, size: tuple[int], key: str) -> str | None:
+    def keypress(
+        self,
+        size: tuple[int],  # type: ignore[override]
+        key: str,
+    ) -> str | None:
         (maxcol,) = size
         return self._original_widget.keypress((maxcol, self.height), key)
 
@@ -102,7 +106,7 @@ class BoxAdapter(WidgetDecoration[WrappedWidget]):
 
     def mouse_event(
         self,
-        size: tuple[int],
+        size: tuple[int],  # type: ignore[override]
         event: str,
         button: int,
         col: int,
@@ -114,7 +118,11 @@ class BoxAdapter(WidgetDecoration[WrappedWidget]):
             return False
         return self._original_widget.mouse_event((maxcol, self.height), event, button, col, row, focus)
 
-    def render(self, size: tuple[int], focus: bool = False) -> CompositeCanvas:
+    def render(
+        self,
+        size: tuple[int],  # type: ignore[override]
+        focus: bool = False,
+    ) -> CompositeCanvas:
         (maxcol,) = size
         canv = CompositeCanvas(self._original_widget.render((maxcol, self.height), focus))
         return canv

--- a/urwid/widget/columns.py
+++ b/urwid/widget/columns.py
@@ -926,7 +926,11 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
             tuple(w_h_args[idx] for idx in range(len(w_h_args))),
         )
 
-    def pack(self, size: tuple[()] | tuple[int] | tuple[int, int] = (), focus: bool = False) -> tuple[int, int]:
+    def pack(
+        self,
+        size: tuple[()] | tuple[int] | tuple[int, int] = (),
+        focus: bool = False,
+    ) -> tuple[int, int]:
         """Get packed sized for widget."""
         if size:
             return super().pack(size, focus)
@@ -1126,7 +1130,11 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
             rows = max(rows, w.rows((mc,), focus=focus and self.focus_position == i))
         return rows
 
-    def keypress(self, size: tuple[()] | tuple[int] | tuple[int, int], key: str) -> str | None:
+    def keypress(
+        self,
+        size: tuple[()] | tuple[int] | tuple[int, int],
+        key: str,
+    ) -> str | None:
         """
         Pass keypress to the focus column.
 

--- a/urwid/widget/container.py
+++ b/urwid/widget/container.py
@@ -97,11 +97,11 @@ class WidgetContainerMixin:
 
         positions -- sequence of positions
         """
-        w = self
+        w: Widget = self
         for p in positions:
             if p != w.focus_position:
                 w.focus_position = p  # modifies w.focus
-            w = w.focus.base_widget
+            w = w.focus.base_widget  # type: ignore[assignment]
 
     def get_focus_widgets(self) -> list[Widget]:
         """

--- a/urwid/widget/divider.py
+++ b/urwid/widget/divider.py
@@ -92,7 +92,11 @@ class Divider(Widget):
         (_maxcol,) = size
         return self.top + 1 + self.bottom
 
-    def render(self, size: tuple[int], focus: bool = False) -> CompositeCanvas:
+    def render(
+        self,
+        size: tuple[int],  # type: ignore[override]
+        focus: bool = False,
+    ) -> CompositeCanvas:
         """
         Render the divider as a canvas and return it.
 

--- a/urwid/widget/edit.py
+++ b/urwid/widget/edit.py
@@ -153,7 +153,7 @@ class Edit(Text):
 
         return self._caption + (self._mask * len(self._edit_text)), self._attrib
 
-    def set_text(self, markup: tuple[str, list[tuple[Hashable, int]]]) -> None:
+    def set_text(self, markup: str | tuple[Hashable, str] | list[str | tuple[Hashable, str]]) -> None:
         """
         Not supported by Edit widget.
 
@@ -359,10 +359,7 @@ class Edit(Text):
         self.highlight = None
 
     def _normalize_to_caption(self, text: str | bytes) -> str | bytes:
-        """
-        Return text converted to the same type as self.caption
-        (bytes or unicode)
-        """
+        """Return text converted to the same type as self.caption (bytes or unicode)"""
         tu = isinstance(text, str)
         cu = isinstance(self._caption, str)
         if tu == cu:
@@ -400,7 +397,11 @@ class Edit(Text):
         result_pos += len(text)
         return (result_text, result_pos)
 
-    def keypress(self, size: tuple[int], key: str) -> str | None:
+    def keypress(
+        self,
+        size: tuple[int],  # type: ignore[override]
+        key: str,
+    ) -> str | None:
         """
         Handle editing keystrokes, return others.
 
@@ -421,9 +422,6 @@ class Edit(Text):
         pos = self.edit_pos
         if self.valid_char(key):
             if isinstance(key, str) and not isinstance(self._caption, str):
-                # screen is sending us unicode input, must be using utf-8
-                # encoding because that's all we support, so convert it
-                # to bytes to match our caption's type
                 key = key.encode("utf-8")
             self.insert_text(key)
             return None
@@ -546,7 +544,7 @@ class Edit(Text):
 
     def mouse_event(
         self,
-        size: tuple[int],
+        size: tuple[int],  # type: ignore[override]
         event: str,
         button: int,
         col: int,
@@ -581,7 +579,11 @@ class Edit(Text):
         self.highlight = None
         return True
 
-    def render(self, size: tuple[int], focus: bool = False) -> TextCanvas | CompositeCanvas:
+    def render(
+        self,
+        size: tuple[int],  # type: ignore[override]
+        focus: bool = False,
+    ) -> TextCanvas | CompositeCanvas:
         """
         Render edit widget and return canvas.  Include cursor when in
         focus.
@@ -679,7 +681,11 @@ class IntEdit(Edit):
             val = ""
         super().__init__(caption, val)
 
-    def keypress(self, size: tuple[int], key: str) -> str | None:
+    def keypress(
+        self,
+        size: tuple[int],  # type: ignore[override]
+        key: str,
+    ) -> str | None:
         """
         Handle editing keystrokes.  Remove leading zeros.
 

--- a/urwid/widget/filler.py
+++ b/urwid/widget/filler.py
@@ -230,7 +230,11 @@ class Filler(WidgetDecoration[WrappedWidget]):
             self.bottom,
         )
 
-    def render(self, size: tuple[int, int] | tuple[int], focus: bool = False) -> CompositeCanvas:
+    def render(
+        self,
+        size: tuple[int, int] | tuple[int],  # type: ignore[override]
+        focus: bool = False,
+    ) -> CompositeCanvas:
         """Render self.original_widget with space above and/or below."""
         maxcol, maxrow = self.pack(size, focus)
         top, bottom = self.filler_values(size, focus)
@@ -251,7 +255,11 @@ class Filler(WidgetDecoration[WrappedWidget]):
         canv.pad_trim_top_bottom(top, bottom)
         return canv
 
-    def keypress(self, size: tuple[int, int] | tuple[()], key: str) -> str | None:
+    def keypress(
+        self,
+        size: tuple[int, int] | tuple[()],  # type: ignore[override]
+        key: str,
+    ) -> str | None:
         """Pass keypress to self.original_widget."""
         maxcol, maxrow = self.pack(size, True)
         if self.height_type == WHSettings.PACK:
@@ -308,7 +316,7 @@ class Filler(WidgetDecoration[WrappedWidget]):
 
     def mouse_event(
         self,
-        size: tuple[int, int] | tuple[int],
+        size: tuple[int, int] | tuple[int],  # type: ignore[override]
         event,
         button: int,
         col: int,

--- a/urwid/widget/frame.py
+++ b/urwid/widget/frame.py
@@ -438,7 +438,11 @@ class Frame(Widget, WidgetContainerMixin, typing.Generic[BodyWidget, HeaderWidge
 
         return (hrows, frows), (hrows, frows)
 
-    def render(self, size: tuple[int, int], focus: bool = False) -> CompositeCanvas:
+    def render(
+        self,
+        size: tuple[int, int],  # type: ignore[override]
+        focus: bool = False,
+    ) -> CompositeCanvas:
         (maxcol, maxrow) = size
         (htrim, ftrim), (hrows, frows) = self.frame_top_bottom((maxcol, maxrow), focus)
 
@@ -474,7 +478,11 @@ class Frame(Widget, WidgetContainerMixin, typing.Generic[BodyWidget, HeaderWidge
 
         return CanvasCombine(combinelist)
 
-    def keypress(self, size: tuple[int, int], key: str) -> str | None:
+    def keypress(
+        self,
+        size: tuple[int, int],  # type: ignore[override]
+        key: str,
+    ) -> str | None:
         """Pass keypress to widget in focus."""
         (maxcol, maxrow) = size
 
@@ -502,7 +510,7 @@ class Frame(Widget, WidgetContainerMixin, typing.Generic[BodyWidget, HeaderWidge
 
     def mouse_event(
         self,
-        size: tuple[int, int],
+        size: tuple[int, int],  # type: ignore[override]
         event: str,
         button: int,
         col: int,

--- a/urwid/widget/listbox.py
+++ b/urwid/widget/listbox.py
@@ -576,7 +576,11 @@ class ListBox(Widget, WidgetContainerMixin):
 
         return self._rows_max_cached
 
-    def render(self, size: tuple[int, int], focus: bool = False) -> CompositeCanvas | SolidCanvas:
+    def render(
+        self,
+        size: tuple[int, int],  # type: ignore[override]
+        focus: bool = False,
+    ) -> CompositeCanvas | SolidCanvas:
         """
         Render ListBox and return canvas.
 
@@ -1174,7 +1178,11 @@ class ListBox(Widget, WidgetContainerMixin):
             self.shift_focus((maxcol, maxrow), maxrow - cy - 1)
             return
 
-    def keypress(self, size: tuple[int, int], key: str) -> str | None:
+    def keypress(
+        self,
+        size: tuple[int, int],  # type: ignore[override]
+        key: str,
+    ) -> str | None:
         """Move selection through the list elements scrolling when
         necessary. Keystrokes are first passed to widget in focus
         in case that widget can handle them.
@@ -1769,7 +1777,7 @@ class ListBox(Widget, WidgetContainerMixin):
 
     def mouse_event(
         self,
-        size: tuple[int, int],
+        size: tuple[int, int],  # type: ignore[override]
         event,
         button: int,
         col: int,

--- a/urwid/widget/overlay.py
+++ b/urwid/widget/overlay.py
@@ -231,7 +231,11 @@ class Overlay(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin, ty
 
         return frozenset(sizing)
 
-    def pack(self, size: tuple[()] | tuple[int] | tuple[int, int] = (), focus: bool = False) -> tuple[int, int]:
+    def pack(
+        self,
+        size: tuple[()] | tuple[int] | tuple[int, int] = (),
+        focus: bool = False,
+    ) -> tuple[int, int]:
         if size:
             return super().pack(size, focus)
 
@@ -482,7 +486,11 @@ class Overlay(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin, ty
         """Return selectable from top_w."""
         return self.top_w.selectable()
 
-    def keypress(self, size: tuple[()] | tuple[int] | tuple[int, int], key: str) -> str | None:
+    def keypress(
+        self,
+        size: tuple[()] | tuple[int] | tuple[int, int],
+        key: str,
+    ) -> str | None:
         """Pass keypress to top_w."""
         real_size = self.pack(size, True)
         return self.top_w.keypress(
@@ -689,7 +697,10 @@ class Overlay(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin, ty
             raise IndexError(f"Overlay.contents has no position {index!r}")
         self._invalidate()
 
-    def get_cursor_coords(self, size: tuple[()] | tuple[int] | tuple[int, int]) -> tuple[int, int] | None:
+    def get_cursor_coords(
+        self,
+        size: tuple[()] | tuple[int] | tuple[int, int],
+    ) -> tuple[int, int] | None:
         """Return cursor coords from top_w, if any."""
         if not hasattr(self.top_w, "get_cursor_coords"):
             return None

--- a/urwid/widget/padding.py
+++ b/urwid/widget/padding.py
@@ -267,7 +267,11 @@ class Padding(WidgetDecoration[WrappedWidget], typing.Generic[WrappedWidget]):
         )
         self.width = width
 
-    def pack(self, size: tuple[()] | tuple[int] | tuple[int, int] = (), focus: bool = False) -> tuple[int, int]:
+    def pack(
+        self,
+        size: tuple[()] | tuple[int] | tuple[int, int] = (),
+        focus: bool = False,
+    ) -> tuple[int, int]:
         if size:
             return super().pack(size, focus)
         if self._width_type == WHSettings.CLIP:

--- a/urwid/widget/pile.py
+++ b/urwid/widget/pile.py
@@ -715,7 +715,7 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
                 w_h_args.append((maxcol, height))
             elif f == WHSettings.PACK or len(size) == 1:
                 if Sizing.FLOW in w_sizing:
-                    w_h_arg = (maxcol,)
+                    w_h_arg: tuple[int] | tuple[()] = (maxcol,)
                 elif Sizing.FIXED in w_sizing and f == WHSettings.PACK:
                     w_h_arg = ()
                 else:

--- a/urwid/widget/progress_bar.py
+++ b/urwid/widget/progress_bar.py
@@ -106,7 +106,11 @@ class ProgressBar(Widget):
         percent = min(100, max(0, int(self.current * 100 / self.done)))
         return f"{percent!s} %"
 
-    def render(self, size: tuple[int], focus: bool = False) -> TextCanvas:
+    def render(
+        self,
+        size: tuple[int],  # type: ignore[override]
+        focus: bool = False,
+    ) -> TextCanvas:
         """
         Render the progress bar.
         """

--- a/urwid/widget/scrollable.py
+++ b/urwid/widget/scrollable.py
@@ -43,7 +43,7 @@ if typing.TYPE_CHECKING:
 __all__ = ("ScrollBar", "Scrollable", "ScrollableError", "ScrollbarSymbols")
 
 
-WrappedWidget = typing.TypeVar("WrappedWidget")
+WrappedWidget = typing.TypeVar("WrappedWidget", bound="SupportsScroll")
 
 
 class ScrollableError(WidgetError):
@@ -153,7 +153,11 @@ class Scrollable(WidgetDecoration[WrappedWidget]):
         self.force_forward_keypress = force_forward_keypress
         super().__init__(widget)
 
-    def render(self, size: tuple[int, int], focus: bool = False) -> CompositeCanvas:
+    def render(
+        self,
+        size: tuple[int, int],  # type: ignore[override]
+        focus: bool = False,
+    ) -> CompositeCanvas:
         from urwid import canvas
 
         maxcol, maxrow = size
@@ -270,7 +274,11 @@ class Scrollable(WidgetDecoration[WrappedWidget]):
 
         return canv
 
-    def keypress(self, size: tuple[int, int], key: str) -> str | None:
+    def keypress(
+        self,
+        size: tuple[int, int],  # type: ignore[override]
+        key: str,
+    ) -> str | None:
         from urwid.command_map import Command
 
         # Maybe offer key to original widget
@@ -311,7 +319,7 @@ class Scrollable(WidgetDecoration[WrappedWidget]):
 
     def mouse_event(
         self,
-        size: tuple[int, int],
+        size: tuple[int, int],  # type: ignore[override]
         event: str,
         button: int,
         col: int,
@@ -375,7 +383,10 @@ class Scrollable(WidgetDecoration[WrappedWidget]):
             elif cursrow >= self._trim_top + maxrow:
                 self._trim_top = max(0, cursrow - maxrow + 1)
 
-    def _get_original_widget_size(self, size: tuple[int, int]) -> tuple[int] | tuple[()]:
+    def _get_original_widget_size(
+        self,
+        size: tuple[int, int],  # type: ignore[override]
+    ) -> tuple[int] | tuple[()]:
         ow = self._original_widget
         sizing = ow.sizing()
         if Sizing.FLOW in sizing:
@@ -465,7 +476,11 @@ class ScrollBar(WidgetDecoration[WrappedWidget]):
         self.scrollbar_width = max(1, width)
         self._original_widget_size = (0, 0)
 
-    def render(self, size: tuple[int, int], focus: bool = False) -> CompositeCanvas:
+    def render(
+        self,
+        size: tuple[int, int],  # type: ignore[override]
+        focus: bool = False,
+    ) -> Canvas:
         from urwid import canvas
 
         maxcol, maxrow = size
@@ -566,12 +581,16 @@ class ScrollBar(WidgetDecoration[WrappedWidget]):
 
         raise ScrollableError(f"Not compatible to be wrapped by ScrollBar: {w!r}")
 
-    def keypress(self, size: tuple[int, int], key: str) -> str | None:
+    def keypress(
+        self,
+        size: tuple[int, int],  # type: ignore[override]
+        key: str,
+    ) -> str | None:
         return self._original_widget.keypress(self._original_widget_size, key)
 
     def mouse_event(
         self,
-        size: tuple[int, int],
+        size: tuple[int, int],  # type: ignore[override]
         event: str,
         button: int,
         col: int,
@@ -580,7 +599,7 @@ class ScrollBar(WidgetDecoration[WrappedWidget]):
     ) -> bool | None:
         ow = self._original_widget
         ow_size = self._original_widget_size
-        handled = False
+        handled: bool | None = False
         if hasattr(ow, "mouse_event"):
             handled = ow.mouse_event(ow_size, event, button, col, row, focus)
 

--- a/urwid/widget/solid_fill.py
+++ b/urwid/widget/solid_fill.py
@@ -31,7 +31,11 @@ class SolidFill(Widget):
     def _repr_words(self) -> list[str]:
         return [*super()._repr_words(), repr(self.fill_char)]
 
-    def render(self, size: tuple[int, int], focus: bool = False) -> SolidCanvas:
+    def render(
+        self,
+        size: tuple[int, int],  # type: ignore[override]
+        focus: bool = False,
+    ) -> SolidCanvas:
         """
         Render the Fill as a canvas and return it.
 

--- a/urwid/widget/text.py
+++ b/urwid/widget/text.py
@@ -245,7 +245,11 @@ class Text(Widget):
     def layout(self):
         return self._layout
 
-    def render(self, size: tuple[int] | tuple[()], focus: bool = False) -> TextCanvas:
+    def render(
+        self,
+        size: tuple[int] | tuple[()],  # type: ignore[override]
+        focus: bool = False,
+    ) -> TextCanvas:
         """
         Render contents with wrapping and alignment.  Return canvas.
 
@@ -312,7 +316,11 @@ class Text(Widget):
         self._cache_maxcol = maxcol
         self._cache_translation = self.layout.layout(text, maxcol, self._align_mode, self._wrap_mode)
 
-    def pack(self, size: tuple[int] | tuple[()] | None = None, focus: bool = False) -> tuple[int, int]:
+    def pack(
+        self,
+        size: tuple[()] | tuple[int] | None = None,  # type: ignore[override]
+        focus: bool = False,
+    ) -> tuple[int, int]:
         """
         Return the number of screen columns and rows required for
         this Text widget to be displayed without wrapping or

--- a/urwid/widget/treetools.py
+++ b/urwid/widget/treetools.py
@@ -37,7 +37,7 @@ from .constants import WHSettings
 from .listbox import ListBox, ListWalker
 from .padding import Padding
 from .text import Text
-from .widget import Widget, WidgetWrap
+from .widget import WidgetWrap
 from .wimp import SelectableIcon
 
 if typing.TYPE_CHECKING:
@@ -95,7 +95,7 @@ class TreeWidget(WidgetWrap[Padding[typing.Union[Text, Columns]]]):
             self._innerwidget = self.load_inner_widget()
         return self._innerwidget
 
-    def load_inner_widget(self) -> Widget:
+    def load_inner_widget(self) -> Text:
         return Text(self.get_display_text())
 
     def get_node(self) -> TreeNode:
@@ -150,7 +150,11 @@ class TreeWidget(WidgetWrap[Padding[typing.Union[Text, Columns]]]):
             prev_node = this_node.get_parent()
         return prev_node.get_widget()
 
-    def keypress(self, size: tuple[int] | tuple[()], key: str) -> str | None:
+    def keypress(
+        self,
+        size: tuple[int] | tuple[()],
+        key: str,
+    ) -> str | None:
         """Handle expand & collapse requests (non-leaf nodes)"""
         if self.is_leaf:
             return key
@@ -236,7 +240,7 @@ class TreeNode:
         self._parent = parent
         self._value = value
         self._depth = depth
-        self._widget = None
+        self._widget: TreeWidget | None = None
 
     def get_widget(self, reload: bool = False) -> TreeWidget:
         """Return the widget for this node."""
@@ -451,8 +455,12 @@ class TreeListBox(ListBox):
     """A ListBox with special handling for navigation and
     collapsing of TreeWidgets"""
 
-    def keypress(self, size: tuple[int, int], key: str) -> str | None:
-        key = super().keypress(size, key)
+    def keypress(
+        self,
+        size: tuple[int, int],  # type: ignore[override]
+        key: str,
+    ) -> str | None:
+        key: str | None = super().keypress(size, key)
         return self.unhandled_input(size, key)
 
     def unhandled_input(self, size: tuple[int, int], data: str) -> str | None:

--- a/urwid/widget/widget.py
+++ b/urwid/widget/widget.py
@@ -298,7 +298,7 @@ class Widget(metaclass=WidgetMeta):
     _sizing = frozenset([Sizing.FLOW, Sizing.BOX, Sizing.FIXED])
     _command_map = command_map
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.logger = logging.getLogger(f"{self.__class__.__module__}.{self.__class__.__name__}")
 
     def _invalidate(self) -> None:
@@ -451,7 +451,11 @@ class Widget(metaclass=WidgetMeta):
     def _repr_attrs(self) -> dict[str, typing.Any]:
         return {}
 
-    def keypress(self, size: tuple[()] | tuple[int] | tuple[int, int], key: str) -> str | None:
+    def keypress(
+        self,
+        size: tuple[()] | tuple[int] | tuple[int, int],
+        key: str,
+    ) -> str | None:
         """Keyboard input handler.
 
         :param size: See :meth:`Widget.render` for details
@@ -514,7 +518,11 @@ class Widget(metaclass=WidgetMeta):
                 LOGGER.debug(f"Widget {self!r} is not selectable")
         return False
 
-    def render(self, size: tuple[()] | tuple[int] | tuple[int, int], focus: bool = False) -> Canvas:
+    def render(
+        self,
+        size: tuple[()] | tuple[int] | tuple[int, int],
+        focus: bool = False,
+    ) -> Canvas:
         """Render widget and produce canvas
 
         :param size: One of the following, *maxcol* and *maxrow* are integers > 0:
@@ -590,7 +598,7 @@ class FlowWidget(Widget):
         """
         raise NotImplementedError()
 
-    def render(self, size: tuple[int], focus: bool = False):
+    def render(self, size: tuple[int], focus: bool = False) -> Canvas:  # type: ignore[override]
         """
         All widgets must implement this function.
         """
@@ -627,14 +635,14 @@ class BoxWidget(Widget):
         )
         super().__init__()
 
-    def render(self, size: tuple[int, int], focus: bool = False):
+    def render(self, size: tuple[int, int], focus: bool = False) -> Canvas:  # type: ignore[override]
         """
         All widgets must implement this function.
         """
         raise NotImplementedError()
 
 
-def fixed_size(size):
+def fixed_size(size: tuple[()]) -> None:
     """
     raise ValueError if size != ().
 
@@ -671,13 +679,13 @@ class FixedWidget(Widget):
         )
         super().__init__()
 
-    def render(self, size, focus=False):
+    def render(self, size: tuple[()], focus: bool = False) -> Canvas:  # type: ignore[override]
         """
         All widgets must implement this function.
         """
         raise NotImplementedError()
 
-    def pack(self, size=None, focus=False):
+    def pack(self, size: tuple[()] = (), focus: bool = False) -> tuple[int, int]:  # type: ignore[override]
         """
         All fixed widgets must implement this function.
         """

--- a/urwid/widget/wimp.py
+++ b/urwid/widget/wimp.py
@@ -75,9 +75,9 @@ class SelectableIcon(Text):
         super().__init__(text, align=align, wrap=wrap, layout=layout)
         self._cursor_position = cursor_position
 
-    def render(
+    def render(  # type: ignore[override]
         self,
-        size: tuple[int] | tuple[()],
+        size: tuple[int] | tuple[()],  # type: ignore[override]
         focus: bool = False,
     ) -> TextCanvas | CompositeCanvas:  # type: ignore[override]
         """
@@ -126,7 +126,11 @@ class SelectableIcon(Text):
             return None
         return x, y
 
-    def keypress(self, size: tuple[int] | tuple[()], key: str) -> str:
+    def keypress(
+        self,
+        size: tuple[int] | tuple[()],  # type: ignore[override]
+        key: str,
+    ) -> str:
         """
         No keys are handled by this widget.  This method is
         required for selectable widgets.
@@ -721,7 +725,7 @@ class Button(WidgetWrap[Columns]):
         """
         self._label.set_text(label)
 
-    def get_label(self) -> str:
+    def get_label(self) -> str | bytes:
         """
         Return label text.
 


### PR DESCRIPTION
Limitations preventing full fix:
* We're intentionally violating Liskov principle in size argument
* We have to deal with `bytes` arguments even if 99,9% of render need `str`
* MyPy not allow covariant call arguments, defining API protocol for each widget is not a goal for current PR
* We have to support deprecated code in downstream during deprecation period
* We have to deal with upstream libs limitations

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

