### PR TITLE
Special case: in case of `Columns`/`Pile` empty - use fallback sizing

### DIFF
--- a/urwid/widget/columns.py
+++ b/urwid/widget/columns.py
@@ -66,40 +66,47 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
 
         # BOX-only widget
         >>> Columns((SolidFill("#"),))
-        <Columns box widget>
+        <Columns box widget with 1 item>
 
         # BOX-only widget with "get height from max"
         >>> Columns((SolidFill("#"),), box_columns=(0,))
-        <Columns box widget>
+        <Columns box widget with 1 item>
 
         # FLOW-only
         >>> Columns((Edit(),))
-        <Columns selectable flow widget>
+        <Columns selectable flow widget with 1 item>
 
         # FLOW allowed by "box_columns"
         >>> Columns((Edit(), SolidFill("#")), box_columns=(1,))
-        <Columns selectable flow widget>
+        <Columns selectable flow widget with 2 items>
 
         # FLOW/FIXED
         >>> Columns((Text("T"),))
-        <Columns fixed/flow widget>
+        <Columns fixed/flow widget with 1 item>
 
         # GIVEN BOX only -> BOX only
         >>> Columns(((5, SolidFill("#")),), box_columns=(0,))
-        <Columns box widget>
+        <Columns box widget with 1 item>
 
         # No FLOW - BOX only
         >>> Columns(((5, SolidFill("#")), SolidFill("*")), box_columns=(0, 1))
-        <Columns box widget>
+        <Columns box widget with 2 items>
 
         # FIXED only -> FIXED
         >>> Columns(((WHSettings.PACK, BigText("1", font)),))
-        <Columns fixed widget>
+        <Columns fixed widget with 1 item>
 
         # Invalid sizing combination -> use fallback settings (and produce warning)
         >>> Columns(((WHSettings.PACK, SolidFill("#")),))
-        <Columns box/flow widget>
+        <Columns box/flow widget with 1 item>
+
+        # Special case: empty columns widget sizing is impossible to calculate
+        >>> Columns(())
+        <Columns box/flow widget without contents>
         """
+        if not self.contents:
+            return frozenset((urwid.BOX, urwid.FLOW))
+
         strict_box = False
         has_flow = False
 
@@ -279,6 +286,13 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         self.pref_col = None
         self.min_width = min_width
         self._cache_maxcol = None
+
+    def _repr_words(self) -> list[str]:
+        if len(self.contents) > 1:
+            return [*super()._repr_words(), f"with {len(self.contents)} items"]
+        if self.contents:
+            return [*super()._repr_words(), "with 1 item"]
+        return [*super()._repr_words(), "without contents"]
 
     def _contents_modified(self) -> None:
         """

--- a/urwid/widget/pile.py
+++ b/urwid/widget/pile.py
@@ -58,36 +58,42 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
 
         # BOX-only widget
         >>> Pile((SolidFill("#"),))
-        <Pile box widget>
+        <Pile box widget with 1 item>
 
         # GIVEN BOX -> BOX/FLOW
         >>> Pile(((10, SolidFill("#")),))
-        <Pile box/flow widget>
+        <Pile box/flow widget with 1 item>
 
         # FLOW-only
         >>> Pile((ProgressBar(None, None),))
-        <Pile flow widget>
+        <Pile flow widget with 1 item>
 
         # FIXED -> FIXED
         >>> Pile(((WHSettings.PACK, BigText("0", font)),))
-        <Pile fixed widget>
+        <Pile fixed widget with 1 item>
 
         # FLOW/FIXED -> FLOW/FIXED
         >>> Pile(((WHSettings.PACK, Text("text")),))
-        <Pile fixed/flow widget>
+        <Pile fixed/flow widget with 1 item>
 
         # FLOW + FIXED widgets -> FLOW/FIXED
         >>> Pile((ProgressBar(None, None), (WHSettings.PACK, BigText("0", font))))
-        <Pile fixed/flow widget>
+        <Pile fixed/flow widget with 2 items>
 
         # GIVEN BOX + FIXED widgets -> BOX/FLOW/FIXED (GIVEN BOX allows overriding its height & allows any width)
         >>> Pile(((10, SolidFill("#")), (WHSettings.PACK, BigText("0", font))))
-        <Pile widget>
+        <Pile widget with 2 items>
 
         # Invalid sizing combination -> use fallback settings (and produce warning)
         >>> Pile(((WHSettings.WEIGHT, 1, BigText("0", font)),))
-        <Pile box/flow widget>
+        <Pile box/flow widget with 1 item>
+
+        # Special case: empty pile widget sizing is impossible to calculate
+        >>> Pile(())
+        <Pile box/flow widget without contents>
         """
+        if not self.contents:
+            return frozenset((Sizing.BOX, Sizing.FLOW))
         strict_box = False
         has_flow = False
 
@@ -224,6 +230,13 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
             self.focus = focus_item
 
         self.pref_col = 0
+
+    def _repr_words(self) -> list[str]:
+        if len(self.contents) > 1:
+            return [*super()._repr_words(), f"with {len(self.contents)} items"]
+        if self.contents:
+            return [*super()._repr_words(), "with 1 item"]
+        return [*super()._repr_words(), "without contents"]
 
     def _contents_modified(self) -> None:
         """Recalculate whether this widget should be selectable whenever the contents has been changed."""


### PR DESCRIPTION
* Extend `repr` to provide brief info about contents

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

