### PR TITLE
Typing: cover base containers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 wcwidth>=0.4
+typing-extensions

--- a/urwid/widget/bar_graph.py
+++ b/urwid/widget/bar_graph.py
@@ -22,7 +22,12 @@ class BarGraphMeta(WidgetMeta):
     should use set_data() instead of overriding get_data().
     """
 
-    def __init__(cls, name, bases, d):
+    def __init__(
+        cls,
+        name: str,
+        bases: tuple[type, ...],
+        d: dict[str, typing.Any],
+    ) -> None:
         # pylint: disable=protected-access
 
         super().__init__(name, bases, d)
@@ -425,7 +430,12 @@ class BarGraph(Widget, metaclass=BarGraphMeta):
         return canv
 
 
-def calculate_bargraph_display(bardata, top: float, bar_widths: list[int], maxrow: int):
+def calculate_bargraph_display(
+    bardata,
+    top: float,
+    bar_widths: list[int],
+    maxrow: int,
+):
     """
     Calculate a rendering of the bar graph described by data, bar_widths
     and height.

--- a/urwid/widget/box_adapter.py
+++ b/urwid/widget/box_adapter.py
@@ -98,7 +98,7 @@ class BoxAdapter(WidgetDecoration[WrappedWidget]):
         (maxcol,) = size
         return self._original_widget.keypress((maxcol, self.height), key)
 
-    def move_cursor_to_coords(self, size: tuple[int], col: int, row: int):
+    def move_cursor_to_coords(self, size: tuple[int], col: int, row: int) -> bool:
         (maxcol,) = size
         if not hasattr(self._original_widget, "move_cursor_to_coords"):
             return True

--- a/urwid/widget/columns.py
+++ b/urwid/widget/columns.py
@@ -4,6 +4,8 @@ import typing
 import warnings
 from itertools import chain, repeat
 
+from typing_extensions import Literal
+
 import urwid
 from urwid.canvas import Canvas, CanvasJoin, CompositeCanvas, SolidCanvas
 from urwid.command_map import Command
@@ -16,9 +18,7 @@ from .monitored_list import MonitoredFocusList, MonitoredList
 from .widget import Widget, WidgetError, WidgetWarning
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Iterable, Iterator, Sequence
-
-    from typing_extensions import Literal
+    from collections.abc import Collection, Iterable, Iterator, Sequence
 
 
 class ColumnsError(WidgetError):
@@ -29,7 +29,17 @@ class ColumnsWarning(WidgetWarning):
     """Columns related warnings."""
 
 
-class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
+class Columns(
+    Widget,
+    WidgetContainerMixin[int],
+    WidgetContainerListContentsMixin[
+        typing.Union[
+            tuple[Literal[WHSettings.PACK], None, bool],
+            tuple[Literal[WHSettings.GIVEN], int, bool],
+            tuple[Literal[WHSettings.WEIGHT], typing.Union[int, float], bool],
+        ]
+    ],
+):
     """
     Widgets arranged horizontally in columns from left to right
     """
@@ -261,6 +271,8 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
 
         box_columns = set(box_columns or ())
 
+        width: Literal["pack", WHSettings.PACK] | int | float | None
+
         for i, original in enumerate(widget_list):
             w = original
             if not isinstance(w, tuple):
@@ -271,15 +283,15 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
                 if width in {Sizing.FLOW, WHSettings.PACK}:  # 'pack' used to be called 'flow'
                     self.contents.append((w, (WHSettings.PACK, None, i in box_columns)))
                 else:
-                    self.contents.append((w, (WHSettings.GIVEN, width, i in box_columns)))
+                    self.contents.append((w, (WHSettings.GIVEN, typing.cast("int", width), i in box_columns)))
 
             elif w[0] in {Sizing.FIXED, WHSettings.GIVEN}:  # backwards compatibility: FIXED -> GIVEN
                 width, w = w[-2:]
-                self.contents.append((w, (WHSettings.GIVEN, width, i in box_columns)))
+                self.contents.append((w, (WHSettings.GIVEN, typing.cast("int", width), i in box_columns)))
 
             elif w[0] == WHSettings.WEIGHT:
                 _ignored, width, w = w
-                self.contents.append((w, (WHSettings.WEIGHT, width, i in box_columns)))
+                self.contents.append((w, (WHSettings.WEIGHT, typing.cast("int | float", width), i in box_columns)))
 
             else:
                 raise ColumnsError(f"initial widget list item invalid: {original!r}")
@@ -293,10 +305,10 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         self.dividechars = dividechars
 
         if self.contents and focus_column is not None:
-            self.focus_position = focus_column
-        self.pref_col = None
+            self.focus_position = typing.cast("int", focus_column)
+        self.pref_col: Literal["left", "right"] | int | None = None
         self.min_width = min_width
-        self._cache_maxcol = None
+        self._cache_maxcol: int | None = None
 
     def _repr_words(self) -> list[str]:
         if len(self.contents) > 1:
@@ -325,13 +337,13 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         box_columns: list[int] = []
         for idx, (w_instance, (sizing, amount, is_box)) in enumerate(self._contents):
             if sizing == WHSettings.GIVEN:
-                widget_list.append((amount, w_instance))
+                widget_list.append((typing.cast("int", amount), w_instance))
             elif sizing == WHSettings.PACK:
                 widget_list.append((WHSettings.PACK, w_instance))
             elif amount == 1:
                 widget_list.append(w_instance)
             else:
-                widget_list.append((WHSettings.WEIGHT, amount, w_instance))
+                widget_list.append((WHSettings.WEIGHT, typing.cast("int | float", amount), w_instance))
 
             if is_box:
                 box_columns.append(idx)
@@ -353,7 +365,18 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         self._selectable = any(w.selectable() for w, o in self.contents)
         self._invalidate()
 
-    def _validate_contents_modified(self, slc, new_items) -> None:
+    def _validate_contents_modified(
+        self,
+        slc: tuple[int, int, int],
+        new_items: Collection[
+            tuple[
+                Widget,
+                tuple[Literal[WHSettings.PACK], None, bool]
+                | tuple[Literal[WHSettings.GIVEN], int, bool]
+                | tuple[Literal[WHSettings.WEIGHT], int | float, bool],
+            ]
+        ],
+    ) -> None:
         invalid_items: list[tuple[Widget, tuple[typing.Any, typing.Any, typing.Any]]] = []
         try:
             for item in new_items:
@@ -373,7 +396,7 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
             raise ColumnsError(f"added content invalid: {invalid_items!r}")
 
     @property
-    def widget_list(self) -> MonitoredList:
+    def widget_list(self) -> MonitoredList[Widget]:
         """
         A list of the widgets in this Columns
 
@@ -388,14 +411,14 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         )
         ml = MonitoredList(w for w, t in self.contents)
 
-        def user_modified():
+        def user_modified() -> None:
             self.widget_list = ml
 
         ml.set_modified_callback(user_modified)
         return ml
 
     @widget_list.setter
-    def widget_list(self, widgets):
+    def widget_list(self, widgets: MonitoredList[Widget]) -> None:
         warnings.warn(
             "only for backwards compatibility. You should use the new standard container `contents`."
             "API will be removed in version 5.0.",
@@ -415,7 +438,13 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
             self.focus_position = focus_position
 
     @property
-    def column_types(self) -> MonitoredList:
+    def column_types(
+        self,
+    ) -> MonitoredList[
+        tuple[Literal[Sizing.FLOW], None]
+        | tuple[Literal[Sizing.FIXED], int]
+        | tuple[Literal[WHSettings.WEIGHT], int | float],
+    ]:
         """
         A list of the old partial options values for widgets in this Pile,
         for backwards compatibility only.  You should use the new standard
@@ -430,18 +459,31 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         )
         ml = MonitoredList(
             # return the old column type names
-            ({WHSettings.GIVEN: Sizing.FIXED, WHSettings.PACK: Sizing.FLOW}.get(t, t), n)
+            (
+                {
+                    WHSettings.GIVEN: Sizing.FIXED,
+                    WHSettings.PACK: Sizing.FLOW,
+                }.get(t, t),
+                n,
+            )
             for w, (t, n, b) in self.contents
         )
 
-        def user_modified():
-            self.column_types = ml
+        def user_modified() -> None:
+            self.column_types = ml  # type: ignore[assignment]
 
         ml.set_modified_callback(user_modified)
-        return ml
+        return ml  # type: ignore[return-value]
 
     @column_types.setter
-    def column_types(self, column_types):
+    def column_types(
+        self,
+        column_types: MonitoredList[
+            tuple[Literal[Sizing.FLOW, WHSettings.PACK], None]
+            | tuple[Literal[Sizing.FIXED, WHSettings.GIVEN], int]
+            | tuple[Literal[WHSettings.WEIGHT], int | float],
+        ],
+    ) -> None:
         warnings.warn(
             "for backwards compatibility only."
             "You should use the new standard container property .contents to modify Pile contents."
@@ -451,14 +493,24 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         )
         focus_position = self.focus_position
         self.contents = [
-            (w, ({Sizing.FIXED: WHSettings.GIVEN, Sizing.FLOW: WHSettings.PACK}.get(new_t, new_t), new_n, b))
+            (  # type: ignore[misc]
+                w,
+                (
+                    {
+                        Sizing.FIXED: WHSettings.GIVEN,
+                        Sizing.FLOW: WHSettings.PACK,
+                    }.get(new_t, new_t),  # type: ignore[arg-type]
+                    new_n,
+                    b,
+                ),
+            )
             for ((new_t, new_n), (w, (t, n, b))) in zip(column_types, self.contents)
         ]
         if focus_position < len(column_types):
             self.focus_position = focus_position
 
     @property
-    def box_columns(self) -> MonitoredList:
+    def box_columns(self) -> MonitoredList[int]:
         """
         A list of the indexes of the columns that are to be treated as
         box widgets when the Columns is treated as a flow widget.
@@ -474,22 +526,22 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         )
         ml = MonitoredList(i for i, (w, (t, n, b)) in enumerate(self.contents) if b)
 
-        def user_modified():
+        def user_modified() -> None:
             self.box_columns = ml
 
         ml.set_modified_callback(user_modified)
         return ml
 
     @box_columns.setter
-    def box_columns(self, box_columns):
+    def box_columns(self, box_columns: MonitoredList[int]) -> None:
         warnings.warn(
             "only for backwards compatibility.You should use the new standard container property `contents`."
             "API will be removed in version 5.0.",
             DeprecationWarning,
             stacklevel=2,
         )
-        box_columns = set(box_columns)
-        self.contents = [(w, (t, n, i in box_columns)) for (i, (w, (t, n, b))) in enumerate(self.contents)]
+        box_columns = set(box_columns)  # type: ignore[assignment]
+        self.contents = [(w, (t, n, i in box_columns)) for (i, (w, (t, n, b))) in enumerate(self.contents)]  # type: ignore[misc]
 
     @property
     def contents(
@@ -561,7 +613,7 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         if width_type == WHSettings.PACK:
             return (WHSettings.PACK, None, box_widget)
         if width_type in {WHSettings.GIVEN, WHSettings.WEIGHT} and width_amount is not None:
-            return (WHSettings(width_type), width_amount, box_widget)
+            return (WHSettings(width_type), width_amount, box_widget)  # type: ignore[return-value]
         raise ColumnsError(f"invalid combination: width_type={width_type!r}, width_amount={width_amount!r}")
 
     def _invalidate(self) -> None:
@@ -638,7 +690,7 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
             return None
         return self.contents[self.focus_position][0]
 
-    def get_focus(self):
+    def get_focus(self) -> Widget | None:
         """
         Return the widget in focus, for backwards compatibility.
 
@@ -657,14 +709,15 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         return self.contents[self.focus_position][0]
 
     @property
-    def focus_position(self) -> int | None:
+    def focus_position(self) -> int:
         """
         index of child widget in focus.
         Raises :exc:`IndexError` if read when Columns is empty, or when set to an invalid index.
         """
-        if not self.contents:
-            raise IndexError("No focus_position, Columns is empty")
-        return self.contents.focus
+        if (focus := self.contents.focus) is not None:
+            return focus
+
+        raise IndexError("No focus_position, Columns is empty")
 
     @focus_position.setter
     def focus_position(self, position: int) -> None:
@@ -683,7 +736,7 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         self.contents.focus = position
 
     @property
-    def focus_col(self):
+    def focus_col(self) -> int:
         """
         A property for reading and setting the index of the column in
         focus.
@@ -701,7 +754,7 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         return self.focus_position
 
     @focus_col.setter
-    def focus_col(self, new_position) -> None:
+    def focus_col(self, new_position: int) -> None:
         warnings.warn(
             "only for backwards compatibility."
             "You may also use the new standard container property `focus_position` to get the focus."
@@ -724,12 +777,14 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
 
         widths = []
 
-        weighted = []
+        weighted: list[tuple[int | float, int]] = []
         shared = maxcol + self.dividechars
+
+        static_w: int
 
         for i, (w, (t, width, b)) in enumerate(self.contents):
             if t == WHSettings.GIVEN:
-                static_w = width
+                static_w = typing.cast("int", width)
             elif t == WHSettings.PACK:
                 if isinstance(w, Widget):
                     w_sizing = w.sizing()
@@ -767,7 +822,7 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
             widths.append(static_w)
             shared -= static_w + self.dividechars
             if t not in {WHSettings.GIVEN, WHSettings.PACK}:
-                weighted.append((width, i))
+                weighted.append((typing.cast("int | float", width), i))
 
         # drop columns on the left until we fit
         for i, width_ in enumerate(widths):
@@ -796,26 +851,27 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
     def _get_fixed_column_sizes(
         self,
         focus: bool = False,
-    ) -> tuple[tuple[int, ...], tuple[int, ...], tuple[tuple[int] | tuple[()], ...]]:
+    ) -> tuple[tuple[int, ...], tuple[int, ...], tuple[tuple[int, int] | tuple[int] | tuple[()], ...]]:
         """Get column widths, heights and render size parameters"""
         widths: dict[int, int] = {}
         heights: dict[int, int] = {}
         w_h_args: dict[int, tuple[int, int] | tuple[int] | tuple[()]] = {}
         box: list[int] = []
-        weighted: dict[int, list[tuple[Widget, int, bool, bool]]] = {}
-        weights: list[int] = []
-        weight_max_sizes: dict[int, int] = {}
+        weighted: dict[int | float, list[tuple[Widget, int, bool, bool]]] = {}
+        weights: list[int | float] = []
+        weight_max_sizes: dict[int | float, int] = {}
 
         for i, (widget, (size_kind, size_weight, is_box)) in enumerate(self.contents):
             w_sizing = widget.sizing()
             focused = focus and i == self.focus_position
 
             if size_kind == WHSettings.GIVEN:
+                size_weight = typing.cast("int", size_weight)
                 widths[i] = size_weight
                 if is_box:
                     box.append(i)
                 elif Sizing.FLOW in w_sizing:
-                    heights[i] = widget.rows((size_weight,), focused)
+                    heights[i] = widget.rows((size_weight,), focused)  # type: ignore[attr-defined]
                     w_h_args[i] = (size_weight,)
                 else:
                     raise ColumnsError(f"Unsupported combination of {size_kind} box={is_box!r} for {widget}")
@@ -826,7 +882,7 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
                 heights[i] = height
                 w_h_args[i] = ()
 
-            elif size_weight <= 0:
+            elif typing.cast("int | float", size_weight) <= 0:
                 widths[i] = 0
                 heights[i] = 1
                 if is_box:
@@ -839,6 +895,8 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
                     width, height = widget.pack((), focused)
                 else:
                     width = self.min_width
+
+                size_weight = typing.cast("int | float", size_weight)
 
                 weighted.setdefault(size_weight, []).append((widget, i, is_box, focused))
                 weights.append(size_weight)
@@ -856,7 +914,7 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
                     widths[i] = width
 
                     if not is_box:
-                        heights[i] = widget.rows((width,), focused)
+                        heights[i] = widget.rows((width,), focused)  # type: ignore[attr-defined]  # float or fail
                         w_h_args[i] = (width,)
                     else:
                         box.append(i)
@@ -907,7 +965,7 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
 
             elif Sizing.FLOW in w_sizing:
                 if width > 0:
-                    heights[i] = widget.rows((width,), focus and i == self.focus_position)
+                    heights[i] = widget.rows((width,), focus and i == self.focus_position)  # type: ignore[attr-defined]
                 else:
                     heights[i] = 0
                 w_h_args[i] = (width,)
@@ -1036,30 +1094,31 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         except Exception as exc:
             raise ValueError(self.contents, size, col, row) from exc
 
-        best = None
+        best: tuple[int, int, int, Widget] | None = None
         x = 0
         for i, (width, (w, _options)) in enumerate(zip(widths, self.contents)):
-            end = x + width
+            end: int = x + width
             if w.selectable():
-                if col != Align.RIGHT and (col == Align.LEFT or x > col) and best is None:
+                if col != Align.RIGHT and (col == Align.LEFT or x > col) and best is None:  # type: ignore[operator]
                     # no other choice
                     best = i, x, end, w
                     break
-                if col != Align.RIGHT and x > col and col - best[2] < x - col:
+                if col != Align.RIGHT and x > col and col - best[2] < x - col:  # type: ignore[operator]
                     # choose one on left
                     break
                 best = i, x, end, w
-                if col != Align.RIGHT and col < end:
+                if col != Align.RIGHT and col < end:  # type: ignore[operator]
                     # choose this one
                     break
             x = end + self.dividechars
 
         if best is None:
             return False
+
         i, x, end, w = best
         if hasattr(w, "move_cursor_to_coords"):
             if isinstance(col, int):
-                move_x = min(max(0, col - x), end - x - 1)
+                move_x: int | Literal["left", "right"] = min(max(0, col - x), end - x - 1)
             else:
                 move_x = col
 
@@ -1111,7 +1170,7 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
             return w.mouse_event(w_size, event, button, col - x, row, focus)
         return False
 
-    def get_pref_col(self, size: tuple[()] | tuple[int] | tuple[int, int]) -> int:
+    def get_pref_col(self, size: tuple[()] | tuple[int] | tuple[int, int]) -> Literal["left", "right"] | int | None:
         """Return the pref col from the column in focus."""
         widths, _, size_args = self.get_column_sizes(size, focus=True)
 
@@ -1172,7 +1231,10 @@ class Columns(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         if self._command_map[key] not in {Command.UP, Command.DOWN, Command.PAGE_UP, Command.PAGE_DOWN}:
             self.pref_col = None
         if w.selectable():
-            key = w.keypress(size_args[i], key)
+            if (processed := w.keypress(size_args[i], key)) is not None:
+                key = processed
+            else:
+                return None
 
         if self._command_map[key] not in {Command.LEFT, Command.RIGHT}:
             return key

--- a/urwid/widget/constants.py
+++ b/urwid/widget/constants.py
@@ -330,9 +330,9 @@ def normalize_height(
 
 @typing.overload
 def normalize_height(
-    height: Literal["flow", "pack", Sizing.FLOW, WHSettings.PACK],
+    height: Literal["flow", "pack", WHSettings.FLOW, WHSettings.PACK],
     err: type[BaseException],
-) -> tuple[Literal[Sizing.FLOW, WHSettings.PACK], None]: ...
+) -> tuple[Literal[WHSettings.FLOW, WHSettings.PACK], None]: ...
 
 
 @typing.overload
@@ -352,13 +352,13 @@ def normalize_height(
 def normalize_height(
     height: (
         int
-        | Literal["flow", "pack", Sizing.FLOW, WHSettings.PACK]
+        | Literal["flow", "pack", WHSettings.FLOW, WHSettings.PACK]
         | tuple[Literal["relative", WHSettings.RELATIVE], int]
         | tuple[Literal["weight", WHSettings.WEIGHT], int | float]
     ),
     err: type[BaseException],
 ) -> (
-    tuple[Literal[Sizing.FLOW, WHSettings.PACK], None]
+    tuple[Literal[WHSettings.FLOW, WHSettings.PACK], None]
     | tuple[Literal[WHSettings.RELATIVE, WHSettings.GIVEN], int]
     | tuple[Literal[WHSettings.WEIGHT], int | float]
 ):
@@ -366,8 +366,8 @@ def normalize_height(
     Split height into (height_type, height_amount).  Raise exception err
     if height isn't valid.
     """
-    if height == Sizing.FLOW:
-        return (Sizing.FLOW, None)
+    if height == WHSettings.FLOW:
+        return (WHSettings.FLOW, None)
 
     if height == WHSettings.PACK:
         return (WHSettings.PACK, None)

--- a/urwid/widget/container.py
+++ b/urwid/widget/container.py
@@ -7,9 +7,35 @@ import typing
 from .constants import Sizing, WHSettings
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Iterable, Iterator
+    from collections.abc import Iterable, Iterator, MutableSequence, Sequence
 
     from .widget import Widget
+
+    _KT_contra = typing.TypeVar("_KT_contra", contravariant=True)
+
+    class WidgetContainerProto(typing.Protocol[_KT_contra]):
+        def __getitem__(self, index: _KT_contra) -> tuple[Widget, typing.Unpack[tuple[typing.Any, ...]] | None]: ...
+
+    class WidgetContainerMixinProto(typing.Protocol[_KT_contra]):
+        @property
+        def contents(self) -> WidgetContainerProto[_KT_contra]: ...
+
+        @property
+        def focus_position(self) -> int | str: ...
+
+        @focus_position.setter
+        def focus_position(self, value: int | str) -> None: ...
+
+        @property
+        def base_widget(self) -> Widget: ...
+else:
+    _KT_contra = typing.TypeVar("_KT_contra", contravariant=True)
+
+    class WidgetContainerMixinProto(typing.Generic[_KT_contra]):
+        pass
+
+
+_WidgetParams = typing.TypeVar("_WidgetParams", bound=tuple[typing.Any, ...])
 
 
 # Ideally, we would like to use an IntFlag coupled with enum.auto().
@@ -55,12 +81,12 @@ class _ContainerElementSizingFlag(enum.IntEnum):
         return "|".join(sorted(mode.upper() for mode in sizing)) + render_string
 
 
-class WidgetContainerMixin:
+class WidgetContainerMixin(WidgetContainerMixinProto[_KT_contra]):
     """
     Mixin class for widget containers implementing common container methods
     """
 
-    def __getitem__(self, position) -> Widget:
+    def __getitem__(self, position: _KT_contra) -> Widget:
         """
         Container short-cut for self.contents[position][0].base_widget
         which means "give me the child widget at position without any
@@ -87,14 +113,13 @@ class WidgetContainerMixin:
             except IndexError:
                 return out
             out.append(p)
-            w = w.focus.base_widget
+            w = w.focus.base_widget  # type: ignore[assignment]
 
     def set_focus_path(self, positions: Iterable[int | str]) -> None:
         """
         Set the .focus_position property starting from this container
-        widget and proceeding along newly focused child widgets.  Any
-        failed assignment due do incompatible position types or invalid
-        positions will raise an IndexError.
+        widget and proceeding along newly focused child widgets.
+        Any failed assignment due to incompatible position types or invalid positions will raise an IndexError.
 
         This method may be used to restore a particular widget to the
         focus by passing in the value returned from an earlier call to
@@ -102,11 +127,11 @@ class WidgetContainerMixin:
 
         positions -- sequence of positions
         """
-        w: Widget = self
+        w: Widget = self  # type: ignore[assignment]
         for p in positions:
             if p != w.focus_position:
                 w.focus_position = p  # modifies w.focus
-            w = w.focus.base_widget  # type: ignore[assignment]
+            w = w.focus.base_widget  # type: ignore[union-attr]
 
     def get_focus_widgets(self) -> list[Widget]:
         """
@@ -120,14 +145,14 @@ class WidgetContainerMixin:
         """
         out = []
         w = self
-        while (w := w.base_widget.focus) is not None:
+        while (w := w.base_widget.focus) is not None:  # type: ignore[assignment]
             out.append(w)
 
         return out
 
     @property
     @abc.abstractmethod
-    def focus(self) -> Widget:
+    def focus(self) -> Widget | None:
         """
         Read-only property returning the child widget in focus for
         container widgets.  This default implementation
@@ -135,7 +160,7 @@ class WidgetContainerMixin:
         """
 
 
-class WidgetContainerListContentsMixin:
+class WidgetContainerListContentsMixin(typing.Generic[_WidgetParams]):
     """
     Mixin class for widget containers whose positions are indexes into
     a list available as self.contents.
@@ -160,11 +185,11 @@ class WidgetContainerListContentsMixin:
 
     @property
     @abc.abstractmethod
-    def contents(self) -> list[tuple[Widget, typing.Any]]:
+    def contents(self) -> MutableSequence[tuple[Widget, _WidgetParams]]:
         """The contents of container as a list of (widget, options)"""
 
     @contents.setter
-    def contents(self, new_contents: list[tuple[Widget, typing.Any]]) -> None:
+    def contents(self, new_contents: Sequence[tuple[Widget, _WidgetParams]]) -> None:
         """The contents of container as a list of (widget, options)"""
 
     @property

--- a/urwid/widget/frame.py
+++ b/urwid/widget/frame.py
@@ -4,6 +4,8 @@ import typing
 import warnings
 from collections.abc import MutableMapping
 
+from typing_extensions import Literal
+
 from urwid.canvas import CanvasCombine, CompositeCanvas
 from urwid.split_repr import remove_defaults
 from urwid.util import is_mouse_press
@@ -16,12 +18,9 @@ from .widget import Widget, WidgetError
 if typing.TYPE_CHECKING:
     from collections.abc import Iterator
 
-    from typing_extensions import Literal
-
-
-BodyWidget = typing.TypeVar("BodyWidget")
-HeaderWidget = typing.TypeVar("HeaderWidget")
-FooterWidget = typing.TypeVar("FooterWidget")
+BodyWidget = typing.TypeVar("BodyWidget", bound=Widget)
+HeaderWidget = typing.TypeVar("HeaderWidget", bound=Widget)
+FooterWidget = typing.TypeVar("FooterWidget", bound=Widget)
 
 
 class FrameError(WidgetError):
@@ -41,7 +40,11 @@ def _check_widget_subclass(widget: Widget | None) -> None:
         )
 
 
-class Frame(Widget, WidgetContainerMixin, typing.Generic[BodyWidget, HeaderWidget, FooterWidget]):
+class Frame(
+    Widget,
+    WidgetContainerMixin[Literal["header", "footer", "body"]],
+    typing.Generic[BodyWidget, HeaderWidget, FooterWidget],
+):
     """
     Frame widget is a box widget with optional header and footer
     flow widgets placed above and below the box widget.
@@ -57,8 +60,8 @@ class Frame(Widget, WidgetContainerMixin, typing.Generic[BodyWidget, HeaderWidge
     def __init__(
         self,
         body: BodyWidget,
-        header: HeaderWidget = None,
-        footer: FooterWidget = None,
+        header: HeaderWidget | None = None,
+        footer: FooterWidget | None = None,
         focus_part: Literal["header", "footer", "body"] | Widget = "body",
     ):
         """
@@ -108,18 +111,18 @@ class Frame(Widget, WidgetContainerMixin, typing.Generic[BodyWidget, HeaderWidge
         yield "focus_part", self.focus_part
 
     @property
-    def header(self) -> HeaderWidget:
+    def header(self) -> HeaderWidget | None:
         return self._header
 
     @header.setter
-    def header(self, header: HeaderWidget) -> None:
+    def header(self, header: HeaderWidget | None) -> None:
         _check_widget_subclass(header)
         self._header = header
         if header is None and self.focus_part == "header":
             self.focus_part = "body"
         self._invalidate()
 
-    def get_header(self) -> HeaderWidget:
+    def get_header(self) -> HeaderWidget | None:
         warnings.warn(
             f"method `{self.__class__.__name__}.get_header` is deprecated, "
             f"standard property `{self.__class__.__name__}.header` should be used instead."
@@ -129,7 +132,7 @@ class Frame(Widget, WidgetContainerMixin, typing.Generic[BodyWidget, HeaderWidge
         )
         return self.header
 
-    def set_header(self, header: HeaderWidget) -> None:
+    def set_header(self, header: HeaderWidget | None) -> None:
         warnings.warn(
             f"method `{self.__class__.__name__}.set_header` is deprecated, "
             f"standard property `{self.__class__.__name__}.header` should be used instead."
@@ -170,18 +173,18 @@ class Frame(Widget, WidgetContainerMixin, typing.Generic[BodyWidget, HeaderWidge
         self.body = body
 
     @property
-    def footer(self) -> FooterWidget:
+    def footer(self) -> FooterWidget | None:
         return self._footer
 
     @footer.setter
-    def footer(self, footer: FooterWidget) -> None:
+    def footer(self, footer: FooterWidget | None) -> None:
         _check_widget_subclass(footer)
         self._footer = footer
         if footer is None and self.focus_part == "footer":
             self.focus_part = "body"
         self._invalidate()
 
-    def get_footer(self) -> FooterWidget:
+    def get_footer(self) -> FooterWidget | None:
         warnings.warn(
             f"method `{self.__class__.__name__}.get_footer` is deprecated, "
             f"standard property `{self.__class__.__name__}.footer` should be used instead."
@@ -191,7 +194,7 @@ class Frame(Widget, WidgetContainerMixin, typing.Generic[BodyWidget, HeaderWidge
         )
         return self.footer
 
-    def set_footer(self, footer: FooterWidget) -> None:
+    def set_footer(self, footer: FooterWidget | None) -> None:
         warnings.warn(
             f"method `{self.__class__.__name__}.set_footer` is deprecated, "
             f"standard property `{self.__class__.__name__}.footer` should be used instead."
@@ -306,15 +309,15 @@ class Frame(Widget, WidgetContainerMixin, typing.Generic[BodyWidget, HeaderWidge
             def __len__(inner_self) -> int:
                 return len(inner_self.keys())
 
-            __getitem__ = self._contents__getitem__
-            __setitem__ = self._contents__setitem__
-            __delitem__ = self._contents__delitem__
+            __getitem__ = self._contents__getitem__  # type: ignore[assignment]
+            __setitem__ = self._contents__setitem__  # type: ignore[assignment]
+            __delitem__ = self._contents__delitem__  # type: ignore[assignment]
 
             def __iter__(inner_self) -> Iterator[str]:
                 yield from inner_self.keys()
 
             def __repr__(inner_self) -> str:
-                return f"<{inner_self.__class__.__name__}({dict(inner_self)}) for {self}>"
+                return f"<{inner_self.__class__.__name__}({dict(inner_self)}) for {self}>"  # type: ignore[misc]
 
             def __rich_repr__(inner_self) -> Iterator[tuple[str | None, typing.Any] | typing.Any]:
                 yield from inner_self.items()
@@ -327,7 +330,7 @@ class Frame(Widget, WidgetContainerMixin, typing.Generic[BodyWidget, HeaderWidge
             keys.append("header")
         if self._footer:
             keys.append("footer")
-        return keys
+        return keys  # type: ignore[return-value]
 
     @typing.overload
     def _contents__getitem__(self, key: Literal["body"]) -> tuple[BodyWidget, None]: ...

--- a/urwid/widget/grid_flow.py
+++ b/urwid/widget/grid_flow.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import typing
 import warnings
 
+from typing_extensions import Literal
+
 from urwid.split_repr import remove_defaults
 
 from .columns import Columns
@@ -17,7 +19,7 @@ from .widget import Widget, WidgetError, WidgetWarning, WidgetWrap
 if typing.TYPE_CHECKING:
     from collections.abc import Iterable, Iterator, Sequence
 
-    from typing_extensions import Literal
+    from urwid.canvas import Canvas
 
 
 class GridFlowError(WidgetError):
@@ -28,7 +30,11 @@ class GridFlowWarning(WidgetWarning):
     """GridFlow specific warning."""
 
 
-class GridFlow(WidgetWrap[Pile], WidgetContainerMixin, WidgetContainerListContentsMixin):
+class GridFlow(
+    WidgetWrap[typing.Union[Pile, Divider]],
+    WidgetContainerMixin[int],
+    WidgetContainerListContentsMixin[tuple[Literal[WHSettings.GIVEN], int]],
+):
     """
     The GridFlow widget is a flow widget that renders all the widgets it contains the same width,
     and it arranges them from left to right and top to bottom.
@@ -73,7 +79,8 @@ class GridFlow(WidgetWrap[Pile], WidgetContainerMixin, WidgetContainerListConten
         focus_position = max(focus_position, 0)
 
         self._contents: MonitoredFocusList[tuple[Widget, tuple[Literal[WHSettings.GIVEN], int]]] = MonitoredFocusList(
-            prepared_contents, focus=focus_position
+            prepared_contents,
+            focus=focus_position,
         )
         self._contents.set_modified_callback(self._invalidate)
         self._contents.set_focus_changed_callback(lambda f: self._invalidate())
@@ -82,8 +89,8 @@ class GridFlow(WidgetWrap[Pile], WidgetContainerMixin, WidgetContainerListConten
         self.h_sep = h_sep
         self.v_sep = v_sep
         self.align = align
-        self._cache_maxcol = self._get_maxcol(())
-        super().__init__(self.generate_display_widget((self._cache_maxcol,)))
+        self._cache_maxcol: int | None = self._get_maxcol(())
+        super().__init__(self.generate_display_widget((typing.cast("int", self._cache_maxcol),)))
 
     def _repr_words(self) -> list[str]:
         if len(self.contents) > 1:
@@ -134,7 +141,7 @@ class GridFlow(WidgetWrap[Pile], WidgetContainerMixin, WidgetContainerListConten
                 raise GridFlowError(f"added content invalid {item!r}").with_traceback(exc.__traceback__) from exc
 
     @property
-    def cells(self):
+    def cells(self) -> MonitoredList[Widget]:
         """
         A list of the widgets in this GridFlow
 
@@ -151,14 +158,14 @@ class GridFlow(WidgetWrap[Pile], WidgetContainerMixin, WidgetContainerListConten
         )
         ml = MonitoredList(w for w, t in self.contents)
 
-        def user_modified():
+        def user_modified() -> None:
             self.cells = ml
 
         ml.set_modified_callback(user_modified)
         return ml
 
     @cells.setter
-    def cells(self, widgets: Sequence[Widget]) -> None:
+    def cells(self, widgets: MonitoredList[Widget]) -> None:
         warnings.warn(
             "only for backwards compatibility."
             "You should use the new standard container property `contents` to modify GridFlow."
@@ -204,7 +211,7 @@ class GridFlow(WidgetWrap[Pile], WidgetContainerMixin, WidgetContainerListConten
         return self._contents
 
     @contents.setter
-    def contents(self, c):
+    def contents(self, c: Sequence[tuple[Widget, tuple[Literal[WHSettings.GIVEN], int]]]) -> None:
         self._contents[:] = c
 
     def options(
@@ -222,7 +229,7 @@ class GridFlow(WidgetWrap[Pile], WidgetContainerMixin, WidgetContainerListConten
             raise GridFlowError(f"invalid width_type: {width_type!r}")
         if width_amount is None:
             width_amount = self._cell_width
-        return (WHSettings(width_type), width_amount)
+        return (WHSettings.GIVEN, width_amount)
 
     def set_focus(self, cell: Widget | int) -> None:
         """
@@ -265,7 +272,7 @@ class GridFlow(WidgetWrap[Pile], WidgetContainerMixin, WidgetContainerListConten
             return None
         return self.contents[self.focus_position][0]
 
-    def get_focus(self):
+    def get_focus(self) -> Widget | None:
         """
         Return the widget in focus, for backwards compatibility.
 
@@ -284,7 +291,7 @@ class GridFlow(WidgetWrap[Pile], WidgetContainerMixin, WidgetContainerListConten
         return self.contents[self.focus_position][0]
 
     @property
-    def focus_cell(self):
+    def focus_cell(self) -> Widget | None:
         warnings.warn(
             "only for backwards compatibility."
             "You may also use the new standard container property"
@@ -312,14 +319,15 @@ class GridFlow(WidgetWrap[Pile], WidgetContainerMixin, WidgetContainerListConten
         raise ValueError(f"Widget not found in GridFlow contents: {cell!r}")
 
     @property
-    def focus_position(self) -> int | None:
+    def focus_position(self) -> int:
         """
         index of child widget in focus.
         Raises :exc:`IndexError` if read when GridFlow is empty, or when set to an invalid index.
         """
-        if not self.contents:
-            raise IndexError("No focus_position, GridFlow is empty")
-        return self.contents.focus
+        if (focus := self.contents.focus) is not None:
+            return focus
+
+        raise IndexError("No focus_position, GridFlow is empty")
 
     @focus_position.setter
     def focus_position(self, position: int) -> None:
@@ -481,7 +489,7 @@ class GridFlow(WidgetWrap[Pile], WidgetContainerMixin, WidgetContainerListConten
         self,
         size: tuple[int] | tuple[()],  # type: ignore[override]
         focus: bool = False,
-    ):
+    ) -> Canvas:
         self.get_display_widget(size)
         return super().render(size, focus)
 
@@ -490,7 +498,7 @@ class GridFlow(WidgetWrap[Pile], WidgetContainerMixin, WidgetContainerListConten
         self.get_display_widget(size)
         return super().get_cursor_coords(size)
 
-    def move_cursor_to_coords(self, size: tuple[int] | tuple[()], col: int, row: int):
+    def move_cursor_to_coords(self, size: tuple[int] | tuple[()], col: int, row: int) -> bool:
         """Set the widget in focus based on the col + row."""
         self.get_display_widget(size)
         rval = super().move_cursor_to_coords(size, col, row)
@@ -511,7 +519,7 @@ class GridFlow(WidgetWrap[Pile], WidgetContainerMixin, WidgetContainerListConten
         self._set_focus_from_display_widget()
         return True  # at a minimum we adjusted our focus
 
-    def get_pref_col(self, size: tuple[int] | tuple[()]):
+    def get_pref_col(self, size: tuple[int] | tuple[()]) -> int:
         """Return pref col from display widget."""
         self.get_display_widget(size)
         return super().get_pref_col(size)

--- a/urwid/widget/monitored_list.py
+++ b/urwid/widget/monitored_list.py
@@ -282,7 +282,10 @@ class MonitoredFocusList(MonitoredList[_T], typing.Generic[_T]):
     ) -> int | None:
         return None
 
-    def set_validate_contents_modified(self, callback: Callable[[tuple[int, int, int], Collection[_T]], int | None]):
+    def set_validate_contents_modified(
+        self,
+        callback: Callable[[tuple[int, int, int], Collection[_T]], int | None],
+    ) -> None:
         """
         Assign a callback function to handle validating changes to the list.
         This may raise an exception if the change should not be performed.

--- a/urwid/widget/overlay.py
+++ b/urwid/widget/overlay.py
@@ -4,6 +4,8 @@ import typing
 import warnings
 from collections.abc import MutableSequence
 
+from typing_extensions import Literal
+
 from urwid.canvas import CanvasOverlay, CompositeCanvas
 from urwid.split_repr import remove_defaults
 
@@ -30,8 +32,6 @@ from .widget import Widget, WidgetError, WidgetWarning
 
 if typing.TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
-
-    from typing_extensions import Literal
 
 
 TopWidget = typing.TypeVar("TopWidget", bound=Widget)
@@ -73,7 +73,12 @@ class OverlayOptions(typing.NamedTuple):
     bottom: int
 
 
-class Overlay(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin, typing.Generic[TopWidget, BottomWidget]):
+class Overlay(
+    Widget,
+    WidgetContainerMixin[Literal[0, 1]],
+    WidgetContainerListContentsMixin[OverlayOptions],
+    typing.Generic[TopWidget, BottomWidget],
+):
     """Overlay contains two widgets and renders one on top of the other.
 
     Top widget can be Box, Flow or Fixed.
@@ -422,14 +427,14 @@ class Overlay(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin, ty
         See also :meth:`.set_overlay_parameters`
         """
         if align_type in {Align.LEFT, Align.CENTER, Align.RIGHT}:
-            align = Align(align_type)
+            align: Align | Literal[WHSettings.RELATIVE] = Align(align_type)
         elif align_type == WHSettings.RELATIVE:
             align = WHSettings.RELATIVE
         else:
             raise ValueError(f"Unknown alignment type {align_type!r}")
 
         if valign_type in {VAlign.TOP, VAlign.MIDDLE, VAlign.BOTTOM}:
-            valign = VAlign(valign_type)
+            valign: VAlign | Literal[WHSettings.RELATIVE] = VAlign(valign_type)
         elif valign_type == WHSettings.RELATIVE:
             valign = WHSettings.RELATIVE
         else:
@@ -495,10 +500,10 @@ class Overlay(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin, ty
         if isinstance(width, tuple):
             if width[0] == "fixed left":
                 left = width[1]
-                width = RELATIVE_100
+                width = RELATIVE_100  # type: ignore[assignment]
             elif width[0] == "fixed right":
                 right = width[1]
-                width = RELATIVE_100
+                width = RELATIVE_100  # type: ignore[assignment]
 
         if isinstance(valign, tuple):
             if valign[0] == "fixed top":
@@ -519,10 +524,10 @@ class Overlay(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin, ty
         if isinstance(height, tuple):
             if height[0] == "fixed bottom":
                 bottom = height[1]
-                height = RELATIVE_100
+                height = RELATIVE_100  # type: ignore[assignment]
             elif height[0] == "fixed top":
                 top = height[1]
-                height = RELATIVE_100
+                height = RELATIVE_100  # type: ignore[assignment]
 
         if width is None:  # more obsolete values accepted
             width = WHSettings.PACK
@@ -590,17 +595,17 @@ class Overlay(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin, ty
         """
         return 1
 
-    @focus_position.setter
-    def focus_position(self, position: int) -> None:
+    @focus_position.setter  # type: ignore[override]
+    def focus_position(self, position: Literal[1]) -> None:
         """
-        Set the widget in focus.  Currently only position 0 is accepted.
+        Set the widget in focus.  Currently only position 1 is accepted.
 
         position -- index of child widget to be made focus
         """
         if position != 1:
             raise IndexError(f"Overlay widget focus_position currently must always be set to 1, not {position}")
 
-    @property
+    @property  # type: ignore[override]
     def contents(self) -> MutableSequence[tuple[TopWidget | BottomWidget, OverlayOptions]]:
         """
         a list-like object similar to::
@@ -637,8 +642,8 @@ class Overlay(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin, ty
             def __len__(inner_self) -> int:
                 return 2
 
-            __getitem__ = self._contents__getitem__
-            __setitem__ = self._contents__setitem__
+            __getitem__ = self._contents__getitem__  # type: ignore[assignment]
+            __setitem__ = self._contents__setitem__  # type: ignore[assignment]
 
             def __delitem__(self, index: int | slice) -> typing.NoReturn:
                 raise TypeError("OverlayContents is fixed-sized sequence")
@@ -653,13 +658,13 @@ class Overlay(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin, ty
                 for val in inner_self:
                     yield None, val
 
-            def __iter__(inner_self) -> Iterator[tuple[Widget, OverlayOptions]]:
+            def __iter__(inner_self) -> Iterator[tuple[TopWidget | BottomWidget, OverlayOptions]]:
                 for idx in range(2):
-                    yield inner_self[idx]
+                    yield inner_self[idx]  # type: ignore[arg-type]
 
         return OverlayContents()
 
-    @contents.setter
+    @contents.setter  # type: ignore[override]
     def contents(self, new_contents: Sequence[tuple[TopWidget | BottomWidget, OverlayOptions]]) -> None:
         if len(new_contents) != 2:
             raise ValueError("Contents length for overlay should be only 2")
@@ -695,6 +700,20 @@ class Overlay(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin, ty
             )
         raise IndexError(f"Overlay.contents has no position {index!r}")
 
+    @typing.overload
+    def _contents__setitem__(
+        self,
+        index: Literal[0],
+        value: tuple[BottomWidget, OverlayOptions],
+    ) -> None: ...
+
+    @typing.overload
+    def _contents__setitem__(
+        self,
+        index: Literal[1],
+        value: tuple[TopWidget, OverlayOptions],
+    ) -> None: ...
+
     def _contents__setitem__(
         self,
         index: Literal[0, 1],
@@ -707,7 +726,7 @@ class Overlay(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin, ty
         if index == 0:
             if value_options != self._DEFAULT_BOTTOM_OPTIONS:
                 raise OverlayError(f"bottom_options must be set to {self._DEFAULT_BOTTOM_OPTIONS!r}")
-            self.bottom_w = value_w
+            self.bottom_w = value_w  # type: ignore[assignment]
         elif index == 1:
             try:
                 (

--- a/urwid/widget/pile.py
+++ b/urwid/widget/pile.py
@@ -4,6 +4,8 @@ import typing
 import warnings
 from itertools import chain, repeat
 
+from typing_extensions import Literal
+
 from urwid.canvas import CanvasCombine, CompositeCanvas, SolidCanvas
 from urwid.command_map import Command
 from urwid.split_repr import remove_defaults
@@ -15,9 +17,7 @@ from .monitored_list import MonitoredFocusList, MonitoredList
 from .widget import Widget, WidgetError, WidgetWarning
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Iterable, Iterator, Sequence
-
-    from typing_extensions import Literal
+    from collections.abc import Collection, Iterable, Iterator, Sequence
 
 
 class PileError(WidgetError):
@@ -28,7 +28,17 @@ class PileWarning(WidgetWarning):
     """Pile related warnings."""
 
 
-class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
+class Pile(
+    Widget,
+    WidgetContainerMixin[int],
+    WidgetContainerListContentsMixin[
+        typing.Union[
+            tuple[Literal[WHSettings.PACK], None],
+            tuple[Literal[WHSettings.GIVEN], int],
+            tuple[Literal[WHSettings.WEIGHT], typing.Union[int, float]],
+        ]
+    ],
+):
     """
     A pile of widgets stacked vertically from top to bottom
     """
@@ -109,7 +119,7 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         for idx, (widget, (size_kind, _size_weight)) in enumerate(self.contents):
             w_sizing = widget.sizing()
 
-            flag = _ContainerElementSizingFlag.NONE
+            flag: int = _ContainerElementSizingFlag.NONE
 
             if size_kind == WHSettings.WEIGHT:
                 flag |= _ContainerElementSizingFlag.WH_WEIGHT
@@ -208,18 +218,24 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         self._contents.set_validate_contents_modified(self._validate_contents_modified)
 
         for i, original in enumerate(widget_list):
-            w = original
-            if not isinstance(w, tuple):
+            if not isinstance(original, tuple):
+                w = original
                 self.contents.append((w, (WHSettings.WEIGHT, 1)))
-            elif w[0] in {Sizing.FLOW, WHSettings.PACK}:  # 'pack' used to be called 'flow'
-                f, w = w
-                self.contents.append((w, (WHSettings.PACK, None)))
-            elif len(w) == 2 or w[0] in {Sizing.FIXED, WHSettings.GIVEN}:  # backwards compatibility
-                height, w = w[-2:]
-                self.contents.append((w, (WHSettings.GIVEN, height)))
-            elif w[0] == WHSettings.WEIGHT:
-                f, height, w = w
-                self.contents.append((w, (f, height)))
+            elif len(original) == 2:
+                if original[0] in {Sizing.FLOW, WHSettings.PACK}:  # 'pack' used to be called 'flow'
+                    w = original[-1]
+                    self.contents.append((w, (WHSettings.PACK, None)))
+                else:
+                    height, w = original
+                    self.contents.append((w, (WHSettings.GIVEN, typing.cast("int", height))))
+            elif len(original) == 3:
+                settings, height, w = original  # type: ignore[assignment]
+                if settings in {Sizing.FIXED, WHSettings.GIVEN}:  # backwards compatibility
+                    self.contents.append((w, (WHSettings.GIVEN, typing.cast("int", height))))
+                elif settings == WHSettings.WEIGHT:
+                    self.contents.append((w, (WHSettings.WEIGHT, typing.cast("int | float", height))))
+                else:
+                    raise PileError(f"initial widget list item invalid {original!r}")
             else:
                 raise PileError(f"initial widget list item invalid {original!r}")
             if focus_item is None and w.selectable():
@@ -255,14 +271,14 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
 
         for w_instance, (sizing, amount) in self._contents:
             if sizing == WHSettings.GIVEN:
-                widget_list.append((amount, w_instance))
+                widget_list.append((typing.cast("int", amount), w_instance))
             elif sizing == WHSettings.PACK:
                 widget_list.append((WHSettings.PACK, w_instance))
             elif sizing == WHSettings.WEIGHT:
                 if amount == 1:
                     widget_list.append(w_instance)
                 else:
-                    widget_list.append((WHSettings.WEIGHT, amount, w_instance))
+                    widget_list.append((WHSettings.WEIGHT, typing.cast("int | float", amount), w_instance))
 
         yield "widget_list", widget_list
         yield "focus_item", self.focus_position if self._contents else None
@@ -275,7 +291,18 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         self._selectable = any(w.selectable() for w, o in self.contents)
         self._invalidate()
 
-    def _validate_contents_modified(self, slc, new_items) -> None:
+    def _validate_contents_modified(
+        self,
+        slc: tuple[int, int, int],
+        new_items: Collection[
+            tuple[
+                Widget,
+                tuple[Literal[WHSettings.PACK], None]
+                | tuple[Literal[WHSettings.GIVEN], int]
+                | tuple[Literal[WHSettings.WEIGHT], int | float],
+            ]
+        ],
+    ) -> None:
         invalid_items: list[tuple[Widget, tuple[typing.Any, typing.Any]]] = []
         try:
             for item in new_items:
@@ -295,7 +322,7 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
             raise PileError(f"added content invalid: {invalid_items!r}")
 
     @property
-    def widget_list(self):
+    def widget_list(self) -> MonitoredList[Widget]:
         """
         A list of the widgets in this Pile
 
@@ -310,14 +337,14 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         )
         ml = MonitoredList(w for w, t in self.contents)
 
-        def user_modified():
+        def user_modified() -> None:
             self.widget_list = ml
 
         ml.set_modified_callback(user_modified)
         return ml
 
     @widget_list.setter
-    def widget_list(self, widgets):
+    def widget_list(self, widgets: MonitoredList[Widget]) -> None:
         focus_position = self.focus_position
         self.contents = [
             (new, options)
@@ -331,7 +358,13 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
             self.focus_position = focus_position
 
     @property
-    def item_types(self):
+    def item_types(
+        self,
+    ) -> MonitoredList[
+        tuple[Literal[Sizing.FIXED], int]
+        | tuple[Literal[Sizing.FLOW], None]
+        | tuple[Literal[WHSettings.WEIGHT], int | float]
+    ]:
         """
         A list of the options values for widgets in this Pile.
 
@@ -346,18 +379,31 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         )
         ml = MonitoredList(
             # return the old item type names
-            ({WHSettings.GIVEN: Sizing.FIXED, WHSettings.PACK: Sizing.FLOW}.get(f, f), height)
+            (
+                {
+                    WHSettings.GIVEN: Sizing.FIXED,
+                    WHSettings.PACK: Sizing.FLOW,
+                }.get(f, f),
+                height,
+            )
             for w, (f, height) in self.contents
         )
 
-        def user_modified():
-            self.item_types = ml
+        def user_modified() -> None:
+            self.item_types = ml  # type: ignore[assignment]
 
         ml.set_modified_callback(user_modified)
-        return ml
+        return ml  # type: ignore[return-value]
 
     @item_types.setter
-    def item_types(self, item_types):
+    def item_types(
+        self,
+        item_types: MonitoredList[
+            tuple[Literal[Sizing.FIXED, WHSettings.GIVEN], int]
+            | tuple[Literal[Sizing.FLOW, WHSettings.PACK], None]
+            | tuple[Literal[WHSettings.WEIGHT], int | float]
+        ],
+    ) -> None:
         warnings.warn(
             "only for backwards compatibility. You should use the new standard container property `contents`."
             "API will be removed in version 5.0.",
@@ -366,7 +412,16 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         )
         focus_position = self.focus_position
         self.contents = [
-            (w, ({Sizing.FIXED: WHSettings.GIVEN, Sizing.FLOW: WHSettings.PACK}.get(new_t, new_t), new_height))
+            (  # type: ignore[misc]
+                w,
+                (
+                    {
+                        Sizing.FIXED: WHSettings.GIVEN,
+                        Sizing.FLOW: WHSettings.PACK,
+                    }.get(new_t, new_t),  # type: ignore[arg-type]  # normalisation from legacy
+                    new_height,
+                ),
+            )
             for ((new_t, new_height), (w, options)) in zip(item_types, self.contents)
         ]
         if focus_position < len(item_types):
@@ -445,7 +500,7 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         if height_type == WHSettings.PACK:
             return (WHSettings.PACK, None)
         if height_type in {WHSettings.GIVEN, WHSettings.WEIGHT} and height_amount is not None:
-            return (height_type, height_amount)
+            return (height_type, height_amount)  # type: ignore[return-value]
         raise PileError(f"invalid combination: height_type={height_type!r}, height_amount={height_amount!r}")
 
     @property
@@ -516,9 +571,10 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         index of child widget in focus.
         Raises :exc:`IndexError` if read when Pile is empty, or when set to an invalid index.
         """
-        if not self.contents:
-            raise IndexError("No focus_position, Pile is empty")
-        return self.contents.focus
+        if (focus := self.contents.focus) is not None:
+            return focus
+
+        raise IndexError("No focus_position, Pile is empty")
 
     @focus_position.setter
     def focus_position(self, position: int) -> None:
@@ -574,7 +630,7 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         maxcol = size[0]
 
         if f == WHSettings.GIVEN:
-            return (maxcol, height)
+            return (maxcol, typing.cast("int", height))
 
         if f == WHSettings.WEIGHT:
             if len(size) == 2:
@@ -589,7 +645,7 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
     def _get_fixed_rows_sizes(
         self,
         focus: bool = False,
-    ) -> tuple[tuple[int, ...], tuple[int, ...], tuple[tuple[int] | tuple[()], ...]]:
+    ) -> tuple[tuple[int, ...], tuple[int, ...], tuple[tuple[int, int] | tuple[int] | tuple[()], ...]]:
         """Get rows widths, heights and render size parameters
 
         Fixed case expect widget sizes calculation with several cycles for unknown height cases.
@@ -603,9 +659,9 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
 
         flow: list[tuple[Widget, int, bool]] = []
         box: list[int] = []
-        weighted: dict[int, list[int]] = {}
-        weights: list[int] = []
-        weight_max_sizes: dict[int, int] = {}
+        weighted: dict[int | float, list[int]] = {}
+        weights: list[int | float] = []
+        weight_max_sizes: dict[int | float, int] = {}
 
         for idx, (widget, (size_kind, size_weight)) in enumerate(self.contents):
             w_sizing = widget.sizing()
@@ -621,25 +677,26 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
                     raise PileError(f"Unsupported sizing {w_sizing} for {size_kind.upper()}")
 
             elif size_kind == WHSettings.GIVEN:
-                heights[idx] = size_weight
+                heights[idx] = typing.cast("int", size_weight)
                 if Sizing.BOX in w_sizing:
                     box.append(idx)
                 else:
                     raise PileError(f"Unsupported sizing {w_sizing} for {size_kind.upper()}")
 
-            elif size_weight <= 0:
+            elif typing.cast("int | float", size_weight) <= 0:
                 widths[idx] = 0
                 heights[idx] = 0
                 if Sizing.FLOW in w_sizing:
                     w_h_args[idx] = (0,)
                 else:
-                    w_sizing[idx] = (0, 0)
+                    w_h_args[idx] = (0, 0)
 
             elif Sizing.FIXED in w_sizing and w_sizing & {Sizing.BOX, Sizing.FLOW}:
                 width, height = widget.pack((), focused)
                 widths[idx] = width  # We're fitting everything in case of FIXED
 
                 if Sizing.BOX in w_sizing:
+                    size_weight = typing.cast("int | float", size_weight)
                     weighted.setdefault(size_weight, []).append(idx)
                     weights.append(size_weight)
 
@@ -663,7 +720,7 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
 
         for widget, idx, focused in flow:
             widths[idx] = max_width
-            heights[idx] = widget.rows((max_width,), focused)
+            heights[idx] = widget.rows((max_width,), focused)  # type: ignore[attr-defined]  # or flow or fail
             w_h_args[idx] = (max_width,)
 
         if weight_max_sizes:
@@ -689,7 +746,7 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         self,
         size: tuple[int],
         focus: bool = False,
-    ) -> tuple[tuple[int, ...], tuple[int, ...], tuple[tuple[int] | tuple[()], ...]]:
+    ) -> tuple[tuple[int, ...], tuple[int, ...], tuple[tuple[int, int] | tuple[int] | tuple[()], ...]]:
         """Get rows widths, heights and render size parameters
 
         Flow case is the simplest one: minimum cycles in the logic and no widgets manipulation.
@@ -714,10 +771,11 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
             focused = focus and i == focus_position
 
             if f == WHSettings.GIVEN:
+                height = typing.cast("int", height)
                 heights.append(height)
                 w_h_args.append((maxcol, height))
             elif Sizing.FLOW in w_sizing:
-                heights.append(w.rows((maxcol,), focus=focused))
+                heights.append(w.rows((maxcol,), focus=focused))  # type: ignore[attr-defined]  # flow
                 w_h_args.append((maxcol,))
             elif Sizing.FIXED in w_sizing and f == WHSettings.PACK:
                 heights.append(w.pack((), focused)[1])
@@ -729,7 +787,7 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
                     PileWarning,
                     stacklevel=3,
                 )
-                heights.append(w.rows((maxcol,), focus=focused))
+                heights.append(w.rows((maxcol,), focus=focused))  # type: ignore[attr-defined]  # or flow or fail
                 w_h_args.append((maxcol,))
 
         return (widths, tuple(heights), tuple(w_h_args))
@@ -753,7 +811,7 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
 
         widths: tuple[int, ...] = (maxcol,) * len(self.contents)
         heights: dict[int, int] = {}
-        weighted: dict[int, int] = {}
+        weighted: dict[int, int | float] = {}
         w_h_args: dict[int, tuple[int, int] | tuple[int] | tuple[()]] = {}
         focus_position = self.focus_position
 
@@ -767,6 +825,7 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
             focused = focus and i == focus_position
 
             if f == WHSettings.GIVEN:
+                height = typing.cast("int", height)
                 heights[i] = height
                 w_h_args[i] = (maxcol, height)
                 remaining -= height
@@ -810,7 +869,7 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
             # Try to move to the center
             offset = len(before) - len(after)
             if not offset:
-                indexes = (element for pair in zip(after[::-1], before) for element in pair)
+                indexes: Iterable[int] = (element for pair in zip(after[::-1], before) for element in pair)
             elif offset > 0:
                 indexes = (
                     *before[:offset],
@@ -883,6 +942,9 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
                 combinelist.append((canv, i, item_focus))
 
         if not combinelist:
+            if not size:
+                raise ValueError("size must be provided when no contents are present")
+
             return SolidCanvas(" ", size[0], (*size[1:], 0)[0])
 
         out = CanvasCombine(combinelist)
@@ -896,17 +958,17 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         """Return the cursor coordinates of the focus widget."""
         if not self.selectable():
             return None
-        if not hasattr(self.focus, "get_cursor_coords"):
-            return None
 
-        i = self.focus_position
-        _widths, heights, size_args = self.get_rows_sizes(size, focus=True)
-        if (coords := self.focus.get_cursor_coords(size_args[i])) is not None:
-            x, y = coords
-            if i > 0:
-                y += sum(heights[:i])
+        if (get_cursor_coords := getattr(self.focus, "get_cursor_coords", None)) is not None:
+            i = self.focus_position
+            _widths, heights, size_args = self.get_rows_sizes(size, focus=True)
 
-            return x, y
+            if (coords := get_cursor_coords(size_args[i])) is not None:  # pylint: disable=not-callable
+                x, y = coords
+                if i > 0:
+                    y += sum(heights[:i])
+
+                return x, y
 
         return None
 
@@ -924,7 +986,10 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
         i = self.focus_position
         _widths, heights, size_args = self.get_rows_sizes(size, focus=self.selectable())
         if self.selectable():
-            key = self.focus.keypress(size_args[i], key)
+            if (processed := self.focus.keypress(size_args[i], key)) is not None:
+                key = processed
+            else:
+                return None
             if self._command_map[key] not in {Command.UP, Command.DOWN}:
                 return key
 
@@ -958,11 +1023,9 @@ class Pile(Widget, WidgetContainerMixin, WidgetContainerListContentsMixin):
     def _update_pref_col_from_focus(self, w_size: tuple[()] | tuple[int] | tuple[int, int]) -> None:
         """Update self.pref_col from the focus widget."""
 
-        if not hasattr(self.focus, "get_pref_col"):
-            return
-
-        if (pref_col := self.focus.get_pref_col(w_size)) is not None:
-            self.pref_col = pref_col
+        if (get_pref_col := getattr(self.focus, "get_pref_col", None)) is not None:  # noqa: SIM102
+            if (pref_col := get_pref_col(w_size)) is not None:  # pylint: disable=not-callable
+                self.pref_col = pref_col
 
     def move_cursor_to_coords(
         self,

--- a/urwid/widget/popup.py
+++ b/urwid/widget/popup.py
@@ -142,7 +142,7 @@ class PopUpTarget(WidgetDecoration[WrappedWidget]):
         self._update_overlay(size, True)
         return self._current_widget.keypress(size, key)
 
-    def move_cursor_to_coords(self, size: tuple[int, int], x: int, y: int):
+    def move_cursor_to_coords(self, size: tuple[int, int], x: int, y: int) -> bool:
         self._update_overlay(size, True)
         return self._current_widget.move_cursor_to_coords(size, x, y)
 


### PR DESCRIPTION
* urwid.widget.columns
* urwid.widget.pile
* urwid.widget.frame
* urwid.widget.overlay
* urwid.widget.grid_flow

Move `typing_extensions` to real dependencies back due to python 3.9

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

Partial #1146 