### PR TITLE
make ScrollBar check wrapped widgets for SupportsScroll (Fixes #878)

### DIFF
--- a/tests/test_scrollable.py
+++ b/tests/test_scrollable.py
@@ -291,6 +291,202 @@ class TestScrollBarListBox(unittest.TestCase):
 
         self.assertEqual(top_position_rendered, widget.render(reduced_size).decoded_text)
 
+
+def trivial_AttrMap(widget):
+    return urwid.AttrMap(widget, {})
+
+
+class TestScrollableAttrMap(unittest.TestCase):
+    def test_basic(self):
+        """Test basic init and scroll."""
+        long_content = urwid.Text(LGPL_HEADER)
+        reduced_size = (80, 5)
+        content_size = long_content.pack()
+
+        widget = urwid.Scrollable(trivial_AttrMap(long_content))
+        self.assertEqual(frozenset((urwid.BOX,)), widget.sizing())
+
+        cropped_content_canvas = urwid.CompositeCanvas(long_content.render((reduced_size[0],)))
+        cropped_content_canvas.trim_end(content_size[1] - reduced_size[1])
+        top_decoded = cropped_content_canvas.decoded_text
+
+        self.assertEqual(
+            top_decoded,
+            widget.render(reduced_size).decoded_text,
+        )
+
+        for key_1, key_2 in (("down", "up"), ("page down", "page up"), ("end", "home")):
+            widget.keypress(reduced_size, key_1)
+
+            self.assertNotEqual(top_decoded, widget.render(reduced_size).decoded_text)
+
+            widget.keypress(reduced_size, key_2)
+
+            self.assertEqual(top_decoded, widget.render(reduced_size).decoded_text)
+
+    def test_negative(self):
+        with self.assertRaises(ValueError):
+            urwid.Scrollable(trivial_AttrMap(urwid.SolidFill(" ")))
+
+
+class TestScrollBarAttrMap(unittest.TestCase):
+    def test_basic(self):
+        """Test basic init and scroll.
+
+        Unlike `Scrollable`, `ScrollBar` can be also scrolled with a mouse wheel.
+        """
+
+        long_content = urwid.Text(LGPL_HEADER)
+        reduced_size = (40, 5)
+        widget = urwid.ScrollBar(urwid.Scrollable(trivial_AttrMap(long_content)))
+
+        self.assertEqual(frozenset((urwid.BOX,)), widget.sizing())
+
+        top_position_rendered = (
+            "                                       █",
+            "Copyright (C) <year>  <name of author>  ",
+            "                                        ",
+            "This library is free software; you can  ",
+            "redistribute it and/or                  ",
+        )
+        pos_1_down_rendered = (
+            "Copyright (C) <year>  <name of author>  ",
+            "                                       █",
+            "This library is free software; you can  ",
+            "redistribute it and/or                  ",
+            "modify it under the terms of the GNU    ",
+        )
+
+        self.assertEqual(top_position_rendered, widget.render(reduced_size).decoded_text)
+
+        widget.keypress(reduced_size, "down")
+
+        self.assertEqual(pos_1_down_rendered, widget.render(reduced_size).decoded_text)
+
+        widget.keypress(reduced_size, "up")
+
+        self.assertEqual(top_position_rendered, widget.render(reduced_size).decoded_text)
+
+        widget.keypress(reduced_size, "page down")
+
+        self.assertEqual(
+            (
+                "redistribute it and/or                  ",
+                "modify it under the terms of the GNU   █",
+                "Lesser General Public                   ",
+                "License as published by the Free        ",
+                "Software Foundation; either             ",
+            ),
+            widget.render(reduced_size).decoded_text,
+        )
+
+        widget.keypress(reduced_size, "page up")
+
+        self.assertEqual(top_position_rendered, widget.render(reduced_size).decoded_text)
+
+        widget.keypress(reduced_size, "end")
+
+        self.assertEqual(
+            (
+                "not, write to the Free Software         ",
+                "Foundation, Inc., 51 Franklin Street,   ",
+                "Fifth Floor, Boston, MA  02110-1301     ",
+                "USA                                     ",
+                "                                       █",
+            ),
+            widget.render(reduced_size).decoded_text,
+        )
+
+        widget.keypress(reduced_size, "home")
+
+        self.assertEqual(top_position_rendered, widget.render(reduced_size).decoded_text)
+
+        widget.mouse_event(reduced_size, "mouse press", 5, 1, 1, False)
+
+        self.assertEqual(pos_1_down_rendered, widget.render(reduced_size).decoded_text)
+
+        widget.mouse_event(reduced_size, "mouse press", 4, 1, 1, False)
+
+        self.assertEqual(top_position_rendered, widget.render(reduced_size).decoded_text)
+
+
+class TestScrollBarListBoxAttrMap(unittest.TestCase):
+    def test_relative_non_selectable(self):
+        widget = urwid.ScrollBar(
+            trivial_AttrMap(
+                urwid.ListBox(urwid.SimpleListWalker(urwid.Text(line) for line in LGPL_HEADER.splitlines()))
+            )
+        )
+
+        reduced_size = (40, 5)
+
+        top_position_rendered = (
+            "                                       █",
+            "Copyright (C) <year>  <name of author>  ",
+            "                                        ",
+            "This library is free software; you can  ",
+            "redistribute it and/or                  ",
+        )
+        pos_1_down_rendered = (
+            "Copyright (C) <year>  <name of author>  ",
+            "                                       █",
+            "This library is free software; you can  ",
+            "redistribute it and/or                  ",
+            "modify it under the terms of the GNU    ",
+        )
+
+        self.assertEqual(top_position_rendered, widget.render(reduced_size).decoded_text)
+
+        widget.keypress(reduced_size, "down")
+
+        self.assertEqual(pos_1_down_rendered, widget.render(reduced_size).decoded_text)
+
+        widget.keypress(reduced_size, "up")
+
+        self.assertEqual(top_position_rendered, widget.render(reduced_size).decoded_text)
+
+        widget.keypress(reduced_size, "page down")
+
+        self.assertEqual(
+            (
+                "modify it under the terms of the GNU    ",
+                "Lesser General Public                  █",
+                "License as published by the Free        ",
+                "Software Foundation; either             ",
+                "version 2.1 of the License, or (at your ",
+            ),
+            widget.render(reduced_size).decoded_text,
+        )
+
+        widget.keypress(reduced_size, "page up")
+
+        self.assertEqual(top_position_rendered, widget.render(reduced_size).decoded_text)
+
+        widget.keypress(reduced_size, "end")
+
+        self.assertEqual(
+            (
+                "License along with this library; if     ",
+                "not, write to the Free Software         ",
+                "Foundation, Inc., 51 Franklin Street,   ",
+                "Fifth Floor, Boston, MA  02110-1301     ",
+                "USA                                    █",
+            ),
+            widget.render(reduced_size).decoded_text,
+        )
+
+        widget.keypress(reduced_size, "home")
+
+        self.assertEqual(top_position_rendered, widget.render(reduced_size).decoded_text)
+
+        widget.mouse_event(reduced_size, "mouse press", 5, 1, 1, False)
+
+        self.assertEqual(pos_1_down_rendered, widget.render(reduced_size).decoded_text)
+
+        widget.mouse_event(reduced_size, "mouse press", 4, 1, 1, False)
+
+        self.assertEqual(top_position_rendered, widget.render(reduced_size).decoded_text)
+
     def test_large_non_selectable(self):
         top = urwid.Text("\n".join(string.ascii_letters))
         bottom = urwid.Text("\n".join(string.digits))

--- a/urwid/widget/scrollable.py
+++ b/urwid/widget/scrollable.py
@@ -138,7 +138,7 @@ class SupportsRelativeScroll(WidgetProto, Protocol):
 
 
 def orig_iter(w: Widget) -> Iterator[Widget]:
-    visited = set(w)
+    visited = set((w,))
     yield w
     while hasattr(w, "original_widget"):
         w = w.original_widget

--- a/urwid/widget/scrollable.py
+++ b/urwid/widget/scrollable.py
@@ -137,6 +137,17 @@ class SupportsRelativeScroll(WidgetProto, Protocol):
     def get_visible_amount(self, size: tuple[int, int], focus: bool = False) -> int: ...
 
 
+def orig_iter(w: Widget) -> Iterator[Widget]:
+    visited = set(w)
+    yield w
+    while hasattr(w, "original_widget"):
+        w = w.original_widget
+        if w in visited:
+            break
+        visited.add(w)
+        yield w
+
+
 class Scrollable(WidgetDecoration[WrappedWidget]):
     def sizing(self) -> frozenset[Sizing]:
         return frozenset((Sizing.BOX,))
@@ -482,12 +493,6 @@ class ScrollBar(WidgetDecoration[WrappedWidget]):
         if Sizing.BOX not in widget.sizing():
             raise ValueError(f"Not a box widget: {widget!r}")
 
-        def orig_iter(w: Widget) -> Iterator[Widget]:
-            yield w
-            while hasattr(w, "original_widget"):
-                w = w.original_widget
-                yield w
-
         if not any(isinstance(w, SupportsScroll) for w in orig_iter(widget)):
             raise TypeError(f"Not a scrollable widget: {widget!r}")
 
@@ -618,12 +623,6 @@ class ScrollBar(WidgetDecoration[WrappedWidget]):
     @property
     def scrolling_base_widget(self) -> SupportsScroll | SupportsRelativeScroll:
         """Nearest `original_widget` that is compatible with the scrolling API"""
-
-        def orig_iter(w: Widget) -> Iterator[Widget]:
-            while hasattr(w, "original_widget"):
-                w = w.original_widget
-                yield w
-            yield w
 
         w = self
 

--- a/urwid/widget/scrollable.py
+++ b/urwid/widget/scrollable.py
@@ -138,7 +138,7 @@ class SupportsRelativeScroll(WidgetProto, Protocol):
 
 
 def orig_iter(w: Widget) -> Iterator[Widget]:
-    visited = set((w,))
+    visited = {w}
     yield w
     while hasattr(w, "original_widget"):
         w = w.original_widget

--- a/urwid/widget/scrollable.py
+++ b/urwid/widget/scrollable.py
@@ -481,7 +481,14 @@ class ScrollBar(WidgetDecoration[WrappedWidget]):
         """
         if Sizing.BOX not in widget.sizing():
             raise ValueError(f"Not a box widget: {widget!r}")
-        if not isinstance(widget, SupportsScroll):
+
+        def orig_iter(w: Widget) -> Iterator[Widget]:
+            yield w
+            while hasattr(w, "original_widget"):
+                w = w.original_widget
+                yield w
+
+        if not any(isinstance(w, SupportsScroll) for w in orig_iter(widget)):
             raise TypeError(f"Not a scrollable widget: {widget!r}")
 
         super().__init__(widget)


### PR DESCRIPTION
##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:

Fixes #878 .
