### PR TITLE
Deprecation: announce deadline for deprecated APIs

### DIFF
--- a/urwid/display/common.py
+++ b/urwid/display/common.py
@@ -1018,7 +1018,8 @@ class BaseScreen(abc.ABC, metaclass=signals.MetaSignals):
         Deprecated in favor of calling `start` as a context manager.
         """
         warnings.warn(
-            "run_wrapper is deprecated in favor of calling `start` as a context manager.",
+            "run_wrapper is deprecated in favor of calling `start` as a context manager."
+            "API will be removed in version 5.0.",
             DeprecationWarning,
             stacklevel=3,
         )

--- a/urwid/font.py
+++ b/urwid/font.py
@@ -98,7 +98,8 @@ def add_font(name: str, cls: FontRegistry) -> None:
     warnings.warn(
         "`add_font` is deprecated, please set 'name' attribute to the font class,"
         " use metaclass keyword argument 'font_name'"
-        " or use `Font.register(<name>)`",
+        " or use `Font.register(<name>)`"
+        "API will be removed in version 5.0.",
         DeprecationWarning,
         stacklevel=2,
     )

--- a/urwid/widget/listbox.py
+++ b/urwid/widget/listbox.py
@@ -896,7 +896,7 @@ class ListBox(Widget, WidgetContainerMixin):
 
             def __call__(inner_self) -> Self:
                 warnings.warn(
-                    "ListBox.contents is a property, not a method",
+                    "ListBox.contents is a property, not a method. Call API will be removed in version 5.0.",
                     DeprecationWarning,
                     stacklevel=3,
                 )


### PR DESCRIPTION
Version 5 is expected not earlier than in 2027, which offer is minimum 3 years of `DeprecationWarning` for marked APIs.

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)