### PR TITLE
Allow wcwidth to select unicode version

### DIFF
--- a/urwid/canvas.py
+++ b/urwid/canvas.py
@@ -726,8 +726,7 @@ class CompositeCanvas(Canvas):
         Return the differences between other and this canvas.
         """
         if not hasattr(other, "shards"):
-            for row in self.content():
-                yield row
+            yield from self.content()
             return
 
         shard_tail = []
@@ -1275,8 +1274,7 @@ def CanvasJoin(canvas_info: Iterable[tuple[Canvas, typing.Any, bool, int]]) -> C
         pad_right = cols - canv.cols()
         if focus:
             focus_item = n
-        if rows > maxrow:
-            maxrow = rows
+        maxrow = max(maxrow, rows)
         l2.append((canv, pos, pad_right, rows))
 
     shard_lists = []

--- a/urwid/str_util.py
+++ b/urwid/str_util.py
@@ -29,7 +29,6 @@ import wcwidth
 if typing.TYPE_CHECKING:
     from typing_extensions import Literal
 
-UNICODE_VERSION = "15.1.0"  # Use explicit version
 SAFE_ASCII_RE = re.compile("^[ -~]*$")
 SAFE_ASCII_BYTES_RE = re.compile(b"^[ -~]*$")
 
@@ -37,7 +36,7 @@ _byte_encoding: Literal["utf8", "narrow", "wide"] = "narrow"
 
 
 def get_char_width(char: str) -> Literal[0, 1, 2]:
-    width = wcwidth.wcwidth(char, UNICODE_VERSION)
+    width = wcwidth.wcwidth(char)
     if width < 0:
         return 0
     return width

--- a/urwid/widget/columns.py
+++ b/urwid/widget/columns.py
@@ -344,7 +344,7 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
                 chain(self.contents, repeat((None, (WHSettings.WEIGHT, 1, False)))),
             )
         ]
-        if focus_position < len(widgets):
+        if focus_position < len(widgets):  # pylint: disable=consider-using-max-builtin  # pylint bug
             self.focus_position = focus_position
 
     @property
@@ -385,7 +385,7 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
             (w, ({Sizing.FIXED: WHSettings.GIVEN, Sizing.FLOW: WHSettings.PACK}.get(new_t, new_t), new_n, b))
             for ((new_t, new_n), (w, (t, n, b))) in zip(column_types, self.contents)
         ]
-        if focus_position < len(column_types):
+        if focus_position < len(column_types):  # pylint: disable=consider-using-max-builtin  # pylint bug
             self.focus_position = focus_position
 
     @property

--- a/urwid/widget/edit.py
+++ b/urwid/widget/edit.py
@@ -308,8 +308,8 @@ class Edit(Text):
         self._emit("change", text)
         old_text = self._edit_text
         self._edit_text = text
-        if self.edit_pos > len(text):
-            self.edit_pos = len(text)
+        self.edit_pos = min(self.edit_pos, len(text))
+
         self._emit("postchange", old_text)
         self._invalidate()
 

--- a/urwid/widget/grid_flow.py
+++ b/urwid/widget/grid_flow.py
@@ -126,7 +126,7 @@ class GridFlow(WidgetWrap[Pile], WidgetContainerMixin, WidgetContainerListConten
         )
         focus_position = self.focus_position
         self.contents = [(new, (WHSettings.GIVEN, self._cell_width)) for new in widgets]
-        if focus_position < len(widgets):
+        if focus_position < len(widgets):  # pylint: disable=consider-using-max-builtin  # pylint bug
             self.focus_position = focus_position
 
     def _get_cells(self):

--- a/urwid/widget/listbox.py
+++ b/urwid/widget/listbox.py
@@ -1881,8 +1881,7 @@ class ListBox(Widget, WidgetContainerMixin):
         """
         positions_fn = getattr(self._body, "positions", None)
         if positions_fn:
-            for pos in positions_fn():
-                yield pos
+            yield from positions_fn()
             return
 
         focus_widget, focus_pos = self._body.get_focus()
@@ -1913,8 +1912,7 @@ class ListBox(Widget, WidgetContainerMixin):
         """
         positions_fn = getattr(self._body, "positions", None)
         if positions_fn:
-            for pos in positions_fn(reverse=True):
-                yield pos
+            yield from positions_fn(reverse=True)
             return
 
         focus_widget, focus_pos = self._body.get_focus()

--- a/urwid/widget/pile.py
+++ b/urwid/widget/pile.py
@@ -281,7 +281,7 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
                 chain(self.contents, repeat((None, (WHSettings.WEIGHT, 1)))),
             )
         ]
-        if focus_position < len(widgets):
+        if focus_position < len(widgets):  # pylint: disable=consider-using-max-builtin  # pylint bug
             self.focus_position = focus_position
 
     @property
@@ -321,7 +321,7 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
             (w, ({Sizing.FIXED: WHSettings.GIVEN, Sizing.FLOW: WHSettings.PACK}.get(new_t, new_t), new_height))
             for ((new_t, new_height), (w, options)) in zip(item_types, self.contents)
         ]
-        if focus_position < len(item_types):
+        if focus_position < len(item_types):  # pylint: disable=consider-using-max-builtin  # pylint bug
             self.focus_position = focus_position
 
     @property


### PR DESCRIPTION
* end user can have old wcwidth
* end user can override unicode version via environment

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
*(P. S. If this pull requests fixes an existing issue, please specify which one.)*

