### PR TITLE
Fix `ListBox.rows_max` calculation for empty container

### DIFF
--- a/tests/test_scrollable.py
+++ b/tests/test_scrollable.py
@@ -291,6 +291,21 @@ class TestScrollBarListBox(unittest.TestCase):
 
         self.assertEqual(top_position_rendered, widget.render(reduced_size).decoded_text)
 
+    def test_empty(self):
+        """Empty widget should be correctly rendered."""
+        widget = urwid.ScrollBar(urwid.ListBox(urwid.SimpleListWalker(())))
+        reduced_size = (10, 5)
+        self.assertEqual(
+            (
+                "          ",
+                "          ",
+                "          ",
+                "          ",
+                "          ",
+            ),
+            widget.render(reduced_size).decoded_text,
+        )
+
 
 def trivial_AttrMap(widget):
     return urwid.AttrMap(widget, {})

--- a/urwid/widget/listbox.py
+++ b/urwid/widget/listbox.py
@@ -645,17 +645,18 @@ class ListBox(Widget, WidgetContainerMixin):
             rows = 0
 
             focused_w, idx = self.body.get_focus()
-            rows += focused_w.rows((cols,), focus)
+            if focused_w:
+                rows += focused_w.rows((cols,), focus)
 
-            prev, pos = self._body.get_prev(idx)
-            while prev is not None:
-                rows += prev.rows((cols,), False)
-                prev, pos = self._body.get_prev(pos)
+                prev, pos = self._body.get_prev(idx)
+                while prev is not None:
+                    rows += prev.rows((cols,), False)
+                    prev, pos = self._body.get_prev(pos)
 
-            next_, pos = self.body.get_next(idx)
-            while next_ is not None:
-                rows += next_.rows((cols,), True)
-                next_, pos = self._body.get_next(pos)
+                next_, pos = self.body.get_next(idx)
+                while next_ is not None:
+                    rows += next_.rows((cols,), True)
+                    next_, pos = self._body.get_next(pos)
 
             self._rows_max_cached = rows
 


### PR DESCRIPTION
In case of empty container,
`get_focus` will return `None, None`

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
