### PR TITLE
Typing: annotate `urwid.display.common`

### DIFF
--- a/urwid/canvas.py
+++ b/urwid/canvas.py
@@ -280,7 +280,7 @@ class Canvas:
         trim_top: int = 0,
         cols: int = 0,
         rows: int = 0,
-        attr: Mapping[object, AttrSpec | str | None] | None = None,
+        attr: Mapping[Hashable, AttrSpec | str | None] | None = None,
     ) -> Iterator[_ContentLine]:
         raise NotImplementedError()
 
@@ -446,7 +446,7 @@ class TextCanvas(Canvas):
             if cs_gap < 0:
                 raise CanvasError(f"Character Set extends beyond text \n{text[i]!r}\n{cs[i]!r}")
             if cs_gap:
-                rle_append_modify(cs[i], (None, cs_gap))
+                rle_append_modify(cs[i], (None, cs_gap))  # type: ignore[arg-type]  # str|None is Hashable
 
         self._attr = attr
         self._cs = cs
@@ -510,20 +510,24 @@ class TextCanvas(Canvas):
 
         for text, a_row, cs_row in text_attr_cs:
             if trim_left or cols < self._maxcol:
-                text, a_row, cs_row = trim_text_attr_cs(  # noqa: PLW2901
+                text, a_row, cs_row = trim_text_attr_cs(  # type: ignore[assignment]  # noqa: PLW2901
                     text,
                     a_row,
-                    cs_row,
+                    cs_row,  # type: ignore[arg-type]  # str|None is Hashable
                     trim_left,
                     trim_left + cols,
                 )
-            attr_cs = rle_product(a_row, cs_row)
+
+            attr_cs = typing.cast(
+                "list[tuple[tuple[Hashable, Literal['0', 'U'] | None], int]]",
+                rle_product(a_row, cs_row),  # type: ignore[arg-type]  # str|None is Hashable
+            )
             i = 0
             row = []
             for (a, cs), run in attr_cs:
                 if attr and a in attr:
                     a = attr[a]  # noqa: PLW2901
-                row.append((a, cs, text[i : i + run]))
+                row.append((typing.cast("AttrSpec | str | None", a), cs, text[i : i + run]))
                 i += run
             yield row
 
@@ -551,7 +555,7 @@ class BlankCanvas(Canvas):
         trim_top: int = 0,
         cols: int = 0,
         rows: int = 0,
-        attr: Mapping[object, AttrSpec | str | None] | None = None,
+        attr: Mapping[Hashable, AttrSpec | str | None] | None = None,
     ) -> Iterator[_ContentLine]:
         """
         return (cols, rows) of spaces with default attributes.
@@ -603,7 +607,7 @@ class SolidCanvas(Canvas):
         trim_top: int = 0,
         cols: int | None = None,
         rows: int | None = None,
-        attr: Mapping[object, AttrSpec | str | None] | None = None,
+        attr: Mapping[Hashable, AttrSpec | str | None] | None = None,
     ) -> Iterator[_ContentLine]:
         if cols is None:
             cols = self.size[0]
@@ -698,7 +702,7 @@ class CompositeCanvas(Canvas):
         trim_top: int = 0,
         cols: int = 0,
         rows: int = 0,
-        attr: Mapping[object, AttrSpec | str | None] | None = None,
+        attr: Mapping[Hashable, AttrSpec | str | None] | None = None,
     ) -> Iterator[_ContentLine]:
         """
         Return the canvas content as a list of rows where each row is a list of (attr, cs, text) tuples.
@@ -728,7 +732,8 @@ class CompositeCanvas(Canvas):
             shard_tail: list[tuple[int, int, Iterator[_ContentLine] | None, _CView]] = []
             for num_rows, cviews in shards_delta(self.shards, other.shards):
                 # combine shard and shard tail
-                sbody = shard_body(cviews, shard_tail)
+                # broken contract, content_delta is deprecated and not used
+                sbody = shard_body(cviews, shard_tail)  # type: ignore[arg-type]
 
                 # output rows
                 row: _ContentLine = []
@@ -1037,6 +1042,7 @@ def shard_body(
     col = 0
     body: list[tuple[int, Iterator[_ContentLine] | None, _CView]] = []  # build the next shard tail
     cviews_iter = iter(cviews)
+    new_iter: Iterator[_ContentLine] | None
     for col_gap, done_rows, content_iter, tail_cview in shard_tail:
         while col_gap:
             try:
@@ -1049,7 +1055,7 @@ def shard_body(
             if col_gap < 0:
                 raise CanvasError("cviews overflow gaps in shard_tail!")
             if create_iter and canv:
-                new_iter = canv.content(trim_left, trim_top, cols, rows, attr_map)
+                new_iter = canv.content(trim_left, trim_top, cols, rows, attr_map)  # type: ignore[arg-type]
             else:
                 new_iter = iter_default
             body.append((0, new_iter, cview))
@@ -1057,7 +1063,7 @@ def shard_body(
     for cview in cviews_iter:
         (trim_left, trim_top, cols, rows, attr_map, canv) = cview[:6]
         if create_iter and canv:
-            new_iter = canv.content(trim_left, trim_top, cols, rows, attr_map)
+            new_iter = canv.content(trim_left, trim_top, cols, rows, attr_map)  # type: ignore[arg-type]
         else:
             new_iter = iter_default
         body.append((0, new_iter, cview))
@@ -1410,13 +1416,13 @@ def apply_text_layout(
             if s.end:
                 tseg, cs = apply_target_encoding(text[s.offs : s.end])
                 line.append(tseg)
-                attrrange(s.offs, s.end, rle_len(cs))
-                rle_join_modify(linec, cs)
+                attrrange(s.offs, s.end, rle_len(cs))  # type: ignore[arg-type]  # s.end is set
+                rle_join_modify(linec, cs)  # type: ignore[arg-type]
             elif s.text:
                 tseg, cs = apply_target_encoding(s.text)
                 line.append(tseg)
-                attrrange(s.offs, s.offs, len(tseg))
-                rle_join_modify(linec, cs)
+                attrrange(s.offs, s.offs, len(tseg))  # type: ignore[arg-type]  # s.text is set
+                rle_join_modify(linec, cs)  # type: ignore[arg-type]
             elif s.offs:
                 if s.sc:
                     line.append(b"".rjust(s.sc))

--- a/urwid/display/_posix_raw_display.py
+++ b/urwid/display/_posix_raw_display.py
@@ -174,12 +174,20 @@ class Screen(_raw_display_base.Screen):
         os.waitpid(self.gpm_mev.pid, 0)
         self.gpm_mev = None
 
-    def _start(self, alternate_buffer: bool = True) -> None:
+    def _start(  # pylint: disable=keyword-arg-before-vararg
+        self,
+        alternate_buffer: bool = True,
+        *args,
+        **kwargs,
+    ) -> None:
         """
         Initialize the screen and input mode.
 
         alternate_buffer -- use an alternate screen buffer
         """
+        if args or kwargs:
+            raise TypeError(f"start() got unexpected arguments: {args=!r}, {kwargs=!r}")
+
         if alternate_buffer:
             self.write(escape.SWITCH_TO_ALTERNATE_BUFFER)
             self._rows_used = None

--- a/urwid/display/_raw_display_base.py
+++ b/urwid/display/_raw_display_base.py
@@ -208,7 +208,12 @@ class Screen(BaseScreen, RealTerminal):
             self.write(escape.MOUSE_TRACKING_OFF)
 
     @abc.abstractmethod
-    def _start(self, alternate_buffer: bool = True) -> None:
+    def _start(  # pylint: disable=keyword-arg-before-vararg
+        self,
+        alternate_buffer: bool = True,
+        *args,
+        **kwargs,
+    ) -> None:
         """
         Initialize the screen and input mode.
 

--- a/urwid/display/_win32_raw_display.py
+++ b/urwid/display/_win32_raw_display.py
@@ -65,12 +65,20 @@ class Screen(_raw_display_base.Screen):
     _dwOriginalOutMode = None
     _dwOriginalInMode = None
 
-    def _start(self, alternate_buffer: bool = True) -> None:
+    def _start(  # pylint: disable=keyword-arg-before-vararg
+        self,
+        alternate_buffer: bool = True,
+        *args,
+        **kwargs,
+    ) -> None:
         """
         Initialize the screen and input mode.
 
         alternate_buffer -- use alternate screen buffer
         """
+        if args or kwargs:
+            raise TypeError(f"start() got unexpected arguments: {args=!r}, {kwargs=!r}")
+
         if alternate_buffer:
             self.write(escape.SWITCH_TO_ALTERNATE_BUFFER)
             self._rows_used = None

--- a/urwid/display/common.py
+++ b/urwid/display/common.py
@@ -31,7 +31,7 @@ from urwid import signals
 from urwid.util import StoppingContext, int_scale
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Iterable, Sequence
+    from collections.abc import Callable, Iterable, Sequence
 
     from typing_extensions import Literal, Self
 
@@ -112,12 +112,12 @@ _BASIC_COLOR_VALUES = [
     (255, 255, 255),
 ]
 
-_COLOR_VALUES_256 = (
+_COLOR_VALUES_256: list[tuple[int, int, int]] = (
     _BASIC_COLOR_VALUES
     + [(r, g, b) for r in _CUBE_STEPS_256 for g in _CUBE_STEPS_256 for b in _CUBE_STEPS_256]
     + [(gr, gr, gr) for gr in _GRAY_STEPS_256]
 )
-_COLOR_VALUES_88 = (
+_COLOR_VALUES_88: list[tuple[int, int, int]] = (
     _BASIC_COLOR_VALUES
     + [(r, g, b) for r in _CUBE_STEPS_88 for g in _CUBE_STEPS_88 for b in _CUBE_STEPS_88]
     + [(gr, gr, gr) for gr in _GRAY_STEPS_88]
@@ -418,7 +418,7 @@ def _parse_color_256(desc: str) -> int | None:
                 r = _CUBE_256_LOOKUP_16[r]
                 g = _CUBE_256_LOOKUP_16[g]
                 b = _CUBE_256_LOOKUP_16[b]
-                return _CUBE_START + (r * _CUBE_SIZE_256 + g) * _CUBE_SIZE_256 + b
+                return typing.cast("int", _CUBE_START + (r * _CUBE_SIZE_256 + g) * _CUBE_SIZE_256 + b)
 
             return None
 
@@ -498,7 +498,7 @@ def _parse_color_88(desc: str) -> int | None:
                 r = _CUBE_88_LOOKUP_16[r]
                 g = _CUBE_88_LOOKUP_16[g]
                 b = _CUBE_88_LOOKUP_16[b]
-                return _CUBE_START + (r * _CUBE_SIZE_88 + g) * _CUBE_SIZE_88 + b
+                return typing.cast("int", _CUBE_START + (r * _CUBE_SIZE_88 + g) * _CUBE_SIZE_88 + b)
 
             return None
 
@@ -743,6 +743,7 @@ class AttrSpec:
 
     def __set_foreground(self, foreground: str) -> None:
         color = None
+        scolor: int | None
         flags = 0
         # handle comma-separated foreground
         for part in foreground.split(","):
@@ -793,6 +794,7 @@ class AttrSpec:
 
     def __set_background(self, background: str) -> None:
         flags = 0
+        color: int | None
         if background in {"", "default"}:
             color = 0
         elif background in _BASIC_COLORS:
@@ -824,6 +826,7 @@ class AttrSpec:
         >>> AttrSpec("default", "g92").get_rgb_values()
         (None, None, None, 238, 238, 238)
         """
+        vals: tuple[int | None, int | None, int | None]
         if not (self.foreground_basic or self.foreground_high or self.foreground_true):
             vals = (None, None, None)
         elif self.colors == 88:
@@ -832,7 +835,10 @@ class AttrSpec:
             vals = _COLOR_VALUES_88[self.foreground_number]
         elif self.colors == 2**24:
             h = f"{self.foreground_number:06x}"
-            vals = tuple(int(x, 16) for x in (h[0:2], h[2:4], h[4:6]))
+            vals = typing.cast(
+                "tuple[int, int, int]",
+                tuple(int(x, 16) for x in (h[0:2], h[2:4], h[4:6])),
+            )
         else:
             vals = _COLOR_VALUES_256[self.foreground_number]
 
@@ -841,12 +847,12 @@ class AttrSpec:
         if self.colors == 88:
             if self.background_number >= 88:
                 raise ValueError(f"Invalid AttrSpec _value: {self.background_number!r}")
-            return vals + _COLOR_VALUES_88[self.background_number]
+            return (*vals, *_COLOR_VALUES_88[self.background_number])
         if self.colors == 2**24:
             h = f"{self.background_number:06x}"
-            return vals + tuple(int(x, 16) for x in (h[0:2], h[2:4], h[4:6]))
+            return (*vals, *(int(x, 16) for x in (h[0:2], h[2:4], h[4:6])))
 
-        return vals + _COLOR_VALUES_256[self.background_number]
+        return (*vals, *_COLOR_VALUES_256[self.background_number])
 
     def __eq__(self, other: object) -> bool:
         return isinstance(other, AttrSpec) and self.__value == other._value
@@ -871,7 +877,7 @@ class RealTerminal:
             stop: Literal["undefined"] | int | None = None,
             susp: Literal["undefined"] | int | None = None,
             fileno: int | None = None,
-        ):
+        ) -> tuple[int, int, int, int, int] | None:
             """
             Read and/or set the tty's signal character settings.
             This function returns the current settings as a tuple.
@@ -885,7 +891,7 @@ class RealTerminal:
             then the original settings will be restored when stop()
             is called.
             """
-            return ()
+            return None
 
     else:
 
@@ -897,7 +903,7 @@ class RealTerminal:
             stop: Literal["undefined"] | int | None = None,
             susp: Literal["undefined"] | int | None = None,
             fileno: int | None = None,
-        ):
+        ) -> tuple[int, int, int, int, int] | None:
             """
             Read and/or set the tty's signal character settings.
             This function returns the current settings as a tuple.
@@ -981,7 +987,7 @@ class BaseScreen(abc.ABC, metaclass=signals.MetaSignals):
     def started(self) -> bool:
         return self._started
 
-    def start(self, *args, **kwargs) -> StoppingContext:
+    def start(self, *args: typing.Any, **kwargs: typing.Any) -> StoppingContext:
         """Set up the screen.  If the screen has already been started, does
         nothing.
 
@@ -999,8 +1005,8 @@ class BaseScreen(abc.ABC, metaclass=signals.MetaSignals):
             self._start(*args, **kwargs)
         return StoppingContext(self)
 
-    def _start(self) -> None:
-        pass
+    def _start(self, *args: typing.Any, **kwargs: typing.Any) -> None:
+        """Perform the actual setup of the screen. Subclasses should override this method."""
 
     def stop(self) -> None:
         if self._started:
@@ -1008,11 +1014,17 @@ class BaseScreen(abc.ABC, metaclass=signals.MetaSignals):
         self._started = False
 
     def _stop(self) -> None:
-        pass
+        """Perform actual teardown of the screen. Subclasses should override this method."""
 
-    def run_wrapper(self, fn, *args, **kwargs) -> None:
-        """Start the screen, call a function, then stop the screen.  Extra
-        arguments are passed to `start`.
+    def run_wrapper(
+        self,
+        fn: Callable[[], typing.Any],
+        *args: typing.Any,
+        **kwargs: typing.Any,
+    ) -> None:
+        """Start the screen, call a function, then stop the screen.
+
+        Extra arguments are passed to `start`.
 
         Deprecated in favor of calling `start` as a context manager.
         """
@@ -1023,7 +1035,7 @@ class BaseScreen(abc.ABC, metaclass=signals.MetaSignals):
             stacklevel=3,
         )
         with self.start(*args, **kwargs):
-            return fn()
+            fn()
 
     def set_mouse_tracking(self, enable: bool = True) -> None:
         pass
@@ -1179,7 +1191,7 @@ class BaseScreen(abc.ABC, metaclass=signals.MetaSignals):
         self._palette[name] = (basic, mono_spec, high_88, high_256, high_true)
 
 
-def _test():
+def _test() -> None:
     import doctest
 
     doctest.testmod()

--- a/urwid/display/web.py
+++ b/urwid/display/web.py
@@ -183,7 +183,7 @@ class Screen(BaseScreen):
     def tty_signal_keys(self, *args, **vargs):
         """Do nothing."""
 
-    def start(self) -> StoppingContext:
+    def start(self, *args, **kwargs) -> StoppingContext:
         """
         This function reads the initial screen size, generates a
         unique id and handles cleanup when fn exits.

--- a/urwid/event_loop/main_loop.py
+++ b/urwid/event_loop/main_loop.py
@@ -561,7 +561,7 @@ class MainLoop:
                 raise TypeError(f"{key!r} is not str | tuple[str, int, int, int]")
 
             if key:
-                if command_map[key] == Command.REDRAW_SCREEN:
+                if command_map[key] == Command.REDRAW_SCREEN:  # type: ignore[index]  # not `str` is mouse event
                     self.screen.clear()
                     something_handled = True
                 else:

--- a/urwid/str_util.py
+++ b/urwid/str_util.py
@@ -47,7 +47,7 @@ def get_char_width(char: str) -> Literal[0, 1, 2]:
         stacklevel=2,
     )
     if (width := wcwidth.wcwidth(char)) >= 0:
-        return width
+        return typing.cast("Literal[0, 1, 2]", width)
 
     return 0
 
@@ -64,7 +64,7 @@ def get_width(o: int) -> Literal[0, 1, 2]:
         stacklevel=2,
     )
     if (width := wcwidth.wcwidth(chr(o))) >= 0:
-        return width
+        return typing.cast("Literal[0, 1, 2]", width)
 
     return 0
 

--- a/urwid/text_layout.py
+++ b/urwid/text_layout.py
@@ -249,7 +249,7 @@ class StandardTextLayout(TextLayout):
         Returns a layout structure without an alignment applied.
         """
         if wrap in {"clip", "ellipsis"}:
-            return self._calculate_trimmed_segments(text, width, wrap)
+            return self._calculate_trimmed_segments(text, width, wrap)  # type: ignore[arg-type]  # filtered by if
 
         nl: str | bytes
         nl_o: int | str
@@ -540,19 +540,11 @@ def trim_line(
     return result
 
 
-def calc_line_pos(
+def _calc_literal_line_pos(
     text: str | bytes,
     line_layout: _LayoutLine,
-    pref_col: Literal["left", "right", Align.LEFT, Align.RIGHT] | int,
+    pref_col: Literal["left", "right", Align.LEFT, Align.RIGHT],
 ) -> int | None:
-    """
-    Calculate the closest linear position to pref_col given a line layout structure.
-    Returns None if no position found.
-    """
-    closest_sc = None
-    closest_pos: LayoutSegment | int | None = None
-    current_sc = 0
-
     if pref_col == "left":
         for seg in line_layout:
             layout = LayoutSegment(seg)
@@ -573,7 +565,34 @@ def calc_line_pos(
         if found.end is None:
             return found.offs
 
-        return calc_text_pos(text, found.offs, found.end, found.sc - 1)[0]
+        return calc_text_pos(
+            text,
+            found.offs,  # type: ignore[arg-type]  # filtered by if in lookup cycle
+            found.end,
+            found.sc - 1,
+        )[0]
+
+    raise ValueError(f"Invalid pref_col value: {pref_col}")
+
+
+def calc_line_pos(
+    text: str | bytes,
+    line_layout: _LayoutLine,
+    pref_col: Literal["left", "right", Align.LEFT, Align.RIGHT] | int,
+) -> int | None:
+    """
+    Calculate the closest linear position to pref_col given a line layout structure.
+    Returns None if no position found.
+    """
+    if pref_col in {"left", "right"}:
+        return _calc_literal_line_pos(text, line_layout, pref_col)
+
+    if not isinstance(pref_col, int):
+        raise TypeError(f"Invalid pref_col value: {pref_col}")
+
+    closest_sc = None
+    closest_pos: LayoutSegment | int | None = None
+    current_sc = 0
 
     for seg in line_layout:
         s = LayoutSegment(seg)
@@ -600,7 +619,7 @@ def calc_line_pos(
 
     # return the last positions in the segment "closest_pos"
     s = closest_pos
-    return calc_text_pos(text, s.offs, s.end, s.sc - 1)[0]
+    return calc_text_pos(text, s.offs, s.end, s.sc - 1)[0]  # type: ignore[arg-type]  # s.offs and s.end are set
 
 
 def calc_pos(

--- a/urwid/util.py
+++ b/urwid/util.py
@@ -412,7 +412,7 @@ def rle_join_modify(
 def rle_product(
     rle1: MutableSequence[tuple[Hashable, int]],
     rle2: MutableSequence[tuple[Hashable, int]],
-) -> list[tuple[Hashable, int]]:
+) -> list[tuple[tuple[Hashable, Hashable], int]]:
     """
     Merge the runs of rle1 and rle2 like this:
     eg.
@@ -428,10 +428,10 @@ def rle_product(
     a1, r1 = rle1[0]
     a2, r2 = rle2[0]
 
-    result: list[tuple[Hashable, int]] = []
+    result: list[tuple[tuple[Hashable, Hashable], int]] = []
     while r1 and r2:
         r = min(r1, r2)
-        rle_append_modify(result, ((a1, a2), r))
+        rle_append_modify(result, ((a1, a2), r))  # type: ignore[arg-type]
         r1 -= r
         if r1 == 0 and i1 < len(rle1):
             a1, r1 = rle1[i1]

--- a/urwid/vterm.py
+++ b/urwid/vterm.py
@@ -48,7 +48,7 @@ from urwid.widget import Sizing, Widget
 from .display.common import _BASIC_COLORS, _color_desc_256, _color_desc_true
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
+    from collections.abc import Callable, Hashable, Iterable, Iterator, Mapping, Sequence
 
     from typing_extensions import Literal
 
@@ -1415,7 +1415,7 @@ class TermCanvas(Canvas):
         trim_top: int = 0,
         cols: int = 0,
         rows: int = 0,
-        attr: Mapping[object, AttrSpec | str | None] | None = None,
+        attr: Mapping[Hashable, AttrSpec | str | None] | None = None,
     ) -> Iterator[list[tuple[AttrSpec | str | None, Literal["0", "U"] | None, bytes]]]:
         """Canvas content.
 


### PR DESCRIPTION
Cover mypy warnings related to:
* `urwid.canvas`:
* * tune `content` parameter `attr` type
* * type casts
* `urwid.str_util`: cast return types of deprecated methods
* `urwid.util`:
* * `rle_product` need to annotate return type detail (but no generic functions in old python versions)
* `urwid.text_latyout`
* * `calc_line_pos` - extract case for literal `pref_col` to the separate private function

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

Partial #1146 