### PR TITLE
`MetaSignals` should subclass `ABCMeta`

### DIFF
--- a/urwid/display/common.py
+++ b/urwid/display/common.py
@@ -988,13 +988,9 @@ class ScreenError(Exception):
     pass
 
 
-class BaseMeta(signals.MetaSignals, abc.ABCMeta):
-    """Base metaclass for abstra"""
-
-
-class BaseScreen(metaclass=BaseMeta):
+class BaseScreen(abc.ABC, metaclass=signals.MetaSignals):
     """
-    Base class for Screen classes (raw_display.Screen, .. etc)
+    Base class for Screen classes (raw_display.Screen, ..., etc.)
     """
 
     signals: typing.ClassVar[list[str]] = [UPDATE_PALETTE_ENTRY, INPUT_DESCRIPTORS_CHANGED]

--- a/urwid/signals.py
+++ b/urwid/signals.py
@@ -20,6 +20,7 @@
 
 from __future__ import annotations
 
+import abc
 import itertools
 import typing
 import warnings
@@ -29,7 +30,7 @@ if typing.TYPE_CHECKING:
     from collections.abc import Callable, Collection, Container, Hashable, Iterable
 
 
-class MetaSignals(type):
+class MetaSignals(abc.ABCMeta):
     """
     register the list of signals in the class variable signals,
     including signals in superclasses.


### PR DESCRIPTION
Simplify base class hierarchy for the abstract classes.
Remove internal undocumented `BaseMeta` metaclass for the `BaseScreen` as not needed.

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
*(P. S. If this pull requests fixes an existing issue, please specify which one.)*
