### PR TITLE
Extend `__repr__` and `rich` repr for the sized containers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,10 @@ exclude_lines = [
 
   # Don't complain about missing debug-only code:
   "def __repr__",
+  "def __rich_repr__",
+  # own repr construct magic
+  "def _repr_words",
+  "def _repr_attrs",
 
   # Don't complain if tests don't hit defensive assertion code:
   "raise NotImplementedError",

--- a/urwid/widget/frame.py
+++ b/urwid/widget/frame.py
@@ -4,6 +4,7 @@ import typing
 import warnings
 
 from urwid.canvas import CanvasCombine, CompositeCanvas
+from urwid.split_repr import remove_defaults
 from urwid.util import is_mouse_press
 
 from .constants import Sizing, VAlign
@@ -88,6 +89,22 @@ class Frame(Widget, WidgetContainerMixin, typing.Generic[BodyWidget, HeaderWidge
         _check_widget_subclass(header)
         _check_widget_subclass(body)
         _check_widget_subclass(footer)
+
+    def _repr_attrs(self) -> dict[str, typing.Any]:
+        attrs = {
+            **super()._repr_attrs(),
+            "body": self._body,
+            "header": self._header,
+            "footer": self._footer,
+            "focus_part": self.focus_part,
+        }
+        return remove_defaults(attrs, Frame.__init__)
+
+    def __rich_repr__(self) -> Iterator[tuple[str | None, typing.Any] | typing.Any]:
+        yield "body", self._body
+        yield "header", self._header
+        yield "footer", self._footer
+        yield "focus_part", self.focus_part
 
     @property
     def header(self) -> HeaderWidget:

--- a/urwid/widget/overlay.py
+++ b/urwid/widget/overlay.py
@@ -4,6 +4,7 @@ import typing
 import warnings
 
 from urwid.canvas import CanvasOverlay, CompositeCanvas
+from urwid.split_repr import remove_defaults
 
 from .constants import (
     RELATIVE_100,
@@ -330,8 +331,67 @@ class Overlay(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin, ty
             f"min_height={self.min_height!r}"
         )
 
-    def _repr_words(self) -> list[str]:
-        return [*super()._repr_words(), f"top={self.top_w!r}", f"bottom={self.bottom_w!r}"]
+    def _repr_attrs(self) -> dict[str, typing.Any]:
+        attrs = {
+            **super()._repr_attrs(),
+            "top_w": self.top_w,
+            "bottom_w": self.bottom_w,
+            "align": self.align,
+            "width": self.width,
+            "valign": self.valign,
+            "height": self.height,
+            "min_width": self.min_width,
+            "min_height": self.min_height,
+            "left": self.left,
+            "right": self.right,
+            "top": self.top,
+            "bottom": self.bottom,
+        }
+        return remove_defaults(attrs, Overlay.__init__)
+
+    def __rich_repr__(self) -> Iterator[tuple[str | None, typing.Any] | typing.Any]:
+        yield "top", self.top_w
+        yield "bottom", self.bottom_w
+        yield "align", self.align
+        yield "width", self.width
+        yield "valign", self.valign
+        yield "height", self.height
+        yield "min_width", self.min_width
+        yield "min_height", self.min_height
+        yield "left", self.left
+        yield "right", self.right
+        yield "top", self.top
+        yield "bottom", self.bottom
+
+    @property
+    def align(self) -> Align | tuple[Literal[WHSettings.RELATIVE], int]:
+        return simplify_align(self.align_type, self.align_amount)
+
+    @property
+    def width(
+        self,
+    ) -> (
+        Literal[WHSettings.CLIP, WHSettings.PACK]
+        | int
+        | tuple[Literal[WHSettings.RELATIVE], int]
+        | tuple[Literal[WHSettings.WEIGHT], int | float]
+    ):
+        return simplify_width(self.width_type, self.width_amount)
+
+    @property
+    def valign(self) -> VAlign | tuple[Literal[WHSettings.RELATIVE], int]:
+        return simplify_valign(self.valign_type, self.valign_amount)
+
+    @property
+    def height(
+        self,
+    ) -> (
+        int
+        | Literal[WHSettings.FLOW, WHSettings.PACK]
+        | tuple[Literal[WHSettings.RELATIVE], int]
+        | tuple[Literal[WHSettings.WEIGHT], int | float]
+    ):
+        return simplify_height(self.height_type, self.height_amount)
 
     @staticmethod
     def options(

--- a/urwid/widget/padding.py
+++ b/urwid/widget/padding.py
@@ -20,6 +20,8 @@ from .constants import (
 from .widget_decoration import WidgetDecoration, WidgetError, WidgetWarning
 
 if typing.TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from typing_extensions import Literal
 
 WrappedWidget = typing.TypeVar("WrappedWidget")
@@ -183,6 +185,14 @@ class Padding(WidgetDecoration[WrappedWidget], typing.Generic[WrappedWidget]):
             "min_width": self.min_width,
         }
         return remove_defaults(attrs, Padding.__init__)
+
+    def __rich_repr__(self) -> Iterator[tuple[str | None, typing.Any] | typing.Any]:
+        yield "w", self.original_widget
+        yield "align", self.align
+        yield "width", self.width
+        yield "min_width", self.min_width
+        yield "left", self.left
+        yield "right", self.right
 
     @property
     def align(

--- a/urwid/widget/widget.py
+++ b/urwid/widget/widget.py
@@ -391,7 +391,7 @@ class Widget(metaclass=WidgetMeta):
         """
         if not size:
             if Sizing.FIXED in self.sizing():
-                raise NotImplementedError("Fixed widgets must override Widget.pack()")
+                raise NotImplementedError(f"{self!r} must override Widget.pack()")
             raise WidgetError(f"Cannot pack () size, this is not a fixed widget: {self!r}")
 
         if len(size) == 1:


### PR DESCRIPTION
Due to extremely hard to debug tracebacks,
add `__repr__` details
and full details for `rich.print`/`rich.pretty.pretty_repr`

* `Columns`
* `Pile`
* `GridFlow`
* `Frame`
* `Overlay`
* `Padding`

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [X] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

