### PR TITLE
Remove deprecated protected setters in the decoration widgets

### DIFF
--- a/urwid/widget/padding.py
+++ b/urwid/widget/padding.py
@@ -215,15 +215,6 @@ class Padding(WidgetDecoration[WrappedWidget], typing.Generic[WrappedWidget]):
         self._align_type, self._align_amount = normalize_align(align, PaddingError)
         self._invalidate()
 
-    def _set_align(self, align: Literal["left", "center", "right"] | tuple[Literal["relative"], int]) -> None:
-        warnings.warn(
-            f"Method `{self.__class__.__name__}._set_align` is deprecated, "
-            f"please use property `{self.__class__.__name__}.align`",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        self.align = align
-
     @property
     def width(
         self,
@@ -251,15 +242,6 @@ class Padding(WidgetDecoration[WrappedWidget], typing.Generic[WrappedWidget]):
         """
         self._width_type, self._width_amount = normalize_width(width, PaddingError)
         self._invalidate()
-
-    def _set_width(self, width: Literal["clip", "pack"] | int | tuple[Literal["relative"], int]) -> None:
-        warnings.warn(
-            f"Method `{self.__class__.__name__}._set_width` is deprecated, "
-            f"please use property `{self.__class__.__name__}.width`",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        self.width = width
 
     def pack(
         self,

--- a/urwid/widget/widget_decoration.py
+++ b/urwid/widget/widget_decoration.py
@@ -71,15 +71,6 @@ class WidgetDecoration(Widget, typing.Generic[WrappedWidget]):  # pylint: disabl
         self._original_widget = original_widget
         self._invalidate()
 
-    def _set_original_widget(self, original_widget: WrappedWidget) -> None:
-        warnings.warn(
-            f"Method `{self.__class__.__name__}._set_original_widget` is deprecated, "
-            f"please use property `{self.__class__.__name__}.original_widget`",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        self.original_widget = original_widget
-
     @property
     def base_widget(self) -> Widget:
         """


### PR DESCRIPTION
* `Padding._set_align`
* `Padding._set_width`
* `WidgetDecoration._set_original_widget`

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
