### PR TITLE
Remove deprecated protected methods from the container widgets

### DIFF
--- a/urwid/widget/columns.py
+++ b/urwid/widget/columns.py
@@ -681,27 +681,6 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
             ) from exc
         self.contents.focus = position
 
-    def _set_focus_position(self, position: int) -> None:
-        """
-        Set the widget in focus.
-
-        position -- index of child widget to be made focus
-        """
-        warnings.warn(
-            f"method `{self.__class__.__name__}._set_focus_position` is deprecated, "
-            f"please use `{self.__class__.__name__}.focus_position` property",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-        try:
-            if position < 0 or position >= len(self.contents):
-                raise IndexError(f"No Columns child widget at position {position}")
-        except TypeError as exc:
-            raise IndexError(f"No Columns child widget at position {position}").with_traceback(
-                exc.__traceback__
-            ) from exc
-        self.contents.focus = position
-
     @property
     def focus_col(self):
         """

--- a/urwid/widget/container.py
+++ b/urwid/widget/container.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import abc
 import enum
 import typing
-import warnings
 
 from .constants import Sizing, WHSettings
 
@@ -162,15 +161,6 @@ class WidgetContainerListContentsMixin:
     def contents(self, new_contents: list[tuple[Widget, typing.Any]]) -> None:
         """The contents of container as a list of (widget, options)"""
 
-    def _set_contents(self, c: list[tuple[Widget, typing.Any]]) -> None:
-        warnings.warn(
-            f"method `{self.__class__.__name__}._set_contents` is deprecated, "
-            f"please use `{self.__class__.__name__}.contents` property",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        self.contents = c
-
     @property
     @abc.abstractmethod
     def focus_position(self) -> int | None:
@@ -183,17 +173,3 @@ class WidgetContainerListContentsMixin:
         """
         index of child widget in focus.
         """
-
-    def _set_focus_position(self, position: int) -> None:
-        """
-        Set the widget in focus.
-
-        position -- index of child widget to be made focus
-        """
-        warnings.warn(
-            f"method `{self.__class__.__name__}._set_focus_position` is deprecated, "
-            f"please use `{self.__class__.__name__}.focus_position` property",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-        self.focus_position = position

--- a/urwid/widget/grid_flow.py
+++ b/urwid/widget/grid_flow.py
@@ -169,15 +169,6 @@ class GridFlow(WidgetWrap[Pile], WidgetContainerMixin, WidgetContainerListConten
         if focus_position < len(widgets):
             self.focus_position = focus_position
 
-    def _set_cells(self, widgets: Sequence[Widget]):
-        warnings.warn(
-            "only for backwards compatibility."
-            "You should use the new standard container property `contents` to modify GridFlow",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-        self.cells = widgets
-
     @property
     def cell_width(self) -> int:
         """
@@ -192,15 +183,6 @@ class GridFlow(WidgetWrap[Pile], WidgetContainerMixin, WidgetContainerListConten
         self.contents = [(w, (WHSettings.GIVEN, width)) for (w, options) in self.contents]
         self.focus_position = focus_position
         self._cell_width = width
-
-    def _set_cell_width(self, width: int) -> None:
-        warnings.warn(
-            f"Method `{self.__class__.__name__}._set_cell_width` is deprecated, "
-            f"please use property `{self.__class__.__name__}.cell_width`",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-        self.cell_width = width
 
     @property
     def contents(self) -> MonitoredFocusList[tuple[Widget, tuple[Literal[WHSettings.GIVEN], int]]]:
@@ -323,20 +305,6 @@ class GridFlow(WidgetWrap[Pile], WidgetContainerMixin, WidgetContainerListConten
                 return
         raise ValueError(f"Widget not found in GridFlow contents: {cell!r}")
 
-    def _set_focus_cell(self, cell: Widget) -> None:
-        warnings.warn(
-            "only for backwards compatibility."
-            "You may also use the new standard container property"
-            "`focus` to get the focus and `focus_position` to get/set the cell in focus by index",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-        for i, (w, _options) in enumerate(self.contents):
-            if cell == w:
-                self.focus_position = i
-                return
-        raise ValueError(f"Widget not found in GridFlow contents: {cell!r}")
-
     @property
     def focus_position(self) -> int | None:
         """
@@ -354,27 +322,6 @@ class GridFlow(WidgetWrap[Pile], WidgetContainerMixin, WidgetContainerListConten
 
         position -- index of child widget to be made focus
         """
-        try:
-            if position < 0 or position >= len(self.contents):
-                raise IndexError(f"No GridFlow child widget at position {position}")
-        except TypeError as exc:
-            raise IndexError(f"No GridFlow child widget at position {position}").with_traceback(
-                exc.__traceback__
-            ) from exc
-        self.contents.focus = position
-
-    def _set_focus_position(self, position: int) -> None:
-        """
-        Set the widget in focus.
-
-        position -- index of child widget to be made focus
-        """
-        warnings.warn(
-            f"method `{self.__class__.__name__}._set_focus_position` is deprecated, "
-            f"please use `{self.__class__.__name__}.focus_position` property",
-            DeprecationWarning,
-            stacklevel=3,
-        )
         try:
             if position < 0 or position >= len(self.contents):
                 raise IndexError(f"No GridFlow child widget at position {position}")

--- a/urwid/widget/listbox.py
+++ b/urwid/widget/listbox.py
@@ -415,15 +415,6 @@ class ListBox(Widget, WidgetContainerMixin):
             self.render = nocache_widget_render_instance(self)
         self._invalidate()
 
-    def _set_body(self, body):
-        warnings.warn(
-            f"Method `{self.__class__.__name__}._set_body` is deprecated, "
-            f"please use property `{self.__class__.__name__}.body`",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-        self.body = body
-
     @property
     def __len__(self) -> Callable[[], int]:
         if isinstance(self._body, Sized):

--- a/urwid/widget/overlay.py
+++ b/urwid/widget/overlay.py
@@ -600,21 +600,6 @@ class Overlay(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin, ty
         if position != 1:
             raise IndexError(f"Overlay widget focus_position currently must always be set to 1, not {position}")
 
-    def _set_focus_position(self, position: int) -> None:
-        """
-        Set the widget in focus.
-
-        position -- index of child widget to be made focus
-        """
-        warnings.warn(
-            f"method `{self.__class__.__name__}._set_focus_position` is deprecated, "
-            f"please use `{self.__class__.__name__}.focus_position` property",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-        if position != 1:
-            raise IndexError(f"Overlay widget focus_position currently must always be set to 1, not {position}")
-
     @property
     def contents(self) -> MutableSequence[tuple[TopWidget | BottomWidget, OverlayOptions]]:
         """

--- a/urwid/widget/pile.py
+++ b/urwid/widget/pile.py
@@ -546,25 +546,6 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
             raise IndexError(f"No Pile child widget at position {position}").with_traceback(exc.__traceback__) from exc
         self.contents.focus = position
 
-    def _set_focus_position(self, position: int) -> None:
-        """
-        Set the widget in focus.
-
-        position -- index of child widget to be made focus
-        """
-        warnings.warn(
-            f"method `{self.__class__.__name__}._set_focus_position` is deprecated, "
-            f"please use `{self.__class__.__name__}.focus_position` property",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-        try:
-            if position < 0 or position >= len(self.contents):
-                raise IndexError(f"No Pile child widget at position {position}")
-        except TypeError as exc:
-            raise IndexError(f"No Pile child widget at position {position}").with_traceback(exc.__traceback__) from exc
-        self.contents.focus = position
-
     def get_pref_col(self, size: tuple[()] | tuple[int] | tuple[int, int]) -> int | None:
         """Return the preferred column for the cursor, or None."""
         if not self.selectable():


### PR DESCRIPTION
* `_set_contents`
* `_set_focus_position`
* `_set_cells`
* `_set_cell_width`
* `_set_focus_cell`
* `_set_body`

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
