### PR TITLE
Support shift key reading for sgrmouse

### DIFF
--- a/urwid/display/escape.py
+++ b/urwid/display/escape.py
@@ -310,17 +310,15 @@ class KeyqueueTrie:
 
         (b, x, y) = (int(val) for val in value[:-1].split(";"))
         action = value[-1]
-
-        # shift, etc. is not communicated on my machine, so I
-        # can't and won't be able to add support for it.
-        # Double and triple clicks are not supported as well. They can be
-        # implemented by using a timer. This timer can check if the last
-        # registered click is below a certain threshold. This threshold
-        # is normally set in the operating system itself, so setting one
-        # here will cause an inconsistent behaviour. I do not plan to use
-        # that feature, so I won't implement it.
+        # Double and triple clicks are not supported.
+        # They can be implemented by using a timer.
+        # This timer can check if the last registered click is below a certain threshold.
+        # This threshold is normally set in the operating system itself,
+        # so setting one here will cause an inconsistent behaviour.
 
         prefixes = []
+        if b & 4:
+            prefixes.append("shift ")
         if b & 8:
             prefixes.append("meta ")
         if b & 16:


### PR DESCRIPTION
Note:

  shift accessibility depends on terminal
  (terminal may intercept "shift mouse press" for keys 1-3)

Fix: #857

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

Validated on the `input_test.py`