### PR TITLE
Fix ListBoxError in _keypress_page_down when snapping to a widget above the top

### DIFF
--- a/tests/test_listbox.py
+++ b/tests/test_listbox.py
@@ -1960,6 +1960,31 @@ class ZeroHeightContentsTest(unittest.TestCase):
         self.assertEqual([b"below  ", b"       ", b"       ", b"       ", b"       "], canvas.text)
 
 
+class PageDownAboveTopTest(unittest.TestCase):
+    def test_page_down_does_not_raise(self):
+        # Two-row rows so the four-item list does not fit the viewport at once.
+        lb = urwid.ListBox(
+            urwid.SimpleListWalker(
+                            [
+                    urwid.Text("a0\nb0"),
+                    SelectableText("a1\nb1"),
+                    urwid.Text("a2\nb2"),
+                    urwid.Text("a3\nb3"),
+                ]
+            )
+        )
+        size = (7, 4)
+        lb.set_focus(0)
+        lb.render(size, focus=True)
+        lb.keypress(size, "page down")  # used to raise ListBoxError
+        self.assertEqual(lb.focus_position, 3)
+        canvas = lb.render(size, focus=True)
+        self.assertEqual([b"a2     ", b"b2     ", b"a3     ", b"b3     "], canvas.text)
+        # a second page down at the bottom is a no-op, not a crash
+        lb.keypress(size, "page down")
+        self.assertEqual(lb.focus_position, 3)
+
+
 class ListBoxSetBodyTest(unittest.TestCase):
     def test_signal_connected(self):
         lb = urwid.ListBox([])

--- a/urwid/widget/listbox.py
+++ b/urwid/widget/listbox.py
@@ -1774,6 +1774,15 @@ class ListBox(Widget, WidgetContainerMixin):
                     (self.pref_col, 0),
                     snap_rows + maxrow - row_offset - 1,
                 )
+            elif row_offset + rows <= 0:
+                self.change_focus(
+                    (maxcol, maxrow),
+                    pos,
+                    -(rows - 1),
+                    "above",
+                    (self.pref_col, rows - 1),
+                    snap_rows - ((-row_offset) - (rows - 1)),
+                )
             else:
                 self.change_focus(
                     (maxcol, maxrow),
@@ -1823,6 +1832,9 @@ class ListBox(Widget, WidgetContainerMixin):
             if row_offset >= maxrow:
                 snap_rows -= snap_rows + maxrow - row_offset - 1
                 row_offset = maxrow - 1
+            elif row_offset + rows <= 0:
+                snap_rows -= (-row_offset) - (rows - 1)
+                row_offset = -(rows - 1)
 
             self.change_focus((maxcol, maxrow), pos, row_offset, "above", None, snap_rows)
             return None


### PR DESCRIPTION
Fix for a crash triggered by scrolling to the top of a ListBox with Home then hitting PageDown when no selectable widget exists in the viewport (but a selectable widget *does* exist above the viewport).

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [X] I've ensured that similar functionality has not earlier been proposed and declined
- [X] I've branched off the `master` branch
- [X] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
