### PR TITLE
Fix ScrollBar mouse_event handling with ListBox

### DIFF
--- a/tests/test_scrollable.py
+++ b/tests/test_scrollable.py
@@ -133,11 +133,11 @@ class TestScrollBarScrollable(unittest.TestCase):
 
         self.assertEqual(top_position_rendered, widget.render(reduced_size).decoded_text)
 
-        widget.mouse_event(reduced_size, "mouse press", 5, 1, 1, False)
+        self.assertTrue(widget.mouse_event(reduced_size, "mouse press", 5, 1, 1, False))
 
         self.assertEqual(pos_1_down_rendered, widget.render(reduced_size).decoded_text)
 
-        widget.mouse_event(reduced_size, "mouse press", 4, 1, 1, False)
+        self.assertTrue(widget.mouse_event(reduced_size, "mouse press", 4, 1, 1, False))
 
         self.assertEqual(top_position_rendered, widget.render(reduced_size).decoded_text)
 
@@ -283,11 +283,11 @@ class TestScrollBarListBox(unittest.TestCase):
 
         self.assertEqual(top_position_rendered, widget.render(reduced_size).decoded_text)
 
-        widget.mouse_event(reduced_size, "mouse press", 5, 1, 1, False)
+        self.assertTrue(widget.mouse_event(reduced_size, "mouse press", 5, 1, 1, False))
 
         self.assertEqual(pos_1_down_rendered, widget.render(reduced_size).decoded_text)
 
-        widget.mouse_event(reduced_size, "mouse press", 4, 1, 1, False)
+        self.assertTrue(widget.mouse_event(reduced_size, "mouse press", 4, 1, 1, False))
 
         self.assertEqual(top_position_rendered, widget.render(reduced_size).decoded_text)
 
@@ -401,11 +401,11 @@ class TestScrollBarAttrMap(unittest.TestCase):
 
         self.assertEqual(top_position_rendered, widget.render(reduced_size).decoded_text)
 
-        widget.mouse_event(reduced_size, "mouse press", 5, 1, 1, False)
+        self.assertTrue(widget.mouse_event(reduced_size, "mouse press", 5, 1, 1, False))
 
         self.assertEqual(pos_1_down_rendered, widget.render(reduced_size).decoded_text)
 
-        widget.mouse_event(reduced_size, "mouse press", 4, 1, 1, False)
+        self.assertTrue(widget.mouse_event(reduced_size, "mouse press", 4, 1, 1, False))
 
         self.assertEqual(top_position_rendered, widget.render(reduced_size).decoded_text)
 
@@ -479,11 +479,11 @@ class TestScrollBarListBoxAttrMap(unittest.TestCase):
 
         self.assertEqual(top_position_rendered, widget.render(reduced_size).decoded_text)
 
-        widget.mouse_event(reduced_size, "mouse press", 5, 1, 1, False)
+        self.assertTrue(widget.mouse_event(reduced_size, "mouse press", 5, 1, 1, False))
 
         self.assertEqual(pos_1_down_rendered, widget.render(reduced_size).decoded_text)
 
-        widget.mouse_event(reduced_size, "mouse press", 4, 1, 1, False)
+        self.assertTrue(widget.mouse_event(reduced_size, "mouse press", 4, 1, 1, False))
 
         self.assertEqual(top_position_rendered, widget.render(reduced_size).decoded_text)
 
@@ -518,11 +518,11 @@ class TestScrollBarListBoxAttrMap(unittest.TestCase):
 
         self.assertEqual(top_position_rendered, widget.render(reduced_size).decoded_text)
 
-        widget.mouse_event(reduced_size, "mouse press", 5, 1, 1, False)
+        self.assertTrue(widget.mouse_event(reduced_size, "mouse press", 5, 1, 1, False))
 
         self.assertEqual(pos_1_down_rendered, widget.render(reduced_size).decoded_text)
 
-        widget.mouse_event(reduced_size, "mouse press", 4, 1, 1, False)
+        self.assertTrue(widget.mouse_event(reduced_size, "mouse press", 4, 1, 1, False))
 
         self.assertEqual(top_position_rendered, widget.render(reduced_size).decoded_text)
 

--- a/urwid/widget/scrollable.py
+++ b/urwid/widget/scrollable.py
@@ -668,4 +668,4 @@ class ScrollBar(WidgetDecoration[WrappedWidget]):
                 ow.set_scrollpos(pos + 1)
                 return True
 
-        return False
+        return handled


### PR DESCRIPTION
Propagate handled from ScrollBar if original widget (ListBox) handled the event.

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment

##### Description:
If original widget (i.e. ListBox) handles the event, return `True` indicating that the event was handled.

Fixes #904 
