### PR TITLE
Adopt ExceptionGroup handling without an external library

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,7 +2,7 @@ tornado>=5
 twisted
 trio
 zmq
-exceptiongroups
+exceptiongroups;python_version<'3.11'
 windows-curses;sys_platform=="win32"
 pyserial
 # for test run

--- a/urwid/event_loop/trio_loop.py
+++ b/urwid/event_loop/trio_loop.py
@@ -26,12 +26,15 @@ Trio library is required.
 from __future__ import annotations
 
 import logging
+import sys
 import typing
 
-import exceptiongroup
 import trio
 
 from .abstract_loop import EventLoop, ExitMainLoop
+
+if sys.version_info < (3, 11):
+    from exceptiongroup import BaseExceptionGroup
 
 if typing.TYPE_CHECKING:
     import io
@@ -156,8 +159,10 @@ class TrioEventLoop(EventLoop):
 
         emulate_idle_callbacks = _TrioIdleCallbackInstrument(self._idle_callbacks)
 
-        with exceptiongroup.catch({BaseException: self._handle_main_loop_exception}):
+        try:
             trio.run(self._main_task, instruments=[emulate_idle_callbacks])
+        except BaseException as exc:
+            self._handle_main_loop_exception(exc)
 
     async def run_async(self) -> None:
         """Starts the main loop and blocks asynchronously until the main loop exits.
@@ -179,12 +184,14 @@ class TrioEventLoop(EventLoop):
 
         emulate_idle_callbacks = _TrioIdleCallbackInstrument(self._idle_callbacks)
 
-        with exceptiongroup.catch({BaseException: self._handle_main_loop_exception}):
+        try:
             trio.lowlevel.add_instrument(emulate_idle_callbacks)
             try:
                 await self._main_task()
             finally:
                 trio.lowlevel.remove_instrument(emulate_idle_callbacks)
+        except BaseException as exc:
+            self._handle_main_loop_exception(exc)
 
     def watch_file(
         self,
@@ -225,12 +232,11 @@ class TrioEventLoop(EventLoop):
         """Handles exceptions raised from the main loop, catching ExitMainLoop
         instead of letting it propagate through.
 
-        Note that since Trio may collect multiple exceptions from tasks into a
-        Trio MultiError, we cannot simply use a try..catch clause, we need a
-        helper function like this.
+        Note that since Trio may collect multiple exceptions from tasks into an ExceptionGroup,
+        we cannot simply use a try..catch clause, we need a helper function like this.
         """
         self._idle_callbacks.clear()
-        if isinstance(exc, exceptiongroup.BaseExceptionGroup) and len(exc.exceptions) == 1:
+        if isinstance(exc, BaseExceptionGroup) and len(exc.exceptions) == 1:
             exc = exc.exceptions[0]
 
         if isinstance(exc, ExitMainLoop):

--- a/urwid/event_loop/trio_loop.py
+++ b/urwid/event_loop/trio_loop.py
@@ -34,7 +34,7 @@ import trio
 from .abstract_loop import EventLoop, ExitMainLoop
 
 if sys.version_info < (3, 11):
-    from exceptiongroup import BaseExceptionGroup
+    from exceptiongroup import BaseExceptionGroup  # pylint: disable=redefined-builtin  # backport
 
 if typing.TYPE_CHECKING:
     import io


### PR DESCRIPTION
* Python <3.11 behaviour not changed

Fix: #893

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

