### PR TITLE
Announce deprecated API removal versions

### DIFF
--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -775,9 +775,9 @@ class ColumnsTest(unittest.TestCase):
 
     def test_old_attributes(self):
         c = urwid.Columns([urwid.Text("a"), urwid.SolidFill("x")], box_columns=[1])
-        with self.assertWarns(PendingDeprecationWarning):
+        with self.assertWarns(DeprecationWarning):
             self.assertEqual(c.box_columns, [1])
-        with self.assertWarns(PendingDeprecationWarning):
+        with self.assertWarns(DeprecationWarning):
             c.box_columns = []
 
         self.assertEqual(c.box_columns, [])

--- a/urwid/container.py
+++ b/urwid/container.py
@@ -53,7 +53,7 @@ __all__ = (
 warnings.warn(
     f"{__name__!r} is not expected to be imported directly. "
     'Please use public access from "urwid" package. '
-    f"Module {__name__!r} is deprecated and will be removed in the future.",
+    f"Module {__name__!r} is deprecated and will be removed in the version 4.0.",
     DeprecationWarning,
     stacklevel=3,
 )

--- a/urwid/decoration.py
+++ b/urwid/decoration.py
@@ -59,7 +59,7 @@ __all__ = (
 warnings.warn(
     f"{__name__!r} is not expected to be imported directly. "
     'Please use public access from "urwid" package. '
-    f"Module {__name__!r} is deprecated and will be removed in the future.",
+    f"Module {__name__!r} is deprecated and will be removed in the version 4.0.",
     DeprecationWarning,
     stacklevel=3,
 )

--- a/urwid/event_loop/main_loop.py
+++ b/urwid/event_loop/main_loop.py
@@ -172,7 +172,8 @@ class MainLoop:
     def _set_widget(self, widget: Widget) -> None:
         warnings.warn(
             f"method `{self.__class__.__name__}._set_widget` is deprecated, "
-            f"please use `{self.__class__.__name__}.widget` property",
+            f"please use `{self.__class__.__name__}.widget` property."
+            "API will be removed in version 4.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -193,7 +194,8 @@ class MainLoop:
     def _set_pop_ups(self, pop_ups: bool) -> None:
         warnings.warn(
             f"method `{self.__class__.__name__}._set_pop_ups` is deprecated, "
-            f"please use `{self.__class__.__name__}.pop_ups` property",
+            f"please use `{self.__class__.__name__}.pop_ups` property."
+            "API will be removed in version 4.0.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/urwid/font.py
+++ b/urwid/font.py
@@ -226,7 +226,7 @@ class Font(metaclass=FontRegistry):
         errors: Literal["strict", "ignore", "replace"] = "strict",
     ) -> str:
         warnings.warn(
-            "_to_text is deprecated: only text fonts are supported",
+            "_to_text is deprecated: only text fonts are supported. API will be removed in version 4.0.",
             DeprecationWarning,
             stacklevel=3,
         )

--- a/urwid/widget/attr_wrap.py
+++ b/urwid/widget/attr_wrap.py
@@ -56,8 +56,8 @@ class AttrWrap(AttrMap):
     def w(self) -> Widget:
         """backwards compatibility, widget used to be stored as w"""
         warnings.warn(
-            "backwards compatibility, widget used to be stored as original_widget",
-            PendingDeprecationWarning,
+            "backwards compatibility, widget used to be stored as original_widget. API will be removed in version 5.0.",
+            DeprecationWarning,
             stacklevel=2,
         )
         return self.original_widget
@@ -65,15 +65,15 @@ class AttrWrap(AttrMap):
     @w.setter
     def w(self, new_widget: Widget) -> None:
         warnings.warn(
-            "backwards compatibility, widget used to be stored as original_widget",
-            PendingDeprecationWarning,
+            "backwards compatibility, widget used to be stored as original_widget. API will be removed in version 5.0.",
+            DeprecationWarning,
             stacklevel=2,
         )
         self.original_widget = new_widget
 
     def get_w(self):
         warnings.warn(
-            "backwards compatibility, widget used to be stored as original_widget",
+            "backwards compatibility, widget used to be stored as original_widget. API will be removed in version 4.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -81,7 +81,7 @@ class AttrWrap(AttrMap):
 
     def set_w(self, new_widget: Widget) -> None:
         warnings.warn(
-            "backwards compatibility, widget used to be stored as original_widget",
+            "backwards compatibility, widget used to be stored as original_widget. API will be removed in version 4.0.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/urwid/widget/box_adapter.py
+++ b/urwid/widget/box_adapter.py
@@ -48,8 +48,8 @@ class BoxAdapter(WidgetDecoration[WrappedWidget]):
     @property
     def box_widget(self) -> WrappedWidget:
         warnings.warn(
-            "original stored as original_widget, keep for compatibility",
-            PendingDeprecationWarning,
+            "original stored as original_widget, keep for compatibility. API will be removed in version 5.0.",
+            DeprecationWarning,
             stacklevel=2,
         )
         return self.original_widget
@@ -57,8 +57,8 @@ class BoxAdapter(WidgetDecoration[WrappedWidget]):
     @box_widget.setter
     def box_widget(self, widget: WrappedWidget) -> None:
         warnings.warn(
-            "original stored as original_widget, keep for compatibility",
-            PendingDeprecationWarning,
+            "original stored as original_widget, keep for compatibility. API will be removed in version 5.0.",
+            DeprecationWarning,
             stacklevel=2,
         )
         self.original_widget = widget

--- a/urwid/widget/columns.py
+++ b/urwid/widget/columns.py
@@ -373,8 +373,9 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
             standard container property :attr:`contents`.
         """
         warnings.warn(
-            "only for backwards compatibility. You should use the new standard container `contents`",
-            PendingDeprecationWarning,
+            "only for backwards compatibility. You should use the new standard container `contents`."
+            "API will be removed in version 5.0.",
+            DeprecationWarning,
             stacklevel=2,
         )
         ml = MonitoredList(w for w, t in self.contents)
@@ -388,8 +389,9 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
     @widget_list.setter
     def widget_list(self, widgets):
         warnings.warn(
-            "only for backwards compatibility. You should use the new standard container `contents`",
-            PendingDeprecationWarning,
+            "only for backwards compatibility. You should use the new standard container `contents`."
+            "API will be removed in version 5.0.",
+            DeprecationWarning,
             stacklevel=2,
         )
         focus_position = self.focus_position
@@ -413,8 +415,9 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         """
         warnings.warn(
             "for backwards compatibility only."
-            "You should use the new standard container property .contents to modify Pile contents.",
-            PendingDeprecationWarning,
+            "You should use the new standard container property .contents to modify Pile contents."
+            "API will be removed in version 5.0.",
+            DeprecationWarning,
             stacklevel=2,
         )
         ml = MonitoredList(
@@ -433,8 +436,9 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
     def column_types(self, column_types):
         warnings.warn(
             "for backwards compatibility only."
-            "You should use the new standard container property .contents to modify Pile contents.",
-            PendingDeprecationWarning,
+            "You should use the new standard container property .contents to modify Pile contents."
+            "API will be removed in version 5.0.",
+            DeprecationWarning,
             stacklevel=2,
         )
         focus_position = self.focus_position
@@ -455,8 +459,9 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
             standard container property :attr:`contents`.
         """
         warnings.warn(
-            "only for backwards compatibility.You should use the new standard container property `contents`",
-            PendingDeprecationWarning,
+            "only for backwards compatibility.You should use the new standard container property `contents`."
+            "API will be removed in version 5.0.",
+            DeprecationWarning,
             stacklevel=2,
         )
         ml = MonitoredList(i for i, (w, (t, n, b)) in enumerate(self.contents) if b)
@@ -470,8 +475,9 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
     @box_columns.setter
     def box_columns(self, box_columns):
         warnings.warn(
-            "only for backwards compatibility.You should use the new standard container property `contents`",
-            PendingDeprecationWarning,
+            "only for backwards compatibility.You should use the new standard container property `contents`."
+            "API will be removed in version 5.0.",
+            DeprecationWarning,
             stacklevel=2,
         )
         box_columns = set(box_columns)
@@ -483,7 +489,7 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         .. deprecated:: 1.0 Read values from :attr:`contents` instead.
         """
         warnings.warn(
-            ".has_flow_type is deprecated, read values from .contents instead.",
+            ".has_flow_type is deprecated, read values from .contents instead. API will be removed in version 4.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -492,7 +498,7 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
     @has_flow_type.setter
     def has_flow_type(self, value):
         warnings.warn(
-            ".has_flow_type is deprecated, read values from .contents instead.",
+            ".has_flow_type is deprecated, read values from .contents instead. API will be removed in version 4.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -583,8 +589,9 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
             standard container property :attr:`focus_position` to set the focus.
         """
         warnings.warn(
-            "only for backwards compatibility.You may also use the new standard container property `focus_position`",
-            PendingDeprecationWarning,
+            "only for backwards compatibility.You may also use the new standard container property `focus_position`."
+            "API will be removed in version 5.0.",
+            DeprecationWarning,
             stacklevel=2,
         )
         self.focus_position = num
@@ -597,8 +604,9 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
             standard container property :attr:`focus_position` to get the focus.
         """
         warnings.warn(
-            "only for backwards compatibility.You may also use the new standard container property `focus_position`",
-            PendingDeprecationWarning,
+            "only for backwards compatibility.You may also use the new standard container property `focus_position`."
+            "API will be removed in version 5.0.",
+            DeprecationWarning,
             stacklevel=2,
         )
         return self.focus_position
@@ -613,8 +621,9 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         :param item: widget or integer index"""
         warnings.warn(
             "only for backwards compatibility."
-            "You may also use the new standard container property `focus_position` to get the focus.",
-            PendingDeprecationWarning,
+            "You may also use the new standard container property `focus_position` to get the focus."
+            "API will be removed in version 5.0.",
+            DeprecationWarning,
             stacklevel=2,
         )
         if isinstance(item, int):
@@ -648,8 +657,9 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         """
         warnings.warn(
             "only for backwards compatibility."
-            "You may also use the new standard container property `focus` to get the focus.",
-            PendingDeprecationWarning,
+            "You may also use the new standard container property `focus` to get the focus."
+            "API will be removed in version 5.0.",
+            DeprecationWarning,
             stacklevel=2,
         )
         if not self.contents:
@@ -693,8 +703,9 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         """
         warnings.warn(
             "only for backwards compatibility."
-            "You may also use the new standard container property `focus_position` to get the focus.",
-            PendingDeprecationWarning,
+            "You may also use the new standard container property `focus_position` to get the focus."
+            "API will be removed in version 5.0.",
+            DeprecationWarning,
             stacklevel=2,
         )
         return self.focus_position
@@ -703,8 +714,9 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
     def focus_col(self, new_position) -> None:
         warnings.warn(
             "only for backwards compatibility."
-            "You may also use the new standard container property `focus_position` to get the focus.",
-            PendingDeprecationWarning,
+            "You may also use the new standard container property `focus_position` to get the focus."
+            "API will be removed in version 5.0.",
+            DeprecationWarning,
             stacklevel=2,
         )
         self.focus_position = new_position

--- a/urwid/widget/filler.py
+++ b/urwid/widget/filler.py
@@ -162,8 +162,8 @@ class Filler(WidgetDecoration[WrappedWidget]):
     def body(self) -> WrappedWidget:
         """backwards compatibility, widget used to be stored as body"""
         warnings.warn(
-            "backwards compatibility, widget used to be stored as body",
-            PendingDeprecationWarning,
+            "backwards compatibility, widget used to be stored as body. API will be removed in version 5.0.",
+            DeprecationWarning,
             stacklevel=2,
         )
         return self.original_widget
@@ -171,8 +171,8 @@ class Filler(WidgetDecoration[WrappedWidget]):
     @body.setter
     def body(self, new_body: WrappedWidget) -> None:
         warnings.warn(
-            "backwards compatibility, widget used to be stored as body",
-            PendingDeprecationWarning,
+            "backwards compatibility, widget used to be stored as body. API will be removed in version 5.0.",
+            DeprecationWarning,
             stacklevel=2,
         )
         self.original_widget = new_body
@@ -180,7 +180,7 @@ class Filler(WidgetDecoration[WrappedWidget]):
     def get_body(self) -> WrappedWidget:
         """backwards compatibility, widget used to be stored as body"""
         warnings.warn(
-            "backwards compatibility, widget used to be stored as body",
+            "backwards compatibility, widget used to be stored as body. API will be removed in version 4.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -188,7 +188,7 @@ class Filler(WidgetDecoration[WrappedWidget]):
 
     def set_body(self, new_body: WrappedWidget) -> None:
         warnings.warn(
-            "backwards compatibility, widget used to be stored as body",
+            "backwards compatibility, widget used to be stored as body. API will be removed in version 4.0.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/urwid/widget/frame.py
+++ b/urwid/widget/frame.py
@@ -122,8 +122,9 @@ class Frame(Widget, WidgetContainerMixin, typing.Generic[BodyWidget, HeaderWidge
     def get_header(self) -> HeaderWidget:
         warnings.warn(
             f"method `{self.__class__.__name__}.get_header` is deprecated, "
-            f"standard property `{self.__class__.__name__}.header` should be used instead",
-            PendingDeprecationWarning,
+            f"standard property `{self.__class__.__name__}.header` should be used instead."
+            "API will be removed in version 5.0.",
+            DeprecationWarning,
             stacklevel=2,
         )
         return self.header
@@ -131,8 +132,9 @@ class Frame(Widget, WidgetContainerMixin, typing.Generic[BodyWidget, HeaderWidge
     def set_header(self, header: HeaderWidget) -> None:
         warnings.warn(
             f"method `{self.__class__.__name__}.set_header` is deprecated, "
-            f"standard property `{self.__class__.__name__}.header` should be used instead",
-            PendingDeprecationWarning,
+            f"standard property `{self.__class__.__name__}.header` should be used instead."
+            "API will be removed in version 5.0.",
+            DeprecationWarning,
             stacklevel=2,
         )
         self.header = header
@@ -150,8 +152,9 @@ class Frame(Widget, WidgetContainerMixin, typing.Generic[BodyWidget, HeaderWidge
     def get_body(self) -> BodyWidget:
         warnings.warn(
             f"method `{self.__class__.__name__}.get_body` is deprecated, "
-            f"standard property {self.__class__.__name__}.body should be used instead",
-            PendingDeprecationWarning,
+            f"standard property {self.__class__.__name__}.body should be used instead."
+            "API will be removed in version 5.0.",
+            DeprecationWarning,
             stacklevel=2,
         )
         return self.body
@@ -159,8 +162,9 @@ class Frame(Widget, WidgetContainerMixin, typing.Generic[BodyWidget, HeaderWidge
     def set_body(self, body: BodyWidget) -> None:
         warnings.warn(
             f"method `{self.__class__.__name__}.set_body` is deprecated, "
-            f"standard property `{self.__class__.__name__}.body` should be used instead",
-            PendingDeprecationWarning,
+            f"standard property `{self.__class__.__name__}.body` should be used instead."
+            "API will be removed in version 5.0.",
+            DeprecationWarning,
             stacklevel=2,
         )
         self.body = body
@@ -180,8 +184,9 @@ class Frame(Widget, WidgetContainerMixin, typing.Generic[BodyWidget, HeaderWidge
     def get_footer(self) -> FooterWidget:
         warnings.warn(
             f"method `{self.__class__.__name__}.get_footer` is deprecated, "
-            f"standard property `{self.__class__.__name__}.footer` should be used instead",
-            PendingDeprecationWarning,
+            f"standard property `{self.__class__.__name__}.footer` should be used instead."
+            "API will be removed in version 5.0.",
+            DeprecationWarning,
             stacklevel=2,
         )
         return self.footer
@@ -189,8 +194,9 @@ class Frame(Widget, WidgetContainerMixin, typing.Generic[BodyWidget, HeaderWidge
     def set_footer(self, footer: FooterWidget) -> None:
         warnings.warn(
             f"method `{self.__class__.__name__}.set_footer` is deprecated, "
-            f"standard property `{self.__class__.__name__}.footer` should be used instead",
-            PendingDeprecationWarning,
+            f"standard property `{self.__class__.__name__}.footer` should be used instead."
+            "API will be removed in version 5.0.",
+            DeprecationWarning,
             stacklevel=2,
         )
         self.footer = footer
@@ -234,8 +240,9 @@ class Frame(Widget, WidgetContainerMixin, typing.Generic[BodyWidget, HeaderWidge
         """
         warnings.warn(
             "included for backwards compatibility."
-            "You should rather use the container property `.focus_position` to get this value.",
-            PendingDeprecationWarning,
+            "You should rather use the container property `.focus_position` to get this value."
+            "API will be removed in version 5.0.",
+            DeprecationWarning,
             stacklevel=2,
         )
         return self.focus_position
@@ -243,8 +250,9 @@ class Frame(Widget, WidgetContainerMixin, typing.Generic[BodyWidget, HeaderWidge
     def set_focus(self, part: Literal["header", "footer", "body"]) -> None:
         warnings.warn(
             "included for backwards compatibility."
-            "You should rather use the container property `.focus_position` to set this value.",
-            PendingDeprecationWarning,
+            "You should rather use the container property `.focus_position` to set this value."
+            "API will be removed in version 5.0.",
+            DeprecationWarning,
             stacklevel=2,
         )
         self.focus_position = part

--- a/urwid/widget/grid_flow.py
+++ b/urwid/widget/grid_flow.py
@@ -144,8 +144,9 @@ class GridFlow(WidgetWrap[Pile], WidgetContainerMixin, WidgetContainerListConten
         """
         warnings.warn(
             "only for backwards compatibility."
-            "You should use the new standard container property `contents` to modify GridFlow",
-            PendingDeprecationWarning,
+            "You should use the new standard container property `contents` to modify GridFlow."
+            "API will be removed in version 5.0.",
+            DeprecationWarning,
             stacklevel=2,
         )
         ml = MonitoredList(w for w, t in self.contents)
@@ -160,8 +161,9 @@ class GridFlow(WidgetWrap[Pile], WidgetContainerMixin, WidgetContainerListConten
     def cells(self, widgets: Sequence[Widget]):
         warnings.warn(
             "only for backwards compatibility."
-            "You should use the new standard container property `contents` to modify GridFlow",
-            PendingDeprecationWarning,
+            "You should use the new standard container property `contents` to modify GridFlow."
+            "API will be removed in version 5.0.",
+            DeprecationWarning,
             stacklevel=2,
         )
         focus_position = self.focus_position
@@ -234,8 +236,9 @@ class GridFlow(WidgetWrap[Pile], WidgetContainerMixin, WidgetContainerListConten
         """
         warnings.warn(
             "only for backwards compatibility."
-            "You may also use the new standard container property `focus_position` to set the focus.",
-            PendingDeprecationWarning,
+            "You may also use the new standard container property `focus_position` to set the focus."
+            "API will be removed in version 5.0.",
+            DeprecationWarning,
             stacklevel=2,
         )
         if isinstance(cell, int):
@@ -271,8 +274,9 @@ class GridFlow(WidgetWrap[Pile], WidgetContainerMixin, WidgetContainerListConten
         """
         warnings.warn(
             "only for backwards compatibility."
-            "You may also use the new standard container property `focus` to get the focus.",
-            PendingDeprecationWarning,
+            "You may also use the new standard container property `focus` to get the focus."
+            "API will be removed in version 5.0.",
+            DeprecationWarning,
             stacklevel=2,
         )
         if not self.contents:
@@ -284,8 +288,9 @@ class GridFlow(WidgetWrap[Pile], WidgetContainerMixin, WidgetContainerListConten
         warnings.warn(
             "only for backwards compatibility."
             "You may also use the new standard container property"
-            "`focus` to get the focus and `focus_position` to get/set the cell in focus by index",
-            PendingDeprecationWarning,
+            "`focus` to get the focus and `focus_position` to get/set the cell in focus by index."
+            "API will be removed in version 5.0.",
+            DeprecationWarning,
             stacklevel=2,
         )
         return self.focus
@@ -295,8 +300,9 @@ class GridFlow(WidgetWrap[Pile], WidgetContainerMixin, WidgetContainerListConten
         warnings.warn(
             "only for backwards compatibility."
             "You may also use the new standard container property"
-            "`focus` to get the focus and `focus_position` to get/set the cell in focus by index",
-            PendingDeprecationWarning,
+            "`focus` to get the focus and `focus_position` to get/set the cell in focus by index."
+            "API will be removed in version 5.0.",
+            DeprecationWarning,
             stacklevel=2,
         )
         for i, (w, _options) in enumerate(self.contents):

--- a/urwid/widget/listbox.py
+++ b/urwid/widget/listbox.py
@@ -844,8 +844,9 @@ class ListBox(Widget, WidgetContainerMixin):
         warnings.warn(
             "only for backwards compatibility."
             "You may also use the new standard container property `focus` to get the focus "
-            "and property `focus_position` to read these values.",
-            PendingDeprecationWarning,
+            "and property `focus_position` to read these values."
+            "API will be removed in version 5.0.",
+            DeprecationWarning,
             stacklevel=2,
         )
         return self._body.get_focus()

--- a/urwid/widget/monitored_list.py
+++ b/urwid/widget/monitored_list.py
@@ -245,7 +245,8 @@ class MonitoredFocusList(MonitoredList[_T], typing.Generic[_T]):
     def _get_focus(self) -> int | None:
         warnings.warn(
             f"method `{self.__class__.__name__}._get_focus` is deprecated, "
-            f"please use `{self.__class__.__name__}.focus` property",
+            f"please use `{self.__class__.__name__}.focus` property."
+            "API will be removed in version 4.0.",
             DeprecationWarning,
             stacklevel=3,
         )
@@ -254,7 +255,8 @@ class MonitoredFocusList(MonitoredList[_T], typing.Generic[_T]):
     def _set_focus(self, index: int) -> None:
         warnings.warn(
             f"method `{self.__class__.__name__}._set_focus` is deprecated, "
-            f"please use `{self.__class__.__name__}.focus` property",
+            f"please use `{self.__class__.__name__}.focus` property."
+            "API will be removed in version 4.0.",
             DeprecationWarning,
             stacklevel=3,
         )

--- a/urwid/widget/pile.py
+++ b/urwid/widget/pile.py
@@ -301,8 +301,9 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
             standard container property :attr:`contents`.
         """
         warnings.warn(
-            "only for backwards compatibility. You should use the new standard container property `contents`",
-            PendingDeprecationWarning,
+            "only for backwards compatibility. You should use the new standard container property `contents`."
+            "API will be removed in version 5.0.",
+            DeprecationWarning,
             stacklevel=2,
         )
         ml = MonitoredList(w for w, t in self.contents)
@@ -336,8 +337,9 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
             standard container property :attr:`contents`.
         """
         warnings.warn(
-            "only for backwards compatibility. You should use the new standard container property `contents`",
-            PendingDeprecationWarning,
+            "only for backwards compatibility. You should use the new standard container property `contents`."
+            "API will be removed in version 5.0.",
+            DeprecationWarning,
             stacklevel=2,
         )
         ml = MonitoredList(
@@ -355,8 +357,9 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
     @item_types.setter
     def item_types(self, item_types):
         warnings.warn(
-            "only for backwards compatibility. You should use the new standard container property `contents`",
-            PendingDeprecationWarning,
+            "only for backwards compatibility. You should use the new standard container property `contents`."
+            "API will be removed in version 5.0.",
+            DeprecationWarning,
             stacklevel=2,
         )
         focus_position = self.focus_position
@@ -475,8 +478,9 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         """
         warnings.warn(
             "for backwards compatibility."
-            "You may also use the new standard container property .focus to get the child widget in focus.",
-            PendingDeprecationWarning,
+            "You may also use the new standard container property .focus to get the child widget in focus."
+            "API will be removed in version 5.0.",
+            DeprecationWarning,
             stacklevel=2,
         )
         if not self.contents:
@@ -486,8 +490,9 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
     def set_focus(self, item: Widget | int) -> None:
         warnings.warn(
             "for backwards compatibility."
-            "You may also use the new standard container property .focus to get the child widget in focus.",
-            PendingDeprecationWarning,
+            "You may also use the new standard container property .focus to get the child widget in focus."
+            "API will be removed in version 5.0.",
+            DeprecationWarning,
             stacklevel=2,
         )
         if isinstance(item, int):
@@ -504,7 +509,8 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         warnings.warn(
             "only for backwards compatibility."
             "You should use the new standard container properties "
-            "`focus` and `focus_position` to get the child widget in focus or modify the focus position.",
+            "`focus` and `focus_position` to get the child widget in focus or modify the focus position."
+            "API will be removed in version 4.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -515,7 +521,8 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         warnings.warn(
             "only for backwards compatibility."
             "You should use the new standard container properties "
-            "`focus` and `focus_position` to get the child widget in focus or modify the focus position.",
+            "`focus` and `focus_position` to get the child widget in focus or modify the focus position."
+            "API will be removed in version 4.0.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/urwid/widget/widget.py
+++ b/urwid/widget/widget.py
@@ -710,7 +710,7 @@ class WidgetWrap(delegate_to_widget_mixin("_wrapped_widget"), typing.Generic[Wra
         False
         """
         warnings.warn(
-            "_set_w is deprecated. Please use 'WidgetWrap._w' property directly",
+            "_set_w is deprecated. Please use 'WidgetWrap._w' property directly. API will be removed in version 5.0.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/urwid/wimp.py
+++ b/urwid/wimp.py
@@ -17,7 +17,7 @@ __all__ = (
 warnings.warn(
     f"{__name__!r} is not expected to be imported directly. "
     'Please use public access from "urwid" package. '
-    f"Module {__name__!r} is deprecated and will be removed in the future.",
+    f"Module {__name__!r} is deprecated and will be removed in the version 4.0.",
     DeprecationWarning,
     stacklevel=3,
 )


### PR DESCRIPTION
Already deprecated -> mostly 4.0
Pending deprecation -> deprecated to remove in 5.0

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
