### PR TITLE
Deprecation: Remove deprecated public methods announced to be removed in v4

### DIFF
--- a/urwid/widget/attr_wrap.py
+++ b/urwid/widget/attr_wrap.py
@@ -71,22 +71,6 @@ class AttrWrap(AttrMap):
         )
         self.original_widget = new_widget
 
-    def get_w(self):
-        warnings.warn(
-            "backwards compatibility, widget used to be stored as original_widget. API will be removed in version 4.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.original_widget
-
-    def set_w(self, new_widget: Widget) -> None:
-        warnings.warn(
-            "backwards compatibility, widget used to be stored as original_widget. API will be removed in version 4.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        self.original_widget = new_widget
-
     def get_attr(self) -> Hashable:
         return self.attr_map[None]
 

--- a/urwid/widget/columns.py
+++ b/urwid/widget/columns.py
@@ -484,26 +484,6 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         self.contents = [(w, (t, n, i in box_columns)) for (i, (w, (t, n, b))) in enumerate(self.contents)]
 
     @property
-    def has_flow_type(self) -> bool:
-        """
-        .. deprecated:: 1.0 Read values from :attr:`contents` instead.
-        """
-        warnings.warn(
-            ".has_flow_type is deprecated, read values from .contents instead. API will be removed in version 4.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return WHSettings.PACK in self.column_types
-
-    @has_flow_type.setter
-    def has_flow_type(self, value):
-        warnings.warn(
-            ".has_flow_type is deprecated, read values from .contents instead. API will be removed in version 4.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
-    @property
     def contents(
         self,
     ) -> MonitoredFocusList[

--- a/urwid/widget/pile.py
+++ b/urwid/widget/pile.py
@@ -505,30 +505,6 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         raise ValueError(f"Widget not found in Pile contents: {item!r}")
 
     @property
-    def focus_item(self):
-        warnings.warn(
-            "only for backwards compatibility."
-            "You should use the new standard container properties "
-            "`focus` and `focus_position` to get the child widget in focus or modify the focus position."
-            "API will be removed in version 4.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.focus
-
-    @focus_item.setter
-    def focus_item(self, new_item):
-        warnings.warn(
-            "only for backwards compatibility."
-            "You should use the new standard container properties "
-            "`focus` and `focus_position` to get the child widget in focus or modify the focus position."
-            "API will be removed in version 4.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        self.focus = new_item
-
-    @property
     def focus_position(self) -> int:
         """
         index of child widget in focus.


### PR DESCRIPTION
Some public methods replacement are also deprecated and marked for removal in version 5

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
