### PR TITLE
Fix button alignment in dialog example

### DIFF
--- a/examples/dialog.py
+++ b/examples/dialog.py
@@ -86,7 +86,7 @@ class DialogDisplay:
     def add_buttons(self, buttons) -> None:
         lines = []
         for name, exitcode in buttons:
-            b = urwid.Button(name, self.button_press)
+            b = urwid.Button(name, self.button_press, align=urwid.CENTER)
             b.exitcode = exitcode
             b = urwid.AttrMap(b, "selectable", "focus")
             lines.append(b)


### PR DESCRIPTION
##### Checklist
- [ ] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [ ] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
*(P. S. If this pull requests fixes an existing issue, please specify which one.)*
Modified examples/dialog.py to center-align buttons by passing align=urwid.CENTER to urwid.Button. This improves the visual consistency of button placement in the example dialog.