### PR TITLE
Bugfix: Corner case: Scrollbar render for only 1 row height

### DIFF
--- a/tests/test_scrollable.py
+++ b/tests/test_scrollable.py
@@ -306,6 +306,24 @@ class TestScrollBarListBox(unittest.TestCase):
             widget.render(reduced_size).decoded_text,
         )
 
+    def test_minimal_height(self):
+        """If we have only 1 line render height and thumb position in the middle - do not render top."""
+        widget = urwid.ScrollBar(
+            urwid.ListBox(
+                (
+                    urwid.CheckBox("A"),
+                    urwid.CheckBox("B"),
+                    urwid.CheckBox("C"),
+                )
+            )
+        )
+        reduced_size = (7, 1)
+        self.assertEqual(("[ ] A █",), widget.render(reduced_size).decoded_text)
+        widget.keypress(reduced_size, "down")
+        self.assertEqual(("[ ] B █",), widget.render(reduced_size).decoded_text)
+        widget.keypress(reduced_size, "down")
+        self.assertEqual(("[ ] C █",), widget.render(reduced_size).decoded_text)
+
 
 def trivial_AttrMap(widget):
     return urwid.AttrMap(widget, {})

--- a/urwid/widget/scrollable.py
+++ b/urwid/widget/scrollable.py
@@ -562,7 +562,7 @@ class ScrollBar(WidgetDecoration[WrappedWidget]):
         top_weight = float(pos) / max(1, posmax)  # pylint: disable=possibly-used-before-assignment
         top_height = int((maxrow - thumb_height) * top_weight)
         if top_height == 0 and top_weight > 0:
-            top_height = 1
+            top_height = min(1, maxrow - thumb_height)
 
         # Bottom part is remaining space
         bottom_height = maxrow - thumb_height - top_height


### PR DESCRIPTION
In the case of only 1 row for render and scroll position not on the top, `ScrollBar` should not try to render extra 1 line

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
