### PR TITLE
Test requirements: exceptiongroups -> exceptiongroup

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,7 +2,7 @@ tornado>=5
 twisted
 trio
 zmq
-exceptiongroups;python_version<'3.11'
+exceptiongroup;python_version<'3.11'
 windows-curses;sys_platform=="win32"
 pyserial
 # for test run


### PR DESCRIPTION
Use correct backport

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
