### PR TITLE
API fix: do not accept "mixed" state for checkbox if not "has_mixed"

### DIFF
--- a/urwid/widget/wimp.py
+++ b/urwid/widget/wimp.py
@@ -248,9 +248,15 @@ class CheckBox(WidgetWrap[Columns]):
         Traceback (most recent call last):
         ...
         ValueError: None not in (True, False, 'mixed')
+        >>> CheckBox("No", "mixed")
+        Traceback (most recent call last):
+        ...
+        ValueError: 'mixed' is not allowed: has_mixed=False
         """
         if state not in self.states:
             raise ValueError(f"{state!r} not in {tuple(self.states.keys())}")
+        if state == "mixed" and not has_mixed:
+            raise ValueError(f"{state!r} is not allowed: {has_mixed=!r}")
 
         self._label = Text(label)
         self.has_mixed = has_mixed
@@ -373,6 +379,9 @@ class CheckBox(WidgetWrap[Columns]):
 
         if state not in self.states:
             raise CheckBoxError(f"{self!r} Invalid state: {state!r}")
+
+        if state == "mixed" and not self.has_mixed:
+            raise ValueError(f"{state!r} is not allowed: {self.has_mixed=!r}")
 
         # self._state is None is a special case when the CheckBox
         # has just been created


### PR DESCRIPTION
##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
