### PR TITLE
Remove deprecated protected getter methods from the `Canvas` and `AttrSpec`

### DIFF
--- a/urwid/canvas.py
+++ b/urwid/canvas.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 import contextlib
 import dataclasses
 import typing
-import warnings
 import weakref
 from contextlib import suppress
 
@@ -244,15 +243,6 @@ class Canvas:
     def widget_info(self):
         return self._widget_info
 
-    def _get_widget_info(self):
-        warnings.warn(
-            f"Method `{self.__class__.__name__}._get_widget_info` is deprecated, "
-            f"please use property `{self.__class__.__name__}.widget_info`",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.widget_info
-
     @property
     def text(self) -> list[bytes]:
         """
@@ -265,15 +255,6 @@ class Canvas:
         """Decoded text content of the canvas as a sequence of strings, one for each row."""
         encoding = get_encoding()
         return tuple(line.decode(encoding) for line in self.text)
-
-    def _text_content(self):
-        warnings.warn(
-            f"Method `{self.__class__.__name__}._text_content` is deprecated, "
-            f"please use property `{self.__class__.__name__}.text`",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.text
 
     def content(
         self,

--- a/urwid/display/common.py
+++ b/urwid/display/common.py
@@ -704,15 +704,6 @@ class AttrSpec:
             return 16
         return 1
 
-    def _colors(self) -> int:
-        warnings.warn(
-            f"Method `{self.__class__.__name__}._colors` is deprecated, "
-            f"please use property `{self.__class__.__name__}.colors`",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.colors
-
     def __repr__(self) -> str:
         """
         Return an executable python representation of the AttrSpec
@@ -785,15 +776,6 @@ class AttrSpec:
             color = 0
         self.__value = (self.__value & ~_FG_MASK) | color | flags
 
-    def _foreground(self) -> str:
-        warnings.warn(
-            f"Method `{self.__class__.__name__}._foreground` is deprecated, "
-            f"please use property `{self.__class__.__name__}.foreground`",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.foreground
-
     @property
     def background(self) -> str:
         """Return the background color."""
@@ -826,15 +808,6 @@ class AttrSpec:
         if color is None:
             raise AttrSpecError(f"Unrecognised color specification in background ({background!r})")
         self.__value = (self.__value & ~_BG_MASK) | (color << _BG_SHIFT) | flags
-
-    def _background(self) -> str:
-        warnings.warn(
-            f"Method `{self.__class__.__name__}._background` is deprecated, "
-            f"please use property `{self.__class__.__name__}.background`",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.background
 
     def get_rgb_values(self) -> tuple[int | None, int | None, int | None, int | None, int | None, int | None]:
         """


### PR DESCRIPTION
* `Canvas._get_widget_info`
* `Canvas._text_content`

* `AttrSpec._colors`
* `AttrSpec._foreground`
* `AttrSpec._background`

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [X] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
