### PR TITLE
Add guard against empty list on focus complete.

### DIFF
--- a/urwid/widget/listbox.py
+++ b/urwid/widget/listbox.py
@@ -1017,6 +1017,9 @@ class ListBox(Widget, WidgetContainerMixin):
         self._body.set_focus(focus_pos)
 
         middle, top, bottom = self.calculate_visible((maxcol, maxrow), focus)
+        if middle is None:
+            return None
+
         focus_offset, _focus_widget, focus_pos, focus_rows, _cursor = middle  # pylint: disable=unpacking-non-sequence
         _trim_top, fill_above = top  # pylint: disable=unpacking-non-sequence
         _trim_bottom, fill_below = bottom  # pylint: disable=unpacking-non-sequence


### PR DESCRIPTION
This commit will prevent on occasional crash when events are quickly updates listbox, and in effect it makes calculate_visible method to return tuple of three Nones, and effectively crash the app in a try to unpack data supposed to be there.

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
Fixes #1032 
