### PR TITLE
Disable mouse tracking and discard input when exiting the main loop

### DIFF
--- a/urwid/display/_posix_raw_display.py
+++ b/urwid/display/_posix_raw_display.py
@@ -211,11 +211,11 @@ class Screen(_raw_display_base.Screen):
 
         self.signal_restore()
 
+        self._stop_mouse_restore_buffer()
+
         fd = self._input_fileno()
         if fd is not None and os.isatty(fd):
-            termios.tcsetattr(fd, termios.TCSADRAIN, self._old_termios_settings)
-
-        self._stop_mouse_restore_buffer()
+            termios.tcsetattr(fd, termios.TCSAFLUSH, self._old_termios_settings)
 
         if self._old_signal_keys:
             self.tty_signal_keys(*self._old_signal_keys, fd)


### PR DESCRIPTION
##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` branch
- [X] I've merged fresh upstream into my branch recently
- [ ] I've ran `tox` successfully in local environment
- [X] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
The current code first drains the input and then disables mouse tracking. This sequence creates a time window where unexpected ANSI escape codes might appear in the user's terminal after the application exits. To prevent this, the correct order is to first disable mouse tracking and then flush any unprocessed input.

##### Test:
```
python -m venv .venv
source .venv/bin/activate
pip install --editable .
git checkout master
patch -p1 < repro-before-fix.patch
python3 test.py
# repeatedly click on the Click button
# you should see output similar to ^[[<0;5;35m on your terminal
git checkout .
git checkout fix-disable-mouse-tracking-discard-input-on-exit
patch -p1 < repro-after-fix.patch
python3 test.py
# repeatedly click on the Click button
# you should not see any unexpected output on your terminal
```

```py
# test.py
import urwid

def f(*args):
    raise urwid.ExitMainLoop()
button = urwid.Button("Click", on_press=f)
fill = urwid.Filler(button, "bottom")
loop = urwid.MainLoop(fill)
loop.run()
```
[repro-before-fix.patch](https://github.com/user-attachments/files/17118616/repro-before-fix.patch)
[repro-after-fix.patch](https://github.com/user-attachments/files/17118617/repro-after-fix.patch)
