### PR TITLE
Typing: finalise display modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,12 @@ show_error_codes = true
 pretty = true
 
 [[tool.mypy.overrides]]
+module = "urwid.display.curses"
+disable_error_code = [
+  "union-attr",  # chacking for started state before each operation if too expensive
+]
+
+[[tool.mypy.overrides]]
 module = [
   "gi.*",
   "trio.*",

--- a/urwid/display/_posix_raw_display.py
+++ b/urwid/display/_posix_raw_display.py
@@ -48,7 +48,10 @@ if typing.TYPE_CHECKING:
 
     from urwid.event_loop import EventLoop
 
-    SignalHandler = Callable[[int, FrameType | None], typing.Any] | int | None  # pylint: disable=unsupported-binary-operation
+    SignalHandler = typing.Union[Callable[[int, typing.Union[FrameType, None]], typing.Any], int, None]
+    _MouseInput = tuple[str, int, int, int]
+    _CursorPosition = tuple[typing.Literal["cursor position"], int, int]
+    _DecodedInput = list[typing.Union[str, _MouseInput, _CursorPosition]]
 
 
 class Screen(_raw_display_base.Screen):
@@ -277,7 +280,7 @@ class Screen(_raw_display_base.Screen):
     def hook_event_loop(
         self,
         event_loop: EventLoop,
-        callback: Callable[[list[str], list[int]], typing.Any],
+        callback: Callable[[_DecodedInput, list[int]], typing.Any],
     ) -> None:
         """
         Register the given callback with the event loop, to be called with new
@@ -291,7 +294,7 @@ class Screen(_raw_display_base.Screen):
         else:
 
             @functools.wraps(callback)
-            def wrapper() -> tuple[list[str], typing.Any] | None:
+            def wrapper() -> tuple[_DecodedInput, list[int]] | None:
                 self.logger.debug('Calling callback for "watch file"')
                 return self.parse_input(event_loop, callback, self.get_available_raw_input())
 

--- a/urwid/display/_raw_display_base.py
+++ b/urwid/display/_raw_display_base.py
@@ -48,6 +48,10 @@ if typing.TYPE_CHECKING:
 
     from urwid import Canvas, EventLoop
 
+    _MouseInput = tuple[str, int, int, int]
+    _CursorPosition = tuple[typing.Literal["cursor position"], int, int]
+    _DecodedInput = list[typing.Union[str, _MouseInput, _CursorPosition]]
+
 IS_WINDOWS = sys.platform == "win32"
 IS_WSL = (sys.platform == "linux") and ("wsl" in platform.platform().lower())
 
@@ -255,12 +259,12 @@ class Screen(BaseScreen, RealTerminal):
         self._term_output_file.flush()
 
     @typing.overload
-    def get_input(self, raw_keys: Literal[False]) -> list[str]: ...
+    def get_input(self, raw_keys: Literal[False]) -> _DecodedInput: ...
 
     @typing.overload
-    def get_input(self, raw_keys: Literal[True]) -> tuple[list[str], list[int]]: ...
+    def get_input(self, raw_keys: Literal[True]) -> tuple[_DecodedInput, list[int]]: ...
 
-    def get_input(self, raw_keys: bool = False) -> list[str] | tuple[list[str], list[int]]:
+    def get_input(self, raw_keys: bool = False) -> _DecodedInput | tuple[_DecodedInput, list[int]]:
         """Return pending input as a list.
 
         raw_keys -- return raw keycodes as well as translated versions
@@ -367,7 +371,7 @@ class Screen(BaseScreen, RealTerminal):
     def hook_event_loop(
         self,
         event_loop: EventLoop,
-        callback: Callable[[list[str], list[int]], typing.Any],
+        callback: Callable[[_DecodedInput, list[int]], typing.Any],
     ) -> None:
         """
         Register the given callback with the event loop, to be called with new
@@ -382,7 +386,7 @@ class Screen(BaseScreen, RealTerminal):
     def _make_legacy_input_wrapper(
         self,
         event_loop: EventLoop,
-        callback: Callable[[list[str], list[int]], typing.Any],
+        callback: Callable[[_DecodedInput, list[int]], typing.Any],
     ) -> Callable[[], None]:
         """
         Support old Screen classes that still have a get_input_nonblocking and expect it to work.
@@ -437,7 +441,7 @@ class Screen(BaseScreen, RealTerminal):
         callback: None,
         codes: list[int],
         wait_for_more: bool = ...,
-    ) -> tuple[list[str], list[int]]: ...
+    ) -> tuple[_DecodedInput, list[int]]: ...
 
     @typing.overload
     def parse_input(
@@ -446,13 +450,13 @@ class Screen(BaseScreen, RealTerminal):
         callback: None,
         codes: list[int],
         wait_for_more: bool = ...,
-    ) -> tuple[list[str], list[int]]: ...
+    ) -> tuple[_DecodedInput, list[int]]: ...
 
     @typing.overload
     def parse_input(
         self,
         event_loop: EventLoop,
-        callback: Callable[[list[str], list[int]], typing.Any],
+        callback: Callable[[_DecodedInput, list[int]], typing.Any],
         codes: list[int],
         wait_for_more: bool = ...,
     ) -> None: ...
@@ -460,21 +464,19 @@ class Screen(BaseScreen, RealTerminal):
     def parse_input(
         self,
         event_loop: EventLoop | None,
-        callback: Callable[[list[str], list[int]], typing.Any] | None,
+        callback: Callable[[_DecodedInput, list[int]], typing.Any] | None,
         codes: list[int],
         wait_for_more: bool = True,
-    ) -> tuple[list[str], list[int]] | None:
+    ) -> tuple[_DecodedInput, list[int]] | None:
         """
-        Read any available input from get_available_raw_input, parses it into
-        keys, and calls the given callback.
+        Read any available input from get_available_raw_input, parses it into keys, and calls the given callback.
 
         The current implementation tries to avoid any assumptions about what
         the screen or event loop look like; it only deals with parsing keycodes
         and setting a timeout when an incomplete one is detected.
 
         `codes` should be a sequence of keycodes, i.e. bytes.  A bytearray is
-        appropriate, but beware of using bytes, which only iterates as integers
-        on Python 3.
+        appropriate, but beware of using bytes, which only iterates as integers on Python 3.
         """
 
         logger = self.logger.getChild("parse_input")

--- a/urwid/display/_win32_raw_display.py
+++ b/urwid/display/_win32_raw_display.py
@@ -45,6 +45,10 @@ if typing.TYPE_CHECKING:
 
     from urwid.event_loop import EventLoop
 
+    _MouseInput = tuple[str, int, int, int]
+    _CursorPosition = tuple[typing.Literal["cursor position"], int, int]
+    _DecodedInput = list[typing.Union[str, _MouseInput, _CursorPosition]]
+
 
 class Screen(_raw_display_base.Screen):
     _term_input_file: socket.socket
@@ -114,7 +118,7 @@ class Screen(_raw_display_base.Screen):
         # restore mouse tracking to previous state
         self._mouse_tracking(self._mouse_tracking_enabled)
 
-        super()._start()
+        super()._start()  # type: ignore[safe-super]
 
     def _stop(self) -> None:
         """
@@ -135,7 +139,7 @@ class Screen(_raw_display_base.Screen):
         if not (ok := _win32.SetConsoleMode(handle_in, self._dwOriginalInMode)):
             raise RuntimeError(f"ConsoleMode set failed for input. Err: {ok!r}")
 
-        super()._stop()
+        super()._stop()  # type: ignore[safe-super]
 
     def unhook_event_loop(self, event_loop: EventLoop) -> None:
         """
@@ -159,7 +163,7 @@ class Screen(_raw_display_base.Screen):
     def hook_event_loop(
         self,
         event_loop: EventLoop,
-        callback: Callable[[list[str], list[int]], typing.Any],
+        callback: Callable[[_DecodedInput, list[int]], typing.Any],
     ) -> None:
         """
         Register the given callback with the event loop, to be called with new
@@ -265,7 +269,7 @@ class ReadInputThread(threading.Thread):
                     pass  # TODO: handle mouse events
 
 
-def _test():
+def _test() -> None:
     import doctest
 
     doctest.testmod()

--- a/urwid/display/curses.py
+++ b/urwid/display/curses.py
@@ -41,6 +41,10 @@ if typing.TYPE_CHECKING:
 
     from urwid import Canvas
 
+    _MouseInput = tuple[str, int, int, int]
+    _CursorPosition = tuple[typing.Literal["cursor position"], int, int]
+    _DecodedInput = list[typing.Union[str, _MouseInput, _CursorPosition]]
+
 IS_WINDOWS = sys.platform == "win32"
 
 # curses.KEY_RESIZE (sometimes not defined)
@@ -298,12 +302,12 @@ class Screen(BaseScreen, RealTerminal):
         self.resize_tenths = convert_to_tenths(resize_wait)
 
     @typing.overload
-    def get_input(self, raw_keys: Literal[False]) -> list[str]: ...
+    def get_input(self, raw_keys: Literal[False]) -> _DecodedInput: ...
 
     @typing.overload
-    def get_input(self, raw_keys: Literal[True]) -> tuple[list[str], list[int]]: ...
+    def get_input(self, raw_keys: Literal[True]) -> tuple[_DecodedInput, list[int]]: ...
 
-    def get_input(self, raw_keys: bool = False) -> list[str] | tuple[list[str], list[int]]:
+    def get_input(self, raw_keys: bool = False) -> _DecodedInput | tuple[_DecodedInput, list[int]]:
         """Return pending input as a list.
 
         raw_keys -- return raw keycodes as well as translated versions
@@ -374,7 +378,7 @@ class Screen(BaseScreen, RealTerminal):
             return keys, raw
         return keys
 
-    def _get_input(self, wait_tenths: int | None) -> tuple[list[str], list[int]]:
+    def _get_input(self, wait_tenths: int | None) -> tuple[_DecodedInput, list[int]]:
         # this works around a strange curses bug with window resizing
         # not being reported correctly with repeated calls to this
         # function without a doupdate call in between
@@ -488,7 +492,7 @@ class Screen(BaseScreen, RealTerminal):
 
     def _dbg_instr(self) -> bytes:  # messy input string (intended for debugging)
         curses.echo()
-        self.s.nodelay(0)
+        self.s.nodelay(False)
         curses.halfdelay(100)
         string = self.s.getstr()
         curses.noecho()

--- a/urwid/display/escape.py
+++ b/urwid/display/escape.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 import re
 import sys
 import typing
-from collections.abc import MutableMapping, Sequence
+from collections.abc import MutableMapping
 
 from urwid import str_util
 
@@ -228,9 +228,9 @@ class KeyqueueTrie:
 
     def get(
         self,
-        keys: Sequence[int],
+        keys: list[int],
         more_available: bool,
-    ) -> tuple[str | _MouseInput | _CursorPosition, Sequence[int]] | None:
+    ) -> tuple[str | _MouseInput | _CursorPosition, list[int]] | None:
         if result := self.get_recurse(self.data, keys, more_available):
             return result
 
@@ -239,9 +239,9 @@ class KeyqueueTrie:
     def get_recurse(
         self,
         root: (_KeyQueueData | str),
-        keys: Sequence[int],
+        keys: list[int],
         more_available: bool,
-    ) -> tuple[str | _MouseInput, Sequence[int]] | None:
+    ) -> tuple[str | _MouseInput, list[int]] | None:
         if not isinstance(root, MutableMapping):
             if root == "mouse":
                 return self.read_mouse_info(keys, more_available)
@@ -264,9 +264,9 @@ class KeyqueueTrie:
 
     def read_mouse_info(
         self,
-        keys: Sequence[int],
+        keys: list[int],
         more_available: bool,
-    ) -> tuple[_MouseInput, Sequence[int]] | None:
+    ) -> tuple[_MouseInput, list[int]] | None:
         if len(keys) < 3:
             if more_available:
                 raise MoreInputRequired()
@@ -307,9 +307,9 @@ class KeyqueueTrie:
 
     def read_sgrmouse_info(
         self,
-        keys: Sequence[int],
+        keys: list[int],
         more_available: bool,
-    ) -> tuple[_MouseInput, Sequence[int]] | None:
+    ) -> tuple[_MouseInput, list[int]] | None:
         # Helpful links:
         # https://stackoverflow.com/questions/5966903/how-to-get-mousemove-and-mouseclick-in-bash
         # http://invisible-island.net/xterm/ctlseqs/ctlseqs.pdf
@@ -370,9 +370,9 @@ class KeyqueueTrie:
 
     def read_cursor_position(
         self,
-        keys: Sequence[int],
+        keys: list[int],
         more_available: bool,
-    ) -> tuple[_CursorPosition, Sequence[int]] | None:
+    ) -> tuple[_CursorPosition, list[int]] | None:
         """
         Interpret cursor position information being sent by the
         user's terminal.  Returned as ('cursor position', x, y)
@@ -495,9 +495,9 @@ if IS_WINDOWS:
 
 
 def process_keyqueue(
-    codes: Sequence[int],
+    codes: list[int],
     more_available: bool,
-) -> tuple[list[str | int | _MouseInput | _CursorPosition], Sequence[int]]:
+) -> tuple[list[str | _MouseInput | _CursorPosition], list[int]]:
     """
     codes -- list of key codes
     more_available -- if True then raise MoreInputRequired when in the

--- a/urwid/display/html_fragment.py
+++ b/urwid/display/html_fragment.py
@@ -38,6 +38,10 @@ if typing.TYPE_CHECKING:
 
     from urwid import Canvas
 
+    _MouseInput = tuple[str, int, int, int]
+    _CursorPosition = tuple[typing.Literal["cursor position"], int, int]
+    _DecodedInput = list[typing.Union[str, _MouseInput, _CursorPosition]]
+
 # replace control characters with ?'s
 _trans_table = "?" * 32 + "".join(chr(x) for x in range(32, 256))
 
@@ -53,7 +57,7 @@ class HtmlGenerator(BaseScreen):
     # class variables
     fragments: typing.ClassVar[list[str]] = []
     sizes: typing.ClassVar[list[tuple[int, int]]] = []
-    keys: typing.ClassVar[list[list[str]]] = []
+    keys: typing.ClassVar[list[_DecodedInput]] = []
     started = True
 
     def __init__(self) -> None:
@@ -128,19 +132,19 @@ class HtmlGenerator(BaseScreen):
         # add the fragment to the list
         self.fragments.append(f"<pre>{''.join(lines)}</pre>")
 
-    def get_cols_rows(self):
+    def get_cols_rows(self) -> tuple[int, int]:
         """Return the next screen size in HtmlGenerator.sizes."""
         if not self.sizes:
             raise HtmlGeneratorSimulationError("Ran out of screen sizes to return!")
         return self.sizes.pop(0)
 
     @typing.overload
-    def get_input(self, raw_keys: Literal[False]) -> list[str]: ...
+    def get_input(self, raw_keys: Literal[False]) -> _DecodedInput: ...
 
     @typing.overload
-    def get_input(self, raw_keys: Literal[True]) -> tuple[list[str], list[int]]: ...
+    def get_input(self, raw_keys: Literal[True]) -> tuple[_DecodedInput, list[int]]: ...
 
-    def get_input(self, raw_keys: bool = False) -> list[str] | tuple[list[str], list[int]]:
+    def get_input(self, raw_keys: bool = False) -> _DecodedInput | tuple[_DecodedInput, list[int]]:
         """Return the next list of keypresses in HtmlGenerator.keys."""
         if not self.keys:
             raise ExitMainLoop()
@@ -183,7 +187,10 @@ def html_span(s: str, aspec: AttrSpec, cursor: int = -1) -> str:
     return _span(html_fg, html_bg, s)
 
 
-def screenshot_init(sizes: list[tuple[int, int]], keys: list[list[str]]) -> None:
+def screenshot_init(
+    sizes: list[tuple[int, int]],
+    keys: list[_DecodedInput],
+) -> None:
     """
     Replace curses_display.Screen and raw_display.Screen class with
     HtmlGenerator.
@@ -231,8 +238,8 @@ def screenshot_init(sizes: list[tuple[int, int]], keys: list[list[str]]) -> None
 
     from . import curses, raw
 
-    curses.Screen = HtmlGenerator
-    raw.Screen = HtmlGenerator
+    curses.Screen = HtmlGenerator  # type: ignore[assignment,misc]
+    raw.Screen = HtmlGenerator  # type: ignore[assignment,misc]
 
     HtmlGenerator.sizes = sizes
     HtmlGenerator.keys = keys

--- a/urwid/display/lcd.py
+++ b/urwid/display/lcd.py
@@ -27,9 +27,9 @@ import typing
 from .common import BaseScreen
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Iterable, Sequence
+    from collections.abc import Collection, Iterable, Sequence
 
-    from typing_extensions import Literal
+    from typing_extensions import Literal, SupportsIndex
 
     from urwid import Canvas
 
@@ -47,13 +47,13 @@ class LCDScreen(BaseScreen, abc.ABC):
     ) -> None:
         pass
 
-    def set_input_timeouts(self, *args):
+    def set_input_timeouts(self, *args: typing.Any) -> None:
         pass
 
-    def reset_default_terminal_palette(self, *args):
+    def reset_default_terminal_palette(self, *args: typing.Any) -> None:
         pass
 
-    def get_cols_rows(self):
+    def get_cols_rows(self) -> tuple[int, int]:
         return self.DISPLAY_SIZE
 
 
@@ -159,7 +159,7 @@ class CFLCDScreen(LCDScreen, abc.ABC):
         # complement that is sent in the packet.
         return (((~new_crc) >> 8) & 0xFFFF).to_bytes(2, "little")
 
-    def _send_packet(self, command: int, data: bytes) -> None:
+    def _send_packet(self, command: int, data: Collection[SupportsIndex]) -> None:
         """
         low-level packet sending.
         Following the protocol requires waiting for ack packet between
@@ -345,11 +345,11 @@ class CF635Screen(CFLCDScreen):
         self.key_repeat = KeyRepeatSimulator(repeat_delay, repeat_next)
         self.key_map = tuple(key_map)
 
-        self._last_command = None
-        self._last_command_time = 0
+        self._last_command: int | None = None
+        self._last_command_time = 0.0
         self._command_queue: list[tuple[int, bytearray]] = []
-        self._screen_buf = None
-        self._previous_canvas = None
+        self._screen_buf: list[list[bytes]] = []
+        self._previous_canvas: Canvas | None = None
         self._update_cursor = False
 
     def get_input_descriptors(self) -> list[int]:
@@ -435,10 +435,10 @@ class CF635Screen(CFLCDScreen):
             osb = self._screen_buf
         else:
             osb = []
-        sb = []
+        sb: list[list[bytes]] = []
 
         for y, row in enumerate(canvas.content()):
-            text = [run for _a, _cs, run in row]
+            text: list[bytes] = [run for _a, _cs, run in row]
 
             if not osb or osb[y] != text:
                 data = bytearray([0, y])

--- a/urwid/display/raw.py
+++ b/urwid/display/raw.py
@@ -34,4 +34,4 @@ if IS_WINDOWS:
     from ._win32_raw_display import Screen
 
 else:
-    from ._posix_raw_display import Screen
+    from ._posix_raw_display import Screen  # type: ignore[assignment]

--- a/urwid/display/web.py
+++ b/urwid/display/web.py
@@ -45,9 +45,13 @@ from urwid.util import StoppingContext, get_encoding
 from .common import BaseScreen
 
 if typing.TYPE_CHECKING:
+    from collections.abc import Iterable
+    from types import FrameType
+
     from typing_extensions import Literal
 
-    from urwid import Canvas
+    from urwid.canvas import Canvas
+    from urwid.display import AttrSpec
 
 TEMP_DIR = tempfile.gettempdir()
 CURRENT_DIR = pathlib.Path(__file__).parent
@@ -125,7 +129,7 @@ Status: <span id="status">Set up</span>
 class Screen(BaseScreen):
     def __init__(self) -> None:
         super().__init__()
-        self.palette = {}
+        self.palette: dict[str | None, tuple[str, str, str | None]] = {}
         self.has_color = True
         self._started = False
 
@@ -133,7 +137,10 @@ class Screen(BaseScreen):
     def started(self) -> bool:
         return self._started
 
-    def register_palette(self, palette) -> None:
+    def register_palette(
+        self,
+        palette: Iterable[tuple[str, str] | tuple[str, str, str] | tuple[str, str, str, str]],  # type: ignore[override]
+    ) -> None:
         """Register a list of palette entries.
 
         palette -- list of (name, foreground, background) or
@@ -180,10 +187,10 @@ class Screen(BaseScreen):
     def set_mouse_tracking(self, enable: bool = True) -> None:
         """Not yet implemented"""
 
-    def tty_signal_keys(self, *args, **vargs):
+    def tty_signal_keys(self, *args: typing.Any, **vargs: typing.Any) -> None:
         """Do nothing."""
 
-    def start(self, *args, **kwargs) -> StoppingContext:
+    def start(self, *args: typing.Any, **kwargs: typing.Any) -> StoppingContext:
         """
         This function reads the initial screen size, generates a
         unique id and handles cleanup when fn exits.
@@ -201,7 +208,7 @@ class Screen(BaseScreen):
         x = int(x)
         y = int(y)
         self._set_screen_size(x, y)
-        self.last_screen = {}
+        self.last_screen: dict[tuple[tuple[AttrSpec | str | None, str] | int | None, ...], list[int]] = {}
         self.last_screen_width = 0
 
         self.update_method = os.environ["HTTP_X_URWID_METHOD"]
@@ -264,7 +271,7 @@ class Screen(BaseScreen):
             sys.stdout.write("\r\nZ\r\n--ZZ--\r\n")
             sys.stdout.flush()
 
-    def _cleanup_pipe(self, *args) -> None:
+    def _cleanup_pipe(self, *args: typing.Any) -> None:
         if not self.pipe_name:
             return
         # XXX which exceptions does this actually raise? EnvironmentError?
@@ -283,6 +290,7 @@ class Screen(BaseScreen):
         """Send a screen update to the client."""
 
         (cols, rows) = size
+        encoding = get_encoding()
 
         if cols != self.last_screen_width:
             self.last_screen = {}
@@ -297,7 +305,7 @@ class Screen(BaseScreen):
                 s, _addr = self.server_socket.accept()
             except socket.timeout:
                 sys.exit(0)
-            send = s.sendall
+            send = s.sendall  # type: ignore[assignment]  # use default flags
         else:
             signal.alarm(0)
             send = sendq.append
@@ -312,16 +320,16 @@ class Screen(BaseScreen):
         else:
             cx = cy = None
 
-        new_screen = {}
+        new_screen: dict[tuple[tuple[AttrSpec | str | None, str] | int | None, ...], list[int]] = {}
 
         y = -1
         for row in canvas.content():
             y += 1
-            l_row = tuple((attr_, line.decode(get_encoding())) for attr_, _, line in row)
+            l_row = tuple((attr_, line.decode(encoding)) for attr_, _, line in row)
 
             line = []
 
-            sig = l_row
+            sig: tuple[tuple[AttrSpec | str | None, str] | int | None, ...] = l_row
             if y == cy:
                 sig = (*sig, cx)
             new_screen[sig] = [*new_screen.get(sig, []), y]
@@ -340,7 +348,7 @@ class Screen(BaseScreen):
                 if a is None:
                     fg, bg, _mono = "black", "light gray", None
                 else:
-                    fg, bg, _mono = self.palette[a]
+                    fg, bg, _mono = self.palette[typing.cast("str | None", a)]
                 if y == cy and col <= cx:
                     run_width = calc_width(t_run, 0, len(t_run))
                     if col + run_width > cx:
@@ -391,7 +399,7 @@ class Screen(BaseScreen):
         s.settimeout(POLL_CONNECT)
         self.server_socket = s
 
-    def _handle_alarm(self, sig, frame) -> None:
+    def _handle_alarm(self, sig: int, frame: FrameType | None) -> None:
         if self.update_method not in {"multipart", "polling child"}:
             raise ValueError(self.update_method)
         if self.update_method == "polling child":
@@ -442,9 +450,7 @@ class Screen(BaseScreen):
         for k in keys[:-1]:
             if k.startswith("window resize "):
                 _ign1, _ign2, x, y = k.split(" ", 3)
-                x = int(x)
-                y = int(y)
-                self._set_screen_size(x, y)
+                self._set_screen_size(int(x), int(y))
                 resized = True
             else:
                 pending_input.append(k)
@@ -533,10 +539,10 @@ def handle_short_request() -> bool:
         s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         try:
             s.connect(os.path.join(_prefs.pipe_dir, f"urwid{urwid_id}.update"))
-            data = f"Content-type: text/plain\r\n\r\n{s.recv(BUF_SZ)}"
+            data = f"Content-type: text/plain\r\n\r\n{s.recv(BUF_SZ).decode('utf-8')}"
             while data:
                 sys.stdout.write(data)
-                data = s.recv(BUF_SZ)
+                data = s.recv(BUF_SZ).decode("utf-8")
         except OSError:
             sys.stdout.write("Status: 404 Not Found\r\n\r\n")
             return True


### PR DESCRIPTION
* `_raw_display_base` - `get_input`, `parse_input` and wrappers
* `_posix_raw_display` - `hook_event_loop`
* `_win32_raw_display` - `hook_event_loop`
* `curses` - `get_input`, `parse_input` and wrappers. Ignore `union-attr` mypy check for not started screen.
* `web`
* `lcd`
* `html_fragment`
* `escape` - tune types from protocol to actual implementation for input codes.

Partial #1146 

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
