### PR TITLE
Python 3.14 compatibility: adjust `AsyncioEventLoop`

### DIFF
--- a/urwid/canvas.py
+++ b/urwid/canvas.py
@@ -1170,7 +1170,7 @@ def cview_trim_rows(cv, rows: int):
 
 
 def cview_trim_top(cv, trim: int):
-    return (cv[0], trim + cv[1], cv[2], cv[3] - trim) + cv[4:]
+    return (cv[0], trim + cv[1], cv[2], cv[3] - trim, *cv[4:])
 
 
 def cview_trim_left(cv, trim: int):


### PR DESCRIPTION
Do not use `EventLoopPolicy` related methods:
removed in python 3.14
Initialize event loop explicit instead.

Fix #951

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
