### PR TITLE
Fix lazy_import of display modules if __package__ is not defined

### DIFF
--- a/urwid/display/__init__.py
+++ b/urwid/display/__init__.py
@@ -97,6 +97,6 @@ def lazy_import(name: str, package: str | None = None) -> types.ModuleType:
     return module
 
 
-html_fragment = lazy_import(".html_fragment", __package__)
-lcd = lazy_import(".lcd", __package__)
-web = lazy_import(".web", __package__)
+html_fragment = lazy_import(".html_fragment", "urwid.display")
+lcd = lazy_import(".lcd", "urwid.display")
+web = lazy_import(".web", "urwid.display")


### PR DESCRIPTION
While such behaviour is not normal, in some cases `__package__` is not defined for subpackages.

Fix #1134

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
