### PR TITLE
Maintenance: add editorconfig to force editing style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{py,pyi,pyx,pxd}]
+indent_size = 4
+max_line_length = 120
+
+[*.{yml,yaml,json,ini,toml}]
+indent_size = 2
+max_line_length = 120
+
+[*.{rst,md}]
+indent_size = 2
+
+[{Makefile,Makefile.in}]
+indent_style = tab

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,9 @@
 # Minimum requirements for the build system to execute.
 # PEP 508 specifications for PEP 518.
 requires = [
-    "setuptools >= 61.0.0",
-    "setuptools_scm[toml]>=7.0",
-    "wheel",
+  "setuptools >= 61.0.0",
+  "setuptools_scm[toml]>=7.0",
+  "wheel",
 ]
 build-backend="setuptools.build_meta"
 
@@ -179,7 +179,7 @@ extend-select = [
 ]
 extend-ignore = [
   "PLR6301", "E203",
-    # refactor rules (too many statements/arguments/branches)
+  # refactor rules (too many statements/arguments/branches)
   "PLR0904", "PLR0911", "PLR0912", "PLR0913", "PLR0914", "PLR0915", "PLR0917", "PLR2004",
   "PLC0415",  # We have a lot of imports outside of top-level
   "RET504",  # Unnecessary variable assignment before return statement

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,8 @@ usedevelop = true
 deps = -r {toxinidir}/test_requirements.txt
 
 commands =
-    coverage run -m unittest discover -s tests -v
-    coverage report
+  coverage run -m unittest discover -s tests -v
+  coverage report
 
 [testenv:readme]
 deps =
@@ -21,7 +21,7 @@ commands =
 [testenv:isort]
 skip_install = true
 deps =
-    isort
+  isort
 commands =
   isort .
 
@@ -41,18 +41,18 @@ commands = ruff check .
 
 [testenv:docs]
 deps =
-    -r {toxinidir}/test_requirements.txt
-    PyGObject
-    sphinx
-    sphinx-github-changelog
+  -r {toxinidir}/test_requirements.txt
+  PyGObject
+  sphinx
+  sphinx-github-changelog
 commands = sphinx-build docs/ build/documentation
 
 [testenv:pylint]
 depends = black,isort
 deps =
-    -r {toxinidir}/test_requirements.txt
-    PyGObject
-    pylint
+  -r {toxinidir}/test_requirements.txt
+  PyGObject
+  pylint
 commands = pylint urwid
 
 [testenv:refurb]


### PR DESCRIPTION
##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [ ] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

