### PR TITLE
fix: prevent a possible infinite loop in WidgetDecoration.base_widget

### DIFF
--- a/urwid/widget/widget_decoration.py
+++ b/urwid/widget/widget_decoration.py
@@ -105,9 +105,13 @@ class WidgetDecoration(Widget, typing.Generic[WrappedWidget]):  # pylint: disabl
         >>> wd3.base_widget is t
         True
         """
+        visited = set((self,))
         w = self
         while hasattr(w, "_original_widget"):
             w = w._original_widget
+            if w in visited:
+                break
+            visited.add(w)
         return w
 
     def _get_base_widget(self) -> Widget:

--- a/urwid/widget/widget_decoration.py
+++ b/urwid/widget/widget_decoration.py
@@ -105,7 +105,7 @@ class WidgetDecoration(Widget, typing.Generic[WrappedWidget]):  # pylint: disabl
         >>> wd3.base_widget is t
         True
         """
-        visited = set((self,))
+        visited = {self}
         w = self
         while hasattr(w, "_original_widget"):
             w = w._original_widget


### PR DESCRIPTION
##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
`WidgetDecoration.base_widget` had a possible infinite loop if at any point the `_original_widget` points to somewhere higher up in the stack. See https://github.com/urwid/urwid/pull/879#discussion_r1585257869

