### PR TITLE
fix three return type annotations

### DIFF
--- a/urwid/canvas.py
+++ b/urwid/canvas.py
@@ -458,7 +458,7 @@ class TextCanvas(Canvas):
         cols: int | None = 0,
         rows: int | None = 0,
         attr=None,
-    ) -> Iterator[tuple[object, Literal["0", "U"] | None, bytes]]:
+    ) -> Iterator[list[tuple[object, Literal["0", "U"] | None, bytes]]]:
         """
         Return the canvas content as a list of rows where each row
         is a list of (attr, cs, text) tuples.

--- a/urwid/canvas.py
+++ b/urwid/canvas.py
@@ -321,7 +321,7 @@ class Canvas:
 
         self.coords["pop up"] = (left, top, (w, overlay_width, overlay_height))
 
-    def translate_coords(self, dx: int, dy: int) -> dict[str, tuple[int, int, tuple[Widget, int, int]]]:
+    def translate_coords(self, dx: int, dy: int) -> dict[str, tuple[int, int, tuple[Widget, int, int] | None]]:
         """
         Return coords shifted by (dx, dy).
         """

--- a/urwid/util.py
+++ b/urwid/util.py
@@ -230,7 +230,7 @@ def supports_unicode() -> bool:
     Return True if python is able to convert non-ascii unicode strings
     to the current encoding.
     """
-    return _target_encoding and _target_encoding != "ascii"
+    return bool(_target_encoding and _target_encoding != "ascii")
 
 
 def calc_trim_text(


### PR DESCRIPTION
hello! i encountered the `TextCanvas.content` issue when using urwid in my project; the other two fixes are from asking claude code to look for similar cases. let me know if there's anything else i should do to check this!

---

## Summary

- `TextCanvas.content()`: return type was missing the `list` wrapper — annotated as `Iterator[tuple[...]]` but actually yields `list[tuple[...]]` per row, consistent with all other `Canvas` subclasses (`Canvas`, `BlankCanvas`, `SolidCanvas`, `CompositeCanvas`)
- `Canvas.translate_coords()`: return type was missing `| None` on the inner data tuple, inconsistent with the declared type of `self.coords`
- `util.supports_unicode()`: `and` short-circuit can return `""` (not `bool`) when `_target_encoding` is falsy; wrapped in `bool()`

These are annotation-only fixes (except `supports_unicode` which also corrects the returned value's type). No behavioural changes.

## Test plan

- [x] `ruff format --check` passes
- [x] `ruff check` passes
- [x] `pytest` — 106 passed, 1 pre-existing failure (`_attrspec_to_escape` doctest, also fails on master)

🤖 Generated with [Claude Code](https://claude.com/claude-code)