### PR TITLE
Remove deprecated `TermScroller`

### DIFF
--- a/urwid/__init__.py
+++ b/urwid/__init__.py
@@ -239,7 +239,7 @@ except ImportError:
 
 # OS Specific
 if sys.platform != "win32":
-    from .vterm import TermCanvas, TermCharset, Terminal, TermModes, TermScroller
+    from .vterm import TermCanvas, TermCharset, Terminal, TermModes
 
     # ZMQEventLoop cause interpreter crash on windows
     try:

--- a/urwid/vterm.py
+++ b/urwid/vterm.py
@@ -35,7 +35,6 @@ import termios
 import time
 import traceback
 import typing
-import warnings
 from collections import deque
 from contextlib import suppress
 from dataclasses import dataclass
@@ -257,39 +256,6 @@ class TermCharset:
             return char
 
         return char
-
-
-class TermScroller(list):
-    """
-    List subclass that handles the terminal scrollback buffer,
-    truncating it as necessary.
-    """
-
-    SCROLLBACK_LINES = 10000
-
-    def __init__(self, iterable: Iterable[typing.Any]) -> None:
-        warnings.warn(
-            "`TermScroller` is deprecated. Please use `collections.deque` with non-zero `maxlen` instead.",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-        super().__init__(iterable)
-
-    def trunc(self) -> None:
-        if len(self) >= self.SCROLLBACK_LINES:
-            self.pop(0)
-
-    def append(self, obj) -> None:
-        self.trunc()
-        super().append(obj)
-
-    def insert(self, idx: typing.SupportsIndex, obj) -> None:
-        self.trunc()
-        super().insert(idx, obj)
-
-    def extend(self, seq) -> None:
-        self.trunc()
-        super().extend(seq)
 
 
 class TermCanvas(Canvas):


### PR DESCRIPTION
* Need to use `collections.deque` with non-zero `maxlen`
* 1-year deprecation period expired

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
