### PR TITLE
Maintenance: update buildsystem to use not deprecated config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
@@ -8,7 +8,7 @@ repos:
       - id: mixed-line-ending
 
   - repo: https://github.com/pycqa/isort
-    rev: 6.0.1
+    rev: 7.0.0
     hooks:
       - id: isort
         name: isort (python)
@@ -20,13 +20,13 @@ repos:
         types: [pyi]
 
   - repo: https://github.com/psf/black
-    rev: 25.1.0
+    rev: 25.9.0
     hooks:
       - id: black
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.12.0
+    rev: v0.14.1
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix ]

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ It includes many features useful for text console application developers includi
 - Display modules include raw, curses, and experimental LCD and web displays
 - Support for UTF-8, simple 8-bit and CJK encodings
 - 24-bit (true color), 256 color, and 88 color mode support
-- Compatible with Python 3.7+ and PyPy
+- Compatible with Python 3.9+ and PyPy
 
 Home Page:
   http://urwid.org/
@@ -92,6 +92,7 @@ Supported Python versions
 - 3.11
 - 3.12
 - 3.13
+- 3.14
 - pypy3
 
 Authors

--- a/classifiers.txt
+++ b/classifiers.txt
@@ -2,7 +2,6 @@ Development Status :: 5 - Production/Stable
 Environment :: Console
 Environment :: Console :: Curses
 Intended Audience :: Developers
-License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)
 Operating System :: POSIX
 Operating System :: Unix
 Operating System :: MacOS :: MacOS X
@@ -15,6 +14,7 @@ Programming Language :: Python :: 3.10
 Programming Language :: Python :: 3.11
 Programming Language :: Python :: 3.12
 Programming Language :: Python :: 3.13
+Programming Language :: Python :: 3.14
 Programming Language :: Python :: 3 :: Only
 Programming Language :: Python :: Implementation :: CPython
 Programming Language :: Python :: Implementation :: PyPy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Minimum requirements for the build system to execute.
 # PEP 508 specifications for PEP 518.
 requires = [
-  "setuptools >= 61.0.0",
+  "setuptools >= 77.0.0",
   "setuptools_scm[toml]>=7.0",
   "wheel",
 ]
@@ -13,7 +13,8 @@ name = "urwid"
 description = "A full-featured console (xterm et al.) user interface library"
 requires-python = ">=3.9.0"
 keywords = ["curses", "ui", "widget", "scroll", "listbox", "user interface", "text layout", "console", "ncurses"]
-license={text="LGPL-2.1-only"}  # Use SPDX classifier
+license="LGPL-2.1-only"  # Use SPDX classifier
+license-files=["COPYING"]
 readme = {file = "README.rst", content-type = "text/x-rst"}
 authors=[{name="Ian Ward", email="ian@excess.org"}]
 dynamic = ["classifiers", "version", "dependencies"]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3{9,10,11,12,13},pypy3,isort,black,ruff,pylint,refurb
+envlist = py3{9,10,11,12,13,14},pypy3,isort,black,ruff,pylint,refurb
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
* LICENSE classifiers deprecated, licence picked-up from metadata
* `build-system.license` should be plain text
* `license-files` collection pointing to the licence files added
* mark minimal version of setuptools 77.0.0
* fix README to mark python 3.14 and remove python 3.7 artefacts.
* update pre-commit

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [X] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
