### PR TITLE
Fix regression: Overlay not accepted relative positioning

### DIFF
--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -279,6 +279,35 @@ class OverlayTest(unittest.TestCase):
                     [line.decode("utf-8") for line in canvas.text],
                 )
 
+    def test_relative(self):
+        ovl = urwid.Overlay(
+            urwid.Text("aaa"),
+            urwid.SolidFill(urwid.SolidFill.Symbols.LITE_SHADE),
+            width=urwid.PACK,
+            height=urwid.PACK,
+            align=(urwid.RELATIVE, 30),
+            valign=(urwid.RELATIVE, 70),
+        )
+        self.assertEqual(
+            ovl.contents[1][1],
+            (urwid.RELATIVE, 30, urwid.PACK, None, None, 0, 0, urwid.RELATIVE, 70, urwid.PACK, None, None, 0, 0),
+        )
+        self.assertEqual(
+            (
+                "░░░░░░░░░░░░░░░░░░░░",
+                "░░░░░░░░░░░░░░░░░░░░",
+                "░░░░░░░░░░░░░░░░░░░░",
+                "░░░░░░░░░░░░░░░░░░░░",
+                "░░░░░░░░░░░░░░░░░░░░",
+                "░░░░░░░░░░░░░░░░░░░░",
+                "░░░░░aaa░░░░░░░░░░░░",
+                "░░░░░░░░░░░░░░░░░░░░",
+                "░░░░░░░░░░░░░░░░░░░░",
+                "░░░░░░░░░░░░░░░░░░░░",
+            ),
+            ovl.render((20, 10)).decoded_text,
+        )
+
     def test_old_params(self):
         o1 = urwid.Overlay(
             urwid.SolidFill("X"),


### PR DESCRIPTION
Fix: #851

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
