### PR TITLE
Type annotations: fix typing issues

### DIFF
--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -231,7 +231,7 @@ class ColumnsTest(unittest.TestCase):
 
     def test_render_pack_item_not_fit(self):
         items = urwid.Text("123"), urwid.Text("456")
-        widget = urwid.Columns(((urwid.PACK, item) for item in items))
+        widget = urwid.Columns((urwid.PACK, item) for item in items)
         # Make width < widget fixed pack
         width = items[0].pack(())[0] - 1
         height = items[0].rows((width,))

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -2,13 +2,12 @@ from __future__ import annotations
 
 import typing
 import unittest
-from typing import Collection
 
 import urwid
 from urwid import TreeNode
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Hashable, Iterable
+    from collections.abc import Collection, Hashable, Iterable
 
 
 class SelfRegisteringParent(urwid.ParentNode):

--- a/urwid/command_map.py
+++ b/urwid/command_map.py
@@ -21,9 +21,10 @@ from __future__ import annotations
 
 import enum
 import typing
-from typing import Iterator
 
 if typing.TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from typing_extensions import Self
 
 

--- a/urwid/display/escape.py
+++ b/urwid/display/escape.py
@@ -32,7 +32,7 @@ from collections.abc import MutableMapping, Sequence
 from urwid import str_util
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Collection, Iterable
+    from collections.abc import Iterable
 
 # NOTE: because of circular imports (urwid.util -> urwid.escape -> urwid.util)
 # from urwid.util import is_mouse_event -- will not work here
@@ -227,7 +227,7 @@ class KeyqueueTrie:
             MutableMapping[int, str | MutableMapping[int, str | MutableMapping[int, str]]]
             | typing.Literal["mouse", "sgrmouse"]
         ),
-        keys: Collection[int],
+        keys: Sequence[int],
         more_available: bool,
     ):
         if not isinstance(root, MutableMapping):
@@ -247,7 +247,7 @@ class KeyqueueTrie:
             return None
         return self.get_recurse(root[keys[0]], keys[1:], more_available)
 
-    def read_mouse_info(self, keys: Collection[int], more_available: bool):
+    def read_mouse_info(self, keys: Sequence[int], more_available: bool):
         if len(keys) < 3:
             if more_available:
                 raise MoreInputRequired()
@@ -286,7 +286,7 @@ class KeyqueueTrie:
 
         return ((f"{prefix}mouse {action}", button, x, y), keys[3:])
 
-    def read_sgrmouse_info(self, keys: Collection[int], more_available: bool):
+    def read_sgrmouse_info(self, keys: Sequence[int], more_available: bool):
         # Helpful links:
         # https://stackoverflow.com/questions/5966903/how-to-get-mousemove-and-mouseclick-in-bash
         # http://invisible-island.net/xterm/ctlseqs/ctlseqs.pdf


### PR DESCRIPTION
* Combining deprecated typing with annotations enabled
* Using `Collection` and expecting `__getitem__`

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
