### PR TITLE
Make `MetaSuper` the last base for classes and notice it in the documentation

### DIFF
--- a/docs/reference/deprecated.rst
+++ b/docs/reference/deprecated.rst
@@ -4,3 +4,5 @@ Deprecated Classes
 .. currentmodule:: urwid
 
 .. autoclass:: AttrWrap
+
+.. autoclass:: MetaSuper

--- a/urwid/util.py
+++ b/urwid/util.py
@@ -496,6 +496,7 @@ class MetaSuper(type):
     """Deprecated metaclass.
 
     Present only for code compatibility, all logic has been removed.
+    Please move to the last position in the class bases to allow future changes.
     """
 
     __slots__ = ()

--- a/urwid/widget/widget.py
+++ b/urwid/widget/widget.py
@@ -41,7 +41,7 @@ WrappedWidget = typing.TypeVar("WrappedWidget")
 LOGGER = logging.getLogger(__name__)
 
 
-class WidgetMeta(MetaSuper, signals.MetaSignals):
+class WidgetMeta(signals.MetaSignals, MetaSuper):
     """
     Bases: :class:`MetaSuper`, :class:`MetaSignals`
 


### PR DESCRIPTION
Making `MetaSuper` the last listed base allow to replace it by `type` in the future. This will allow to remove `MetaSuper` in the far future.

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
