### PR TITLE
Drop deprecated `__super` property

### DIFF
--- a/urwid/util.py
+++ b/urwid/util.py
@@ -493,24 +493,12 @@ def is_mouse_press(ev: str) -> bool:
 
 
 class MetaSuper(type):
-    """adding .__super"""
+    """Deprecated metaclass.
 
-    def __init__(cls, name: str, bases, d):
-        super().__init__(name, bases, d)
-        if hasattr(cls, f"_{name}__super"):
-            raise AttributeError("Class has same name as one of its super classes")
+    Present only for code compatibility, all logic has been removed.
+    """
 
-        @property
-        def _super(self):
-            warnings.warn(
-                f"`{name}.__super` was a deprecated feature for old python versions."
-                f"Please use `super()` call instead.",
-                DeprecationWarning,
-                stacklevel=3,
-            )
-            return super(cls, self)
-
-        setattr(cls, f"_{name}__super", _super)
+    __slots__ = ()
 
 
 def int_scale(val: int, val_range: int, out_range: int) -> int:


### PR DESCRIPTION
Python native `super()` method should be used.
1-year period of `DeprecationWarning` was used.

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
