### PR TITLE
Use UUID4 as key for signals

### DIFF
--- a/urwid/signals.py
+++ b/urwid/signals.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import abc
 import itertools
 import typing
+import uuid
 import weakref
 
 if typing.TYPE_CHECKING:
@@ -53,15 +54,6 @@ def setdefaultattr(obj, name, value):
     return value
 
 
-class Key:
-    """
-    Minimal class, whose only purpose is to produce objects with a
-    unique hash
-    """
-
-    __slots__ = ()
-
-
 class Signals:
     _signal_attr = "_urwid_signals"  # attribute to attach to signal senders
 
@@ -90,7 +82,7 @@ class Signals:
         *,
         weak_args: Iterable[typing.Any] = (),
         user_args: Iterable[typing.Any] = (),
-    ) -> Key:
+    ) -> uuid.UUID:
         """
         :param obj: the object sending a signal
         :type obj: object
@@ -172,7 +164,7 @@ class Signals:
             raise NameError(f"No such signal {name!r} for object {obj!r}")
 
         # Just generate an arbitrary (but unique) key
-        key = Key()
+        key = uuid.uuid4()
 
         handlers = setdefaultattr(obj, self._signal_attr, {}).setdefault(name, [])
 
@@ -252,7 +244,7 @@ class Signals:
                 return self.disconnect_by_key(obj, name, h[0])
         return None
 
-    def disconnect_by_key(self, obj, name: Hashable, key: Key) -> None:
+    def disconnect_by_key(self, obj, name: Hashable, key: uuid.UUID) -> None:
         """
         :param obj: the object to disconnect the signal from
         :type obj: object


### PR DESCRIPTION
less custom non-public types

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
