### PR TITLE
`ScrollBar`: fully support `__length_hint__` not `Sized`

### DIFF
--- a/examples/browse.py
+++ b/examples/browse.py
@@ -274,7 +274,14 @@ class DirectoryBrowser:
         self.listbox.offset_rows = 1
         self.footer = urwid.AttrMap(urwid.Text(self.footer_text), "foot")
         self.view = urwid.Frame(
-            urwid.AttrMap(urwid.ScrollBar(self.listbox), "body"),
+            urwid.AttrMap(
+                urwid.ScrollBar(
+                    self.listbox,
+                    thumb_char=urwid.ScrollBar.Symbols.FULL_BLOCK,
+                    trough_char=urwid.ScrollBar.Symbols.LITE_SHADE,
+                ),
+                "body",
+            ),
             header=urwid.AttrMap(self.header, "head"),
             footer=self.footer,
         )

--- a/examples/browse.py
+++ b/examples/browse.py
@@ -379,9 +379,9 @@ def escape_filename_sh_ansic(name: str) -> str:
 SPLIT_RE = re.compile(r"[a-zA-Z]+|\d+")
 
 
-def alphabetize(s):
+def alphabetize(s: str) -> list[str]:
     L = []
-    for isdigit, group in itertools.groupby(SPLIT_RE.findall(s), key=lambda x: x.isdigit()):
+    for isdigit, group in itertools.groupby(SPLIT_RE.findall(s), key=str.isdigit):
         if isdigit:
             L.extend(("", int(n)) for n in group)
         else:


### PR DESCRIPTION
* Convert `__len__` and `__length_hint__` of `ListBox` to properties: `AttributeError` will be properly handled by `getattr` / `hasattr`
* Reset to the absolute render way in case of the all contents are expected to be rendered
* better handling of decorated widgets for scrolling

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
