### PR TITLE
Maintenance: update PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,10 @@
 ##### Checklist
 - [ ] I've ensured that similar functionality has not already been implemented
 - [ ] I've ensured that similar functionality has not earlier been proposed and declined
-- [ ] I've branched off the `master` or `python-dual-support` branch
+- [ ] I've branched off the `master` branch
 - [ ] I've merged fresh upstream into my branch recently
 - [ ] I've ran `tox` successfully in local environment
 - [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
 
 ##### Description:
 *(P. S. If this pull requests fixes an existing issue, please specify which one.)*
-


### PR DESCRIPTION
`python-dual-support` branch is not used

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` or `python-dual-support` branch
- [x] I've merged fresh upstream into my branch recently
- [ ] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

