### PR TITLE
Windows: use Unicode input directly

### DIFF
--- a/urwid/display/_win32_raw_display.py
+++ b/urwid/display/_win32_raw_display.py
@@ -246,11 +246,12 @@ class ReadInputThread(threading.Thread):
                     if not inp.Event.KeyEvent.bKeyDown:
                         continue
 
-                    input_data = inp.Event.KeyEvent.uChar.AsciiChar
-                    # On Windows atomic press/release of modifier keys produce phantom input with code NULL
+                    input_data = inp.Event.KeyEvent.uChar.UnicodeChar
+                    # On Windows atomic press/release of modifier keys produce phantom input with code NULL.
                     # This input cannot be decoded and should be handled as garbage.
-                    if input_data != b"\x00":
-                        self._input.send(input_data)
+                    input_bytes = input_data.encode("utf-8")
+                    if input_bytes != b"\x00":
+                        self._input.send(input_bytes)
 
                 elif inp.EventType == _win32.EventType.WINDOW_BUFFER_SIZE_EVENT:
                     self._resize()


### PR DESCRIPTION
Fix: #934 #882

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
