### PR TITLE
Pylint: disable `too-many-positional-arguments` check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -240,6 +240,7 @@ disable = [
   "too-many-instance-attributes",
   "too-many-lines",
   "too-many-nested-blocks",
+  "too-many-positional-arguments",
   "broad-except",
   "broad-exception-raised",
   "logging-fstring-interpolation",

--- a/urwid/font.py
+++ b/urwid/font.py
@@ -192,9 +192,9 @@ class Font(metaclass=FontRegistry):
 
     __slots__ = ("canvas", "char", "utf8_required")
 
-    height: int
-    data: Sequence[str]
-    name: str
+    height: int  # pylint: disable=declare-non-slot
+    data: Sequence[str]  # pylint: disable=declare-non-slot
+    name: str  # pylint: disable=declare-non-slot
 
     def __init__(self) -> None:
         if not self.height:

--- a/urwid/util.py
+++ b/urwid/util.py
@@ -143,7 +143,7 @@ def get_encoding() -> str:
 
 
 @contextlib.contextmanager
-def set_temporary_encoding(encoding_name: str) -> Generator[None, None, None]:
+def set_temporary_encoding(encoding_name: str) -> Generator[None]:
     """Internal helper for encoding specific validation in unittests/doctests.
 
     Not exported globally.


### PR DESCRIPTION
In our case it's noise