### PR TITLE
Check input descriptors for closed state

### DIFF
--- a/urwid/display/_posix_raw_display.py
+++ b/urwid/display/_posix_raw_display.py
@@ -249,6 +249,14 @@ class Screen(_raw_display_base.Screen):
 
         fd_list = super().get_input_descriptors()
         if self.gpm_mev is not None and self.gpm_mev.stdout is not None:
+            if self.gpm_mev.stdout.closed:
+                if (return_code := self.gpm_mev.returncode) is not None:
+                    # process is closed, remove leftovers to allow `__del__` on the `Popen` instance
+                    self.gpm_mev = None
+                    raise RuntimeError(f"gpm_mev process is closed with returncode: {return_code}")
+
+                raise RuntimeError("gpm_mev.stdout is closed while process is still running")
+
             fd_list.append(self.gpm_mev.stdout)
         return fd_list
 

--- a/urwid/display/_raw_display_base.py
+++ b/urwid/display/_raw_display_base.py
@@ -325,6 +325,9 @@ class Screen(BaseScreen, RealTerminal):
         fd_list: list[socket.socket | typing.IO | int] = [self._resize_pipe_rd]
 
         if (input_io := self._term_input_io) is not None:
+            if input_io.closed:
+                raise RuntimeError("Input IO is closed")
+
             fd_list.append(input_io)
         return fd_list
 


### PR DESCRIPTION
Raise `RuntimeError` during input descriptors collection if term_input_file or gpm_mev.stdout closed.

Fix #1011

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
*(P. S. If this pull requests fixes an existing issue, please specify which one.)*
