### PR TITLE
Deprecation: Deprecate `content_delta` as unused

### DIFF
--- a/urwid/canvas.py
+++ b/urwid/canvas.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import contextlib
 import dataclasses
 import typing
+import warnings
 import weakref
 from contextlib import suppress
 
@@ -294,8 +295,13 @@ class Canvas:
         """Delta between two canvases
 
         Returns list of row deltas if other is None, otherwise returns iterator of row deltas.
-        Not used by code base.
+        Not used by code base and will be removed in the future releases.
         """
+        warnings.warn(
+            "content_delta is not used by code base and will be removed in the future releases",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         raise NotImplementedError()
 
     def get_cursor(self) -> tuple[int, int] | None:
@@ -534,6 +540,11 @@ class TextCanvas(Canvas):
         If other is the same object as self this will return no differences,
         otherwise this is the same as calling content().
         """
+        warnings.warn(
+            "content_delta is not used by code base and will be removed in the future releases",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if other is self:
             return [self.cols()] * self.rows()
         return self.content()
@@ -570,6 +581,11 @@ class BlankCanvas(Canvas):
         raise NotImplementedError("BlankCanvas doesn't know its own size!")
 
     def content_delta(self, other: Canvas) -> typing.NoReturn:
+        warnings.warn(
+            "content_delta is not used by code base and will be removed in the future releases",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         raise NotImplementedError("BlankCanvas doesn't know its own size!")
 
 
@@ -621,6 +637,11 @@ class SolidCanvas(Canvas):
         """
         Return the differences between other and this canvas.
         """
+        warnings.warn(
+            "content_delta is not used by code base and will be removed in the future releases",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if other is self:
             return [self.cols()] * self.rows()
         return self.content()
@@ -721,6 +742,11 @@ class CompositeCanvas(Canvas):
         """
         Return the differences between other and this canvas.
         """
+        warnings.warn(
+            "content_delta is not used by code base and will be removed in the future releases",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if not hasattr(other, "shards"):
             yield from self.content()
 
@@ -966,6 +992,11 @@ def shards_delta(
     """
     Yield shards1 with cviews that are the same as shards2 having canv = None.
     """
+    warnings.warn(
+        "shards_delta is deprecated and will be removed in a future version",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     # pylint: disable=stop-iteration-return
     other_shards_iter = iter(other_shards)
     other_num_rows = other_cviews = None
@@ -995,6 +1026,11 @@ def shard_cviews_delta(
 
     If Canvas and shard tail are equal between shards, return None instead of canvas.
     """
+    warnings.warn(
+        "shard_cviews_delta is deprecated and will be removed in a future version",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     # pylint: disable=stop-iteration-return
     other_cviews_iter = iter(other_cviews)
     other_cv = None

--- a/urwid/vterm.py
+++ b/urwid/vterm.py
@@ -35,6 +35,7 @@ import termios
 import time
 import traceback
 import typing
+import warnings
 from collections import deque
 from contextlib import suppress
 from dataclasses import dataclass
@@ -1431,6 +1432,11 @@ class TermCanvas(Canvas):
         self,
         other: Canvas,
     ) -> list[int] | Iterator[list[tuple[AttrSpec | str | None, Literal["0", "U"] | None, bytes]]]:
+        warnings.warn(
+            "content_delta is not used by code base and will be removed in the future releases",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if other is self:
             return [self.cols()] * self.rows()
         return self.content()


### PR DESCRIPTION
Deprecate related helpers:
* shards_delta
* shard_cviews_delta

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
