### PR TITLE
API Extension: make `CommandMap` `MutableMapping`

### DIFF
--- a/urwid/command_map.py
+++ b/urwid/command_map.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import enum
 import typing
-from collections.abc import Mapping
+from collections.abc import MutableMapping
 
 if typing.TYPE_CHECKING:
     from collections.abc import Iterator
@@ -57,7 +57,7 @@ CURSOR_MAX_RIGHT = Command.MAX_RIGHT
 ACTIVATE = Command.ACTIVATE
 
 
-class CommandMap(Mapping[str, typing.Union[str, Command, None]]):
+class CommandMap(MutableMapping[str, typing.Union[str, Command, None]]):
     """
     dict-like object for looking up commands from keystrokes
 


### PR DESCRIPTION
Support all standard `MutableMapping` methods instead of only `__getitem__`/`__setitem__`/`__delitem__`

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
