### PR TITLE
Feature: Add focus reporting support

### DIFF
--- a/urwid/display/escape.py
+++ b/urwid/display/escape.py
@@ -85,6 +85,8 @@ input_sequences = [
     ("[F", "end"),
     ("[G", "5"),
     ("[H", "home"),
+    ("[I", "focus in"),
+    ("[O", "focus out"),
     ("[1~", "home"),
     ("[2~", "insert"),
     ("[3~", "delete"),
@@ -573,6 +575,9 @@ RESTORE_NORMAL_BUFFER = f"{ESC}[?1049l"
 
 ENABLE_BRACKETED_PASTE_MODE = f"{ESC}[?2004h"
 DISABLE_BRACKETED_PASTE_MODE = f"{ESC}[?2004l"
+
+ENABLE_FOCUS_REPORTING = f"{ESC}[?1004h"
+DISABLE_FOCUS_REPORTING = f"{ESC}[?1004l"
 
 # RESET_SCROLL_REGION = ESC+"[;r"
 # RESET = ESC+"c"


### PR DESCRIPTION
This allows an application to request that focus events (i.e. when focus is gained or lost by the application) be reported as keypress events "focus in" and "focus out". It is currently only supported by raw POSIX displays.

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment (note: some stuff in my environment was funky so I had to manually re-run some of the tests `tox` was running on the command-line, but I believe I was able to get everything to pass that way)
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
*(P. S. If this pull requests fixes an existing issue, please specify which one.)*
