### PR TITLE
Fix regression in TreeWidget: original widget can be overridden

### DIFF
--- a/urwid/widget/treetools.py
+++ b/urwid/widget/treetools.py
@@ -85,7 +85,7 @@ class TreeWidget(WidgetWrap[Padding[typing.Union[Text, Columns]]]):
         """Update display widget text for parent widgets"""
         # icon is first element in columns indented widget
         icon = [self.unexpanded_icon, self.expanded_icon][self.expanded]
-        self._w.original_widget.contents[0] = (icon, (WHSettings.GIVEN, 1, False))
+        self._w.base_widget.contents[0] = (icon, (WHSettings.GIVEN, 1, False))
 
     def get_indent_cols(self) -> int:
         return self.indent_cols * self.get_node().get_depth()


### PR DESCRIPTION
Use `base_widget` instead

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

