### PR TITLE
Bugfix: Corner case: Scrollbar render for only 1 row height (#1021)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,15 @@
 Changelog
 ---------
 
+Urwid 3.0.2
+===========
+
+2025-05-07
+
+Bug fixes 🕷
+++++++++++++
+* Bugfix: Corner case: Scrollbar render for only 1 row height by @penguinolog in https://github.com/urwid/urwid/pull/1021
+
 Urwid 3.0.1
 ===========
 


### PR DESCRIPTION
In the case of only 1 row for render and scroll position not on the top, `ScrollBar` should not try to render extra 1 line

##### Checklist
- [ ] I've ensured that similar functionality has not already been implemented
- [ ] I've ensured that similar functionality has not earlier been proposed and declined
- [ ] I've branched off the `master` branch
- [ ] I've merged fresh upstream into my branch recently
- [ ] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
