### PR TITLE
Clean-up: Remove unused imports from `urwid.graphics`

### DIFF
--- a/urwid/graphics.py
+++ b/urwid/graphics.py
@@ -24,33 +24,16 @@ import typing
 
 from urwid.display import AttrSpec
 from urwid.widget import (
-    BarGraph,
-    BarGraphError,
-    BarGraphMeta,
-    BigText,
-    GraphVScale,
-    LineBox,
-    ProgressBar,
     Sizing,
     Text,
     Widget,
     fixed_size,
-    scale_bar_values,
 )
 
 if typing.TYPE_CHECKING:
     from urwid import canvas
 
-__all__ = (
-    "BarGraph",
-    "BarGraphError",
-    "BarGraphMeta",
-    "BigText",
-    "GraphVScale",
-    "LineBox",
-    "ProgressBar",
-    "scale_bar_values",
-)
+__all__ = ("PythonLogo",)
 
 
 class PythonLogo(Widget):


### PR DESCRIPTION
`urwid.graphics` contains only example widget `PythonLogo` and should not re-export anything not relevant

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
