### PR TITLE
Support relative scroll for ListBox

### DIFF
--- a/examples/browse.py
+++ b/examples/browse.py
@@ -274,7 +274,7 @@ class DirectoryBrowser:
         self.listbox.offset_rows = 1
         self.footer = urwid.AttrMap(urwid.Text(self.footer_text), "foot")
         self.view = urwid.Frame(
-            urwid.AttrMap(self.listbox, "body"),
+            urwid.AttrMap(urwid.ScrollBar(self.listbox), "body"),
             header=urwid.AttrMap(self.header, "head"),
             footer=self.footer,
         )

--- a/tests/test_scrollable.py
+++ b/tests/test_scrollable.py
@@ -192,9 +192,28 @@ class TestScrollBarScrollable(unittest.TestCase):
         with self.assertRaises(TypeError):
             urwid.ScrollBar(urwid.SolidFill(" "))
 
+    def test_no_scrollbar(self):
+        """If widget fit without scroll - no scrollbar needed"""
+        widget = urwid.ScrollBar(
+            urwid.Scrollable(urwid.BigText("1", urwid.HalfBlockHeavy6x5Font())),
+            trough_char=urwid.ScrollBar.Symbols.LITE_SHADE,
+            thumb_char=urwid.ScrollBar.Symbols.DARK_SHADE,
+        )
+        reduced_size = (8, 5)
+        self.assertEqual(
+            (
+                " ▐█▌    ",
+                " ▀█▌    ",
+                "  █▌    ",
+                "  █▌    ",
+                " ███▌   ",
+            ),
+            widget.render(reduced_size).decoded_text,
+        )
+
 
 class TestScrollBarListBox(unittest.TestCase):
-    def test_non_selectable(self):
+    def test_relative_non_selectable(self):
         widget = urwid.ScrollBar(
             urwid.ListBox(urwid.SimpleListWalker(urwid.Text(line) for line in LGPL_HEADER.splitlines()))
         )
@@ -245,13 +264,15 @@ class TestScrollBarListBox(unittest.TestCase):
 
         widget.keypress(reduced_size, "end")
 
+        # Here we have ListBox issue: "end" really scroll not to the "dead end"
+        # in case of the bottom focus position is multiline
         self.assertEqual(
             (
+                "GNU Lesser General Public               ",
                 "License along with this library; if     ",
                 "not, write to the Free Software         ",
                 "Foundation, Inc., 51 Franklin Street,   ",
-                "Fifth Floor, Boston, MA  02110-1301     ",
-                "USA                                    █",
+                "Fifth Floor, Boston, MA  02110-1301    █",
             ),
             widget.render(reduced_size).decoded_text,
         )

--- a/urwid/widget/treetools.py
+++ b/urwid/widget/treetools.py
@@ -496,8 +496,8 @@ class TreeListBox(ListBox):
 
         middle, top, _bottom = self.calculate_visible(size)
 
-        row_offset, _focus_widget, _focus_pos, _focus_rows, _cursor = middle
-        _trim_top, fill_above = top
+        row_offset, _focus_widget, _focus_pos, _focus_rows, _cursor = middle  # pylint: disable=unpacking-non-sequence
+        _trim_top, fill_above = top  # pylint: disable=unpacking-non-sequence
 
         for _widget, pos, rows in fill_above:
             row_offset -= rows


### PR DESCRIPTION
* By default use relative scroll if amount_of_widgets >= maxrow * 3
* Simplify typing for `calculate_visible`

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

Fix: #845
