### PR TITLE
docs: missing docstrings for public API (#84)

### DIFF
--- a/examples/pop_up.py
+++ b/examples/pop_up.py
@@ -1,49 +1,111 @@
-#!/usr/bin/env python
+<|channel>thought
+The reviewer wants the docstrings to be in Sphinx (reStructuredText) format.
+Currently, the docstrings use a Google-style or NumPy-style format (e.g., `Returns:`, `Args:`).
 
-from __future__ import annotations
+Looking at the current content of `examples/pop_up.py`:
 
-import typing
-
-import urwid
-
-
-class PopUpDialog(urwid.WidgetWrap):
-    """A dialog that appears with nothing but a close button"""
-
-    signals: typing.ClassVar[list[str]] = ["close"]
-
-    def __init__(self):
-        close_button = urwid.Button("that's pretty cool")
-        urwid.connect_signal(close_button, "click", lambda button: self._emit("close"))
-        pile = urwid.Pile(
-            [
-                urwid.Text("^^  I'm attached to the widget that opened me. Try resizing the window!\n"),
-                close_button,
-            ]
-        )
-        super().__init__(urwid.AttrMap(urwid.Filler(pile), "popbg"))
-
-
-class ThingWithAPopUp(urwid.PopUpLauncher):
-    def __init__(self) -> None:
-        super().__init__(urwid.Button("click-me"))
-        urwid.connect_signal(self.original_widget, "click", lambda button: self.open_pop_up())
-
+1. `create_pop_up` method:
+```python
     def create_pop_up(self) -> PopUpDialog:
-        pop_up = PopUpDialog()
-        urwid.connect_signal(pop_up, "close", lambda button: self.close_pop_up())
-        return pop_up
+        """Create and return the popup dialog widget.
 
-    def get_pop_up_parameters(self):
-        return {"left": 0, "top": 1, "overlay_width": 32, "overlay_height": 7}
+        This method is called by the popup launcher to create the actual
+        popup dialog widget that will be displayed.
 
+        Returns:
+            PopUpDialog: The popup dialog widget to display
+        """
+```
+Sphinx (reST) format for `Returns` is typically `:return: <description>` or `:returns: <description>`.
+
+2. `get_pop_up_parameters` method:
+```python
+    def get_pop_up_parameters(self) -> dict[str, int]:
+        """Return the parameters for positioning the popup dialog.
+
+        This method defines where and how large the popup dialog should appear.
+
+        Returns:
+            dict: Dictionary containing popup positioning parameters
+        """
+```
+Sphinx (reST) format for `Returns` is `:return: <description>`.
+
+3. `keypress` method:
+```python
     def keypress(self, size: tuple[int], key: str) -> str | None:
-        parsed = super().keypress(size, key)
-        if parsed in {"q", "Q"}:
-            raise urwid.ExitMainLoop("Done")
-        return parsed
+        """Handle keypress events for the widget.
 
+        This method handles keyboard input for the widget, including
+        quitting the application when 'q' or 'Q' is pressed.
 
-fill = urwid.Filler(urwid.Padding(ThingWithAPopUp(), urwid.CENTER, 15))
-loop = urwid.MainLoop(fill, [("popbg", "white", "dark blue")], pop_ups=True)
-loop.run()
+        Args:
+            size: The size of the widget
+            key: The key that was pressed
+
+        Returns:
+            The parsed key or None if not handled
+        """
+```
+Sphinx (reST) format for `Args` is `:param <name>: <description>`.
+Sphinx (reST) format for `Returns` is `:return: <description>`.
+
+The user wants the "MINIMUM change".
+
+Let's convert these to reST.
+
+For `create_pop_up`:
+`Returns:` -> `:return: The popup dialog widget to display`
+
+For `get_pop_up_parameters`:
+`Returns:` -> `:return: Dictionary containing popup positioning parameters`
+
+For `keypress`:
+`Args:` -> (remove)
+`size: The size of the widget` -> `:param size: The size of the widget`
+`key: The key that was pressed` -> `:param key: The key that was pressed`
+`Returns:` -> `:return: The parsed key or None if not handled`
+
+Wait, the prompt asks to fix the code based on the reviewer's feedback. The reviewer says "project use Sphinx docstring format (reStructuredText format)".
+
+Let's look at the `create_pop_up` docstring again.
+```python
+        Returns:
+            PopUpDialog: The popup dialog widget to display
+```
+In reST:
+```python
+        :return: The popup dialog widget to display
+```
+
+`get_pop_up_parameters`:
+```python
+        Returns:
+            dict: Dictionary containing popup positioning parameters
+```
+In reST:
+```python
+        :return: Dictionary containing popup positioning parameters
+```
+
+`keypress`:
+```python
+        Args:
+            size: The size of the widget
+            key: The key that was pressed
+
+        Returns:
+            The parsed key or None if not handled
+```
+In reST:
+```python
+        :param size: The size of the widget
+        :param key: The key that was pressed
+        :return: The parsed key or None if not handled
+```
+
+I need to provide a single search/replace or multiple? The prompt says "Return a JSON object with a search/replace edit". Usually, this implies one search/replace block. If I need to change multiple parts of the file, I might need to search for a larger block.
+
+Let's see if I can group these.
+
+The `create_pop_up` method is at line 41.


### PR DESCRIPTION
Fixes #84

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [ ] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
docs: missing docstrings for public API

The example code lacks docstrings for public classes and methods, which is a significant documentation gap. While this is an example file, it demonstrates the library's API and should serve as a reference for how to properly document public interfaces. The PopUpDialog class and ThingWithAPopUp class are missing docstrings, making it unclear what these components are for or how they should be used.