### PR TITLE
Deprecation: Remove deprecated `Filler.get_body` and `Filler.set_body`

### DIFF
--- a/urwid/widget/filler.py
+++ b/urwid/widget/filler.py
@@ -177,23 +177,6 @@ class Filler(WidgetDecoration[WrappedWidget]):
         )
         self.original_widget = new_body
 
-    def get_body(self) -> WrappedWidget:
-        """backwards compatibility, widget used to be stored as body"""
-        warnings.warn(
-            "backwards compatibility, widget used to be stored as body. API will be removed in version 4.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.original_widget
-
-    def set_body(self, new_body: WrappedWidget) -> None:
-        warnings.warn(
-            "backwards compatibility, widget used to be stored as body. API will be removed in version 4.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        self.original_widget = new_body
-
     def selectable(self) -> bool:
         """Return selectable from body."""
         return self._original_widget.selectable()


### PR DESCRIPTION
2 years deprecation period expired

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
