### PR TITLE
Remove deprecated protected getter methods from the container widgets

### DIFF
--- a/urwid/widget/columns.py
+++ b/urwid/widget/columns.py
@@ -638,17 +638,6 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
             return None
         return self.contents[self.focus_position][0]
 
-    def _get_focus(self) -> Widget:
-        warnings.warn(
-            f"method `{self.__class__.__name__}._get_focus` is deprecated, "
-            f"please use `{self.__class__.__name__}.focus` property",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-        if not self.contents:
-            return None
-        return self.contents[self.focus_position][0]
-
     def get_focus(self):
         """
         Return the widget in focus, for backwards compatibility.
@@ -691,17 +680,6 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
                 exc.__traceback__
             ) from exc
         self.contents.focus = position
-
-    def _get_focus_position(self) -> int | None:
-        warnings.warn(
-            f"method `{self.__class__.__name__}._get_focus_position` is deprecated, "
-            f"please use `{self.__class__.__name__}.focus_position` property",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-        if not self.contents:
-            raise IndexError("No focus_position, Columns is empty")
-        return self.contents.focus
 
     def _set_focus_position(self, position: int) -> None:
         """

--- a/urwid/widget/container.py
+++ b/urwid/widget/container.py
@@ -130,15 +130,6 @@ class WidgetContainerMixin:
         always returns ``None``, indicating that this widget has no children.
         """
 
-    def _get_focus(self) -> Widget:
-        warnings.warn(
-            f"method `{self.__class__.__name__}._get_focus` is deprecated, "
-            f"please use `{self.__class__.__name__}.focus` property",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-        return self.focus
-
 
 class WidgetContainerListContentsMixin:
     """
@@ -172,15 +163,6 @@ class WidgetContainerListContentsMixin:
     def contents(self, new_contents: list[tuple[Widget, typing.Any]]) -> None:
         """The contents of container as a list of (widget, options)"""
 
-    def _get_contents(self) -> list[tuple[Widget, typing.Any]]:
-        warnings.warn(
-            f"method `{self.__class__.__name__}._get_contents` is deprecated, "
-            f"please use `{self.__class__.__name__}.contents` property",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.contents
-
     def _set_contents(self, c: list[tuple[Widget, typing.Any]]) -> None:
         warnings.warn(
             f"method `{self.__class__.__name__}._set_contents` is deprecated, "
@@ -202,15 +184,6 @@ class WidgetContainerListContentsMixin:
         """
         index of child widget in focus.
         """
-
-    def _get_focus_position(self) -> int | None:
-        warnings.warn(
-            f"method `{self.__class__.__name__}._get_focus_position` is deprecated, "
-            f"please use `{self.__class__.__name__}.focus_position` property",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-        return self.focus_position
 
     def _set_focus_position(self, position: int) -> None:
         """

--- a/urwid/widget/frame.py
+++ b/urwid/widget/frame.py
@@ -255,15 +255,6 @@ class Frame(Widget, WidgetContainerMixin, typing.Generic[BodyWidget, HeaderWidge
         This is a read-only property."""
         return {"header": self._header, "footer": self._footer, "body": self._body}[self.focus_part]
 
-    def _get_focus(self) -> BodyWidget | HeaderWidget | FooterWidget:
-        warnings.warn(
-            f"method `{self.__class__.__name__}._get_focus` is deprecated, "
-            f"please use `{self.__class__.__name__}.focus` property",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-        return {"header": self._header, "footer": self._footer, "body": self._body}[self.focus_part]
-
     @property
     def contents(
         self,
@@ -387,15 +378,6 @@ class Frame(Widget, WidgetContainerMixin, typing.Generic[BodyWidget, HeaderWidge
             self.header = None
         else:
             self.footer = None
-
-    def _contents(self):
-        warnings.warn(
-            f"method `{self.__class__.__name__}._contents` is deprecated, "
-            f"please use property `{self.__class__.__name__}.contents`",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-        return self.contents
 
     def options(self) -> None:
         """

--- a/urwid/widget/grid_flow.py
+++ b/urwid/widget/grid_flow.py
@@ -169,15 +169,6 @@ class GridFlow(WidgetWrap[Pile], WidgetContainerMixin, WidgetContainerListConten
         if focus_position < len(widgets):
             self.focus_position = focus_position
 
-    def _get_cells(self):
-        warnings.warn(
-            "only for backwards compatibility."
-            "You should use the new standard container property `contents` to modify GridFlow",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-        return self.cells
-
     def _set_cells(self, widgets: Sequence[Widget]):
         warnings.warn(
             "only for backwards compatibility."
@@ -201,15 +192,6 @@ class GridFlow(WidgetWrap[Pile], WidgetContainerMixin, WidgetContainerListConten
         self.contents = [(w, (WHSettings.GIVEN, width)) for (w, options) in self.contents]
         self.focus_position = focus_position
         self._cell_width = width
-
-    def _get_cell_width(self) -> int:
-        warnings.warn(
-            f"Method `{self.__class__.__name__}._get_cell_width` is deprecated, "
-            f"please use property `{self.__class__.__name__}.cell_width`",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-        return self.cell_width
 
     def _set_cell_width(self, width: int) -> None:
         warnings.warn(
@@ -298,17 +280,6 @@ class GridFlow(WidgetWrap[Pile], WidgetContainerMixin, WidgetContainerListConten
             return None
         return self.contents[self.focus_position][0]
 
-    def _get_focus(self) -> Widget | None:
-        warnings.warn(
-            f"method `{self.__class__.__name__}._get_focus` is deprecated, "
-            f"please use `{self.__class__.__name__}.focus` property",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-        if not self.contents:
-            return None
-        return self.contents[self.focus_position][0]
-
     def get_focus(self):
         """
         Return the widget in focus, for backwards compatibility.
@@ -391,17 +362,6 @@ class GridFlow(WidgetWrap[Pile], WidgetContainerMixin, WidgetContainerListConten
                 exc.__traceback__
             ) from exc
         self.contents.focus = position
-
-    def _get_focus_position(self) -> int | None:
-        warnings.warn(
-            f"method `{self.__class__.__name__}._get_focus_position` is deprecated, "
-            f"please use `{self.__class__.__name__}.focus_position` property",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-        if not self.contents:
-            raise IndexError("No focus_position, GridFlow is empty")
-        return self.contents.focus
 
     def _set_focus_position(self, position: int) -> None:
         """

--- a/urwid/widget/listbox.py
+++ b/urwid/widget/listbox.py
@@ -166,15 +166,6 @@ class SimpleListWalker(MonitoredList[_T], ListWalker):
         """
         return self
 
-    def _get_contents(self) -> Self:
-        warnings.warn(
-            f"Method `{self.__class__.__name__}._get_contents` is deprecated, "
-            f"please use property`{self.__class__.__name__}.contents`",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-        return self
-
     def _modified(self) -> None:
         if self.focus >= len(self):
             self.focus = max(0, len(self) - 1)
@@ -425,15 +416,6 @@ class ListBox(Widget, WidgetContainerMixin):
             # content has changed
             self.render = nocache_widget_render_instance(self)
         self._invalidate()
-
-    def _get_body(self):
-        warnings.warn(
-            f"Method `{self.__class__.__name__}._get_body` is deprecated, "
-            f"please use property `{self.__class__.__name__}.body`",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-        return self.body
 
     def _set_body(self, body):
         warnings.warn(
@@ -887,15 +869,6 @@ class ListBox(Widget, WidgetContainerMixin):
         Return the widget in focus according to our :obj:`list walker <ListWalker>`.
         """
         return self._body.get_focus()[0]
-
-    def _get_focus(self) -> Widget:
-        warnings.warn(
-            f"method `{self.__class__.__name__}._get_focus` is deprecated, "
-            f"please use `{self.__class__.__name__}.focus` property",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-        return self.focus
 
     def _get_focus_position(self):
         """

--- a/urwid/widget/overlay.py
+++ b/urwid/widget/overlay.py
@@ -582,15 +582,6 @@ class Overlay(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin, ty
         """
         return self.top_w
 
-    def _get_focus(self) -> TopWidget:
-        warnings.warn(
-            f"method `{self.__class__.__name__}._get_focus` is deprecated, "
-            f"please use `{self.__class__.__name__}.focus` property",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-        return self.top_w
-
     @property
     def focus_position(self) -> Literal[1]:
         """
@@ -607,15 +598,6 @@ class Overlay(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin, ty
         """
         if position != 1:
             raise IndexError(f"Overlay widget focus_position currently must always be set to 1, not {position}")
-
-    def _get_focus_position(self) -> int | None:
-        warnings.warn(
-            f"method `{self.__class__.__name__}._get_focus_position` is deprecated, "
-            f"please use `{self.__class__.__name__}.focus_position` property",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-        return 1
 
     def _set_focus_position(self, position: int) -> None:
         """

--- a/urwid/widget/pile.py
+++ b/urwid/widget/pile.py
@@ -468,17 +468,6 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
                 return
         raise ValueError(f"Widget not found in Pile contents: {item!r}")
 
-    def _get_focus(self) -> Widget:
-        warnings.warn(
-            f"method `{self.__class__.__name__}._get_focus` is deprecated, "
-            f"please use `{self.__class__.__name__}.focus` property",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-        if not self.contents:
-            return None
-        return self.contents[self.focus_position][0]
-
     def get_focus(self) -> Widget | None:
         """
         Return the widget in focus, for backwards compatibility.  You may
@@ -556,17 +545,6 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         except TypeError as exc:
             raise IndexError(f"No Pile child widget at position {position}").with_traceback(exc.__traceback__) from exc
         self.contents.focus = position
-
-    def _get_focus_position(self) -> int | None:
-        warnings.warn(
-            f"method `{self.__class__.__name__}._get_focus_position` is deprecated, "
-            f"please use `{self.__class__.__name__}.focus_position` property",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-        if not self.contents:
-            raise IndexError("No focus_position, Pile is empty")
-        return self.contents.focus
 
     def _set_focus_position(self, position: int) -> None:
         """


### PR DESCRIPTION
* `_get_focus`
* `_get_focus_position`
* `_contents`
* `_get_contents`
* `_get_cells`
* `_get_cell_width`

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
*(P. S. If this pull requests fixes an existing issue, please specify which one.)*
