### PR TITLE
Maintenance: add dev-dependencies in pyproject and auto-format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,23 +2,29 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
-      - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: mixed-line-ending
+        args: [ --fix=lf ]
+      - id: check-yaml
+      - id: check-toml
+      - id: check-json
+      - id: check-merge-conflict
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    # Ruff version.
-    rev: v0.14.5
+    rev: v0.15.18
     hooks:
-      # Run the linter.
       - id: ruff-check
-        args: [ --fix ]
-      # Run the formatter.
+        args: [ --show-fixes, --fix ]
       - id: ruff-format
 
+  - repo: https://github.com/tox-dev/pyproject-fmt
+    rev: v2.25.0
+    hooks:
+      - id: pyproject-fmt
+
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.37.1
+    rev: v1.38.0
     hooks:
       - id: yamllint
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,34 +1,78 @@
 [build-system]
+build-backend = "setuptools.build_meta"
 # Minimum requirements for the build system to execute.
 # PEP 508 specifications for PEP 518.
 requires = [
-  "setuptools >= 80.8.0",
-  "wheel",
-  "setuptools_scm[toml]>=8.1.0",
+  "setuptools>=80.8.0",
+  "setuptools-scm[toml]>=8.1.0",
 ]
-build-backend="setuptools.build_meta"
 
 [project]
 name = "urwid"
 description = "A full-featured console (xterm et al.) user interface library"
-requires-python = ">=3.9.0"
-keywords = ["curses", "ui", "widget", "scroll", "listbox", "user interface", "text layout", "console", "ncurses"]
+readme = { file = "README.rst", content-type = "text/x-rst" }
+keywords = [ "console", "curses", "listbox", "ncurses", "scroll", "text layout", "ui", "user interface", "widget" ]
 license = "LGPL-2.1-only"  # Use SPDX classifier
-license-files=["COPYING"]
-readme = {file = "README.rst", content-type = "text/x-rst"}
-authors=[{name="Ian Ward", email="ian@excess.org"}]
-dynamic = ["classifiers", "version", "dependencies"]
-
+license-files = [ "COPYING" ]
+requires-python = ">=3.9.0"
+dynamic = [ "classifiers", "dependencies", "version" ]
+[[project.authors]]
+name = "Ian Ward"
+email = "ian@excess.org"
+[project.optional-dependencies]
+curses = [ "windows-curses; sys_platform=='win32'" ]
+glib = [ "pygobject" ]
+tornado = [ "tornado>=5.0" ]
+trio = [ "exceptiongroup; python_version<'3.11'", "trio>=0.24.0" ]
+twisted = [ "twisted" ]
+zmq = [ "zmq" ]
+# for lcd_display
+serial = [ "pyserial" ]
+lcd = [ "pyserial" ]
 [project.urls]
-"Homepage" = "https://urwid.org/"
-"Documentation" = "https://urwid.org/manual/index.html"
-"Repository" = "https://github.com/urwid/urwid"
+Homepage = "https://urwid.org/"
+Documentation = "https://urwid.org/manual/index.html"
+Repository = "https://github.com/urwid/urwid"
 "Bug Tracker" = "https://github.com/urwid/urwid/issues"
 
-[tool.setuptools]
-platforms=["unix-like"]
-zip-safe = false
+[dependency-groups]
+dev = [
+  { include-group = "build" },
+  { include-group = "documentation" },
+  { include-group = "lint" },
+  { include-group = "mypy" },
+  { include-group = "pre-commit" },
+  { include-group = "pylint" },
+]
+build = [
+  "build",
+]
+documentation = [
+  "sphinx",
+]
+lint = [
+  "pyproject-fmt",
+  "ruff",
+  "yamllint",
+]
+mypy = [
+  "mypy[faster-cache,reports]",
+]
+pre-commit = [
+  "prek",
+]
+pylint = [
+  "pylint",
+]
 
+[tool.setuptools]
+platforms = [ "unix-like" ]
+zip-safe = false
+[tool.setuptools.dynamic]
+classifiers = { file = [ "classifiers.txt" ] }
+dependencies = { file = [ "requirements.txt" ] }
+[tool.setuptools.package-data]
+urwid = [ "py.typed" ]
 [tool.setuptools.packages.find]
 include = [
   "urwid",
@@ -36,26 +80,8 @@ include = [
 ]
 namespaces = false
 
-[tool.setuptools.dynamic]
-dependencies = {file = ["requirements.txt"]}
-classifiers = {file = ["classifiers.txt"]}
-
-[project.optional-dependencies]
-curses = ["windows-curses; sys_platform == 'win32'"]
-glib = ["PyGObject"]
-tornado = ["tornado>=5.0"]
-trio = ["trio>=0.24.0", "exceptiongroup; python_version < '3.11'"]
-twisted = ["twisted"]
-zmq = ["zmq"]
-# for lcd_display
-serial = ["pyserial"]
-lcd = ["pyserial"]
-
 [tool.distutils.bdist_wheel]
 universal = 0
-
-[tool.setuptools.package-data]
-urwid = [ "py.typed" ]
 
 [tool.setuptools_scm]
 write_to = "urwid/version.py"
@@ -63,24 +89,208 @@ write_to = "urwid/version.py"
 [tool.cibuildwheel]
 # Disable building PyPy wheels on all platforms
 # Disable musllinux as not popular platform
-skip = ["pp*", "*-musllinux_*"]
+skip = [ "pp*", "*-musllinux_*" ]
 
-[tool.isort]
-profile = "black"
-line_length = 120
-
-[tool.black]
+[tool.ruff]
+target-version = "py39"
 line-length = 120
+extend-exclude = [ "tests" ]
+output-format = "full"
+[tool.ruff.format]
+docstring-code-format = true
+[tool.ruff.lint]
+extend-select = [
+  "E",
+  "W",     # also pycodestyle warnings
+  "F",     # pyflakes
+  "PYI",   # flake8-pyi
+  "ASYNC", # flake8-async
+  "FA",    # from __future__ import annotations
+  "SLOT",  # flake8-slots
+  "TC",    # flake8-type-checking
+  "S",     # flake8-bandit
+  "A",     # flake8-builtins
+  "B",
+  "T10",
+  "EXE",   # flake8-bugbear, flake8-debugger, flake8-executable
+  "ISC",   # flake8-implicit-str-concat
+  "RET",
+  "SIM",
+  "C4",    # flake8-return, flake8-simplify, flake8-comprehensions
+  "ICN",
+  "PGH",   # flake8-import-conventions, pygrep-hooks
+  "Q",     # quotes
+  "FLY",   # Flynt
+  "FURB",  # Refurb
+  "PIE",   # flake8-pie,
+  "TRY",
+  "UP",
+  "I",
+  "PL",
+  "PERF",
+  "RUF",   # tryceratops, pyupgrade, isort, pylint + perflint, Ruff-specific
+]
+extend-ignore = [
+  "E221",
+  "E222",    # handled by formatter
+  "PLR6301",
+  "E203",
+  # refactor rules (too many statements/arguments/branches)
+  "PLR0904",
+  "PLR0911",
+  "PLR0912",
+  "PLR0913",
+  "PLR0914",
+  "PLR0915",
+  "PLR0917",
+  "PLR2004",
+  "PLC0415", # We have a lot of imports outside top-level
+  "RET504",  # Unnecessary variable assignment before a return statement
+  "SIM108",  # Use ternary operator,
+  "TRY003",  # long messages prepare outside, ...
+  "PYI063",  # MonitoredList is a list subclass, this expected to change
+]
+[tool.ruff.lint.isort]
+known-third-party = []
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = [ "F401", "SIM105" ]
+"urwid/display/curses.py" = [ "A005" ]
+[tool.ruff.lint.pydocstyle]
+convention = "pep257"
+[tool.ruff.lint.pylint]
+allow-dunder-method-names = [
+  "__rich_repr__",
+  # class generation
+  "_contents__getitem__",
+  "_contents__setitem__",
+  "_contents__delitem__",
+]
+
+[tool.pylint]
+reports = false
+disable = [
+  "arguments-differ",
+  "attribute-defined-outside-init",                   # old bad practice, fixed step-by-step
+  "broad-except",
+  "broad-exception-raised",
+  "consider-using-assignment-expr",
+  # iterable modification during iteration
+  "consider-using-enumerate",
+  "cyclic-import",
+  "file-ignored",
+  "fixme",
+  "import-outside-toplevel",
+  "invalid-name",
+  # Magic part
+  "invalid-overridden-method",
+  "locally-disabled",
+  "logging-format-interpolation",
+  "logging-fstring-interpolation",
+  "missing-docstring",
+  "redefined-variable-type",                          # makes not happy typechecking, but super common
+  "similarities",
+  "superfluous-parens",
+  "suppressed-message",
+  "too-few-public-methods",
+  "too-many-ancestors",
+  "too-many-arguments",
+  "too-many-branches",
+  "too-many-instance-attributes",
+  "too-many-lines",
+  "too-many-locals",
+  "too-many-nested-blocks",
+  "too-many-positional-arguments",
+  "too-many-public-methods",
+  "too-many-return-statements",
+  "too-many-statements",
+  "unused-argument",
+  "unused-private-member",
+  # too complex union
+  "use-implicit-booleaness-not-comparison-to-string",
+  "use-implicit-booleaness-not-comparison-to-zero",
+]
+enable = "all"
+extension-pkg-whitelist = []
+ignore = [ "CVS", "version.py" ]
+jobs = 0
+load-plugins = [
+  "pylint.extensions.check_elif",
+  "pylint.extensions.code_style",
+  "pylint.extensions.dict_init_mutate",
+  "pylint.extensions.dunder",
+  "pylint.extensions.for_any_all",
+  "pylint.extensions.overlapping_exceptions",
+  "pylint.extensions.redefined_variable_type",
+  "pylint.extensions.typing",
+]
+max-line-length = 120
+py-version = "3.9"
+[tool.pylint.basic]
+good-names = [
+  "i",
+  "j",
+  "k",
+  "ex",
+  "Run",
+  "_",
+  "bar", # we draw bars
+]
+[tool.pylint.classes]
+exclude-protected = [
+  "_asdict",
+  "_fields",
+  "_replace",
+  "_source",
+  "_make",
+  "os._exit",
+  # API
+  "_original_widget",
+  "_invalidate",
+  "_repr_attrs",
+  "_repr_words",
+  "_w",
+]
+[tool.pylint.dunder]
+good-dunder-names = [
+  "__rich_repr__",
+  # class generation
+  "_contents__getitem__",
+  "_contents__setitem__",
+  "_contents__delitem__",
+]
+[tool.pylint.format]
+ignore-long-lines = "^(\\s*(# )?<?https?://\\S+>?)|(.+# type: ignore\\[[\\w\\-\\,]+\\])$"
+
+[tool.pyproject-fmt]
+# After how many columns split arrays/dicts into multiple lines and wrap long strings;
+# use a trailing comma in arrays to force multiline format instead of lowering this value
+column_width = 120
+# Keep full version numbers (e.g., 1.0.0 instead of 1.0) in dependency specifiers
+keep_full_version = true
+generate_python_version_classifiers = false
+# Table format: "short" collapses sub-tables to dotted keys, "long" expands to [table.subtable] headers
+table_format = "long"
+
+[tool.mypy]
+disallow_untyped_defs = true
+show_error_context = true
+show_column_numbers = true
+pretty = true
+show_error_codes = true
+[[tool.mypy.overrides]]
+module = "urwid.display.curses"
+disable_error_code = [
+  "union-attr", # chacking for started state before each operation if too expensive
+]
+[[tool.mypy.overrides]]
+module = [ "gi.*", "serial.*", "trio.*" ]
+ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = "-vvvv --doctest-modules -s --cov=urwid"
-doctest_optionflags = ["ELLIPSIS", "IGNORE_EXCEPTION_DETAIL"]
-testpaths = ["urwid"]
-
-[tool.coverage.run]
-omit = ["tests/*", ".tox/*", "setup.py"]
-branch = true
+doctest_optionflags = [ "ELLIPSIS", "IGNORE_EXCEPTION_DETAIL" ]
+testpaths = [ "urwid" ]
 
 [tool.coverage.report]
 exclude_lines = [
@@ -102,11 +312,11 @@ exclude_lines = [
   "@abc.abstractmethod",
 
   # Exclude import statements
-  "^from\b",
-  "^import\b",
+  "^from\\b",
+  "^import\\b",
 
   # Exclude variable declarations that are executed when file is loaded
-  "^[a-zA-Z_]+\b\\s=",
+  "^[a-zA-Z_]+\\b\\s=",
 
   # Code for static analysis is never covered:
   "if typing.TYPE_CHECKING:",
@@ -135,200 +345,19 @@ exclude_lines = [
   "class \\w*test:",
   "def \\wtest():"
 ]
-
-[tool.mypy]
-show_error_context = true
-show_column_numbers = true
-show_error_codes = true
-disallow_untyped_defs = true
-pretty = true
-
-[[tool.mypy.overrides]]
-module = "urwid.display.curses"
-disable_error_code = [
-  "union-attr",  # chacking for started state before each operation if too expensive
-]
-
-[[tool.mypy.overrides]]
-module = [
-  "gi.*",
-  "trio.*",
-  "serial.*"
-]
-ignore_missing_imports = true
-
-[tool.ruff]
-line-length = 120
-output-format = "full"
-target-version = "py39"
-extend-exclude = ["tests"]
-
-[tool.ruff.lint]
-extend-select = [
-  "E",
-  "W",  # also pycodestyle warnings
-  "F",  # pyflakes
-  "PYI",  # flake8-pyi
-  "ASYNC",  # flake8-async
-  "FA",  # from __future__ import annotations
-  "SLOT",  # flake8-slots
-  "TC",  # flake8-type-checking
-  "S",  # flake8-bandit
-  "A",  # flake8-builtins
-  "B", "T10", "EXE",  # flake8-bugbear, flake8-debugger, flake8-executable
-  "ISC",  # flake8-implicit-str-concat
-  "RET", "SIM", "C4",  # flake8-return, flake8-simplify, flake8-comprehensions
-  "ICN", "PGH",  # flake8-import-conventions, pygrep-hooks
-  "Q",  # quotes
-  "FLY",  # Flynt
-  "FURB",  # Refurb
-  "PIE",  # flake8-pie,
-  "TRY", "UP", "I", "PL", "PERF", "RUF",  # tryceratops, pyupgrade, isort, pylint + perflint, Ruff-specific
-]
-extend-ignore = [
-  "E221", "E222",  # handled by formatter
-  "PLR6301", "E203",
-  # refactor rules (too many statements/arguments/branches)
-  "PLR0904", "PLR0911", "PLR0912", "PLR0913", "PLR0914", "PLR0915", "PLR0917", "PLR2004",
-  "PLC0415",  # We have a lot of imports outside top-level
-  "RET504",  # Unnecessary variable assignment before a return statement
-  "SIM108",  # Use ternary operator,
-  "TRY003",  # long messages prepare outside, ...
-  "PYI063",  # MonitoredList is a list subclass, this expected to change
-]
-
-[tool.ruff.lint.per-file-ignores]
-"__init__.py" = ["F401", "SIM105"]
-"urwid/display/curses.py" = ["A005"]
-
-
-[tool.ruff.lint.isort]
-known-third-party = []
-
-[tool.ruff.lint.pydocstyle]
-convention = "pep257"
-
-[tool.ruff.lint.pylint]
-allow-dunder-method-names = [
-  "__rich_repr__",
-  # class generation
-  "_contents__getitem__",
-  "_contents__setitem__",
-  "_contents__delitem__",
-]
-
-[tool.ruff.format]
-docstring-code-format = true
-
-[tool.pylint]
-extension-pkg-whitelist = []
-ignore = ["CVS", "version.py"]
-
-jobs = 0
-py-version = "3.9"
-
-load-plugins = [
-  "pylint.extensions.overlapping_exceptions",
-  "pylint.extensions.check_elif",
-  "pylint.extensions.for_any_all",
-  "pylint.extensions.code_style",
-  "pylint.extensions.redefined_variable_type",
-  "pylint.extensions.dict_init_mutate",
-  "pylint.extensions.typing",
-  "pylint.extensions.dunder",
-]
-
-enable = "all"
-disable = [
-  "locally-disabled",
-  "file-ignored",
-  "suppressed-message",
-  "similarities",
-  "too-many-ancestors",
-  "too-few-public-methods",
-  "too-many-public-methods",
-  "too-many-return-statements",
-  "too-many-branches",
-  "too-many-arguments",
-  "too-many-locals",
-  "too-many-statements",
-  "too-many-instance-attributes",
-  "too-many-lines",
-  "too-many-nested-blocks",
-  "too-many-positional-arguments",
-  "broad-except",
-  "broad-exception-raised",
-  "logging-fstring-interpolation",
-  "logging-format-interpolation",
-  "fixme",
-  "invalid-name",
-  "import-outside-toplevel",
-  "cyclic-import",
-  "missing-docstring",
-  "use-implicit-booleaness-not-comparison-to-zero",
-  "unused-argument",
-  "unused-private-member",
-  "arguments-differ",
-  "consider-using-assignment-expr",
-  "superfluous-parens",
-  # Magic part
-  "invalid-overridden-method",
-  "attribute-defined-outside-init",  # old bad practice, fixed step-by-step
-  "redefined-variable-type",  # makes not happy typechecking, but super common
-  # too complex union
-  "use-implicit-booleaness-not-comparison-to-string",
-  # iterable modification during iteration
-  "consider-using-enumerate",
-]
-max-line-length = 120
-reports = false
-
-[tool.pylint.basic]
-good-names = [
-  "i", "j", "k", "ex", "Run", "_",
-  "bar",  # we draw bars
-]
-
-[tool.pylint.classes]
-exclude-protected = [
-  "_asdict",
-  "_fields",
-  "_replace",
-  "_source",
-  "_make",
-  "os._exit",
-  # API
-  "_original_widget",
-  "_invalidate",
-  "_repr_attrs",
-  "_repr_words",
-  "_w",
-]
-
-[tool.pylint.format]
-ignore-long-lines = "^(\\s*(# )?<?https?://\\S+>?)|(.+# type: ignore\\[[\\w\\-\\,]+\\])$"
-
-[tool.pylint.dunder]
-good-dunder-names = [
-  "__rich_repr__",
-  # class generation
-  "_contents__getitem__",
-  "_contents__setitem__",
-  "_contents__delitem__",
-]
+[tool.coverage.run]
+omit = [ "tests/*", ".tox/*", "setup.py" ]
+branch = true
 
 [tool.refurb]
 python_version = "3.9"
-ignore = ["FURB104", "FURB144", "FURB146"]
-
+ignore = [ "FURB104", "FURB144", "FURB146" ]
 [[tool.refurb.amend]]
 path = "urwid/__init__.py"
-ignore = ["FURB107"]
-
+ignore = [ "FURB107" ]
 [[tool.refurb.amend]]
 path = "urwid/display/__init__.py"
-ignore = ["FURB107"]
-
+ignore = [ "FURB107" ]
 [[tool.refurb.amend]]
 path = "urwid/event_loop/__init__.py"
-ignore = ["FURB107"]
+ignore = [ "FURB107" ]


### PR DESCRIPTION
Use `pyproject-fmt` to format ``pyproject.toml`` on pre-commit phase

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
