### PR TITLE
Typing: cover generic cases without extended fixes

### DIFF
--- a/urwid/graphics.py
+++ b/urwid/graphics.py
@@ -20,6 +20,8 @@
 
 from __future__ import annotations
 
+import typing
+
 from urwid.display import AttrSpec
 from urwid.widget import (
     BarGraph,
@@ -35,6 +37,9 @@ from urwid.widget import (
     fixed_size,
     scale_bar_values,
 )
+
+if typing.TYPE_CHECKING:
+    from urwid import canvas
 
 __all__ = (
     "BarGraph",
@@ -61,7 +66,7 @@ class PythonLogo(Widget):
         yel = AttrSpec("yellow", "default")
         width = 17
         # fmt: off
-        self._canvas = Text(
+        self._canvas: canvas.TextCanvas = Text(
             [
                 (blu, "     ______\n"),
                 (blu, "   _|_o__  |"), (yel, "__\n"),
@@ -72,13 +77,13 @@ class PythonLogo(Widget):
         ).render((width,))
         # fmt: on
 
-    def pack(self, size: tuple[()] | None = None, focus: bool = False):
+    def pack(self, size: tuple[()] | None = None, focus: bool = False) -> tuple[int, int]:  # type: ignore[override]
         """
         Return the size from our pre-rendered canvas.
         """
         return self._canvas.cols(), self._canvas.rows()
 
-    def render(self, size: tuple[()], focus: bool = False):
+    def render(self, size: tuple[()], focus: bool = False) -> canvas.TextCanvas:  # type: ignore[override]
         """
         Return the pre-rendered canvas.
         """
@@ -86,7 +91,7 @@ class PythonLogo(Widget):
         return self._canvas
 
 
-def _test():
+def _test() -> None:
     import doctest
 
     doctest.testmod()

--- a/urwid/numedit.py
+++ b/urwid/numedit.py
@@ -21,15 +21,17 @@
 
 from __future__ import annotations
 
+import decimal
 import re
+import typing
 import warnings
-from decimal import Decimal
-from typing import TYPE_CHECKING
 
 from urwid import Edit
 
-if TYPE_CHECKING:
-    from collections.abc import Container
+if typing.TYPE_CHECKING:
+    from collections.abc import Container, Hashable
+
+    _TagMarkup = typing.Union[str, tuple[Hashable, typing.Union[str]], list["_TagMarkup"]]
 
 
 class NumEdit(Edit):
@@ -48,7 +50,7 @@ class NumEdit(Edit):
     def __init__(
         self,
         allowed: Container[str],
-        caption,
+        caption: _TagMarkup,
         default: str,
         trimLeadingZeros: bool | None = None,
         *,
@@ -131,8 +133,8 @@ class IntegerEdit(NumEdit):
 
     def __init__(
         self,
-        caption="",
-        default: int | str | Decimal | None = None,
+        caption: _TagMarkup = "",
+        default: int | str | decimal.Decimal | None = None,
         base: int = 10,
         *,
         allow_negative: bool = False,
@@ -159,7 +161,7 @@ class IntegerEdit(NumEdit):
         >>> e.keypress(size, "end")
         >>> e.keypress(size, "1")
         >>> assert e.edit_text == "10101"
-        >>> assert e.value() == Decimal("21")
+        >>> assert e.value() == decimal.Decimal("21")
         >>> # HEX
         >>> e, size = IntegerEdit("", "10", base=16), (10,)
         >>> e.keypress(size, "end")
@@ -171,7 +173,7 @@ class IntegerEdit(NumEdit):
         >>> # keep leading 0's when not base 10
         >>> e, size = IntegerEdit("", "10FF", base=16), (10,)
         >>> assert e.edit_text == "10FF"
-        >>> assert e.value() == Decimal("4351")
+        >>> assert e.value() == decimal.Decimal("4351")
         >>> e.keypress(size, "home")
         >>> e.keypress(size, "delete")
         >>> e.keypress(size, "0")
@@ -186,7 +188,7 @@ class IntegerEdit(NumEdit):
         Traceback (most recent call last):
             ...
         ValueError: default: Only 'str', 'int', 'long' or Decimal input allowed
-        >>> e, size = IntegerEdit("", Decimal("10.0")), (10,)
+        >>> e, size = IntegerEdit("", decimal.Decimal("10.0")), (10,)
         Traceback (most recent call last):
             ...
         ValueError: not an 'integer Decimal' instance
@@ -195,7 +197,7 @@ class IntegerEdit(NumEdit):
         val = ""
         allowed_chars = self.ALLOWED[: self.base]
         if default is not None:
-            if not isinstance(default, (int, str, Decimal)):
+            if not isinstance(default, (int, str, decimal.Decimal)):
                 raise ValueError("default: Only 'str', 'int' or Decimal input allowed")
 
             # convert to a long first, this will raise a ValueError
@@ -206,7 +208,7 @@ class IntegerEdit(NumEdit):
                 if not re.match(validation_re, str(default), re.IGNORECASE):
                     raise ValueError(f"invalid value: {default} for base {base}")
 
-            elif isinstance(default, Decimal) and default.as_tuple()[2] != 0:
+            elif isinstance(default, decimal.Decimal) and default.as_tuple()[2] != 0:
                 # a Decimal instance with no fractional part
                 raise ValueError("not an 'integer Decimal' instance")
 
@@ -221,7 +223,7 @@ class IntegerEdit(NumEdit):
             allow_negative=allow_negative,
         )
 
-    def value(self) -> Decimal | None:
+    def value(self) -> decimal.Decimal | None:
         """
         Return the numeric value of self.edit_text.
 
@@ -231,7 +233,7 @@ class IntegerEdit(NumEdit):
         >>> assert e.value() == 51
         """
         if self.edit_text:
-            return Decimal(int(self.edit_text, self.base))
+            return decimal.Decimal(int(self.edit_text, self.base))
 
         return None
 
@@ -255,8 +257,8 @@ class FloatEdit(NumEdit):
 
     def __init__(
         self,
-        caption="",
-        default: str | int | Decimal | None = None,
+        caption: _TagMarkup = "",
+        default: str | int | decimal.Decimal | None = None,
         preserveSignificance: bool | None = None,
         decimalSeparator: str | None = None,
         *,
@@ -285,7 +287,7 @@ class FloatEdit(NumEdit):
         >>> e.keypress(size, ".")
         >>> e.keypress(size, "5")
         >>> e.keypress(size, "1")
-        >>> assert e.value() == Decimal("51.51"), e.value()
+        >>> assert e.value() == decimal.Decimal("51.51"), e.value()
         >>> e, size = FloatEdit(decimal_separator=":"), (10,)
         Traceback (most recent call last):
             ...
@@ -302,11 +304,11 @@ class FloatEdit(NumEdit):
         >>> e.keypress(size, "backspace")
         >>> e.keypress(size, "backspace")
         >>> assert e.edit_text == "3.14"
-        >>> assert e.value() == Decimal("3.1400")
+        >>> assert e.value() == decimal.Decimal("3.1400")
         >>> e.keypress(size, "1")
         >>> e.keypress(size, "5")
         >>> e.keypress(size, "9")
-        >>> assert e.value() == Decimal("3.1416"), e.value()
+        >>> assert e.value() == decimal.Decimal("3.1416"), e.value()
         >>> e, size = FloatEdit("", ""), (10,)
         >>> assert e.value() is None
         >>> e, size = FloatEdit("", 10.0), (10,)
@@ -337,27 +339,27 @@ class FloatEdit(NumEdit):
 
         val = ""
         if default is not None and default != "":  # noqa: PLC1901,RUF100
-            if not isinstance(default, (int, str, Decimal)):
+            if not isinstance(default, (int, str, decimal.Decimal)):
                 raise ValueError("default: Only 'str', 'int' or Decimal input allowed")
 
             if isinstance(default, str) and default:
                 # check if it is a float, raises a ValueError otherwise
                 float(default)
-                default = Decimal(default)
+                default = decimal.Decimal(default)
 
-            if preserve_significance and isinstance(default, Decimal):
+            if preserve_significance and isinstance(default, decimal.Decimal):
                 self.significance = default
 
             val = str(default)
 
         super().__init__(self.ALLOWED[0:10] + self._decimal_separator, caption, val, allow_negative=allow_negative)
 
-    def value(self) -> Decimal | None:
+    def value(self) -> decimal.Decimal | None:
         """
         Return the numeric value of self.edit_text.
         """
         if self.edit_text:
-            normalized = Decimal(self.edit_text.replace(self._decimal_separator, "."))
+            normalized = decimal.Decimal(self.edit_text.replace(self._decimal_separator, "."))
             if self.significance is not None:
                 return normalized.quantize(self.significance)
             return normalized

--- a/urwid/util.py
+++ b/urwid/util.py
@@ -38,7 +38,7 @@ if typing.TYPE_CHECKING:
     class CanBeStopped(Protocol):
         def stop(self) -> None: ...
 
-    _TagMarkup = typing.Union[str, bytes, tuple["Hashable", typing.Union[str, bytes]], list["_TagMarkup"]]
+    _TagMarkup = typing.Union[str, bytes, tuple[Hashable, typing.Union[str, bytes]], list["_TagMarkup"]]
 
 
 def __getattr__(name: str) -> typing.Any:

--- a/urwid/widget/attr_wrap.py
+++ b/urwid/widget/attr_wrap.py
@@ -6,14 +6,19 @@ import warnings
 from .attr_map import AttrMap
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Hashable
+    from collections.abc import Hashable, Mapping
 
     from .constants import Sizing
     from .widget import Widget
 
 
 class AttrWrap(AttrMap):
-    def __init__(self, w: Widget, attr, focus_attr=None):
+    def __init__(
+        self,
+        w: Widget,
+        attr: Hashable | Mapping[Hashable, Hashable],
+        focus_attr: Hashable | Mapping[Hashable, Hashable] = None,
+    ) -> None:
         """
         w -- widget to wrap (stored as self.original_widget)
         attr -- attribute to apply to w
@@ -112,11 +117,12 @@ class AttrWrap(AttrMap):
 
     focus_attr = property(get_focus_attr, set_focus_attr)
 
-    def __getattr__(self, name: str):
+    def __getattr__(self, name: str) -> typing.Any:
         """
-        Call getattr on wrapped widget.  This has been the longstanding
-        behaviour of AttrWrap, but is discouraged.  New code should be
-        using AttrMap and .base_widget or .original_widget instead.
+        Call getattr on wrapped widget.
+
+        This has been the longstanding behaviour of AttrWrap, but is discouraged.
+        New code should be using AttrMap and .base_widget or .original_widget instead.
         """
         return getattr(self._original_widget, name)
 

--- a/urwid/widget/edit.py
+++ b/urwid/widget/edit.py
@@ -20,6 +20,8 @@ if typing.TYPE_CHECKING:
 
     from urwid.canvas import TextCanvas
 
+    _TagMarkup = typing.Union[str, tuple[Hashable, typing.Union[str]], list["_TagMarkup"]]
+
 
 class EditError(TextError):
     pass
@@ -65,7 +67,7 @@ class Edit(Text):
 
     def __init__(
         self,
-        caption: str | tuple[Hashable, str] | list[str | tuple[Hashable, str]] = "",
+        caption: _TagMarkup = "",
         edit_text: str = "",
         multiline: bool = False,
         align: Literal["left", "center", "right"] | Align = Align.LEFT,
@@ -111,7 +113,7 @@ class Edit(Text):
         self.multiline = multiline
         self.allow_tab = allow_tab
         self._edit_pos = 0
-        self._caption, self._attrib = decompose_tagmarkup(caption)
+        self._caption, self._attrib = decompose_tagmarkup(caption)  # type: ignore[arg-type]  # discourage `bytes` input
         self._edit_text = ""
         self.highlight: tuple[int, int] | None = None
         self.set_edit_text(edit_text)
@@ -153,7 +155,7 @@ class Edit(Text):
 
         return self._caption + (self._mask * len(self._edit_text)), self._attrib
 
-    def set_text(self, markup: str | tuple[Hashable, str] | list[str | tuple[Hashable, str]]) -> None:
+    def set_text(self, markup: _TagMarkup) -> None:
         """
         Not supported by Edit widget.
 
@@ -579,7 +581,7 @@ class Edit(Text):
         self.highlight = None
         return True
 
-    def render(
+    def render(  # type: ignore[override]
         self,
         size: tuple[int],  # type: ignore[override]
         focus: bool = False,
@@ -667,7 +669,7 @@ class IntEdit(Edit):
         """
         return len(ch) == 1 and ch in string.digits
 
-    def __init__(self, caption="", default: int | str | None = None) -> None:
+    def __init__(self, caption: _TagMarkup = "", default: int | str | None = None) -> None:
         """
         caption -- caption markup
         default -- default edit value

--- a/urwid/widget/filler.py
+++ b/urwid/widget/filler.py
@@ -300,7 +300,7 @@ class Filler(WidgetDecoration[WrappedWidget]):
     def mouse_event(
         self,
         size: tuple[int, int] | tuple[int],  # type: ignore[override]
-        event,
+        event: str,
         button: int,
         col: int,
         row: int,

--- a/urwid/widget/line_box.py
+++ b/urwid/widget/line_box.py
@@ -11,6 +11,8 @@ from .text import Text
 from .widget_decoration import WidgetDecoration, delegate_to_widget_mixin
 
 if typing.TYPE_CHECKING:
+    from collections.abc import Hashable
+
     from typing_extensions import Literal
 
     from .widget import Widget
@@ -26,7 +28,7 @@ class LineBox(WidgetDecoration[WrappedWidget], delegate_to_widget_mixin("_wrappe
         original_widget: WrappedWidget,
         title: str = "",
         title_align: Literal["left", "center", "right"] | Align = Align.CENTER,
-        title_attr=None,
+        title_attr: Hashable = None,
         tlcorner: str = BOX_SYMBOLS.LIGHT.TOP_LEFT,
         tline: str = BOX_SYMBOLS.LIGHT.HORIZONTAL,
         lline: str = BOX_SYMBOLS.LIGHT.VERTICAL,

--- a/urwid/widget/listbox.py
+++ b/urwid/widget/listbox.py
@@ -1886,7 +1886,7 @@ class ListBox(Widget, WidgetContainerMixin):
     def mouse_event(
         self,
         size: tuple[int, int],  # type: ignore[override]
-        event,
+        event: str,
         button: int,
         col: int,
         row: int,

--- a/urwid/widget/popup.py
+++ b/urwid/widget/popup.py
@@ -163,7 +163,7 @@ class PopUpTarget(WidgetDecoration[WrappedWidget]):
         return self._current_widget.pack(size)
 
 
-def _test():
+def _test() -> None:
     import doctest
 
     doctest.testmod()

--- a/urwid/widget/text.py
+++ b/urwid/widget/text.py
@@ -18,7 +18,7 @@ if typing.TYPE_CHECKING:
 
     from urwid.canvas import TextCanvas
 
-    _TagMarkup = typing.Union[str, bytes, tuple["Hashable", typing.Union[str, bytes]], list["_TagMarkup"]]
+    _TagMarkup = typing.Union[str, tuple[Hashable, typing.Union[str]], list["_TagMarkup"]]
 
 
 class TextError(WidgetError):
@@ -123,7 +123,7 @@ class Text(Widget):
         Traceback (most recent call last):
         AttributeError: can't set attribute
         """
-        self._text, self._attrib = decompose_tagmarkup(markup)
+        self._text, self._attrib = decompose_tagmarkup(markup)  # type: ignore[arg-type]  # discourage `bytes` input
         self._invalidate()
 
     def get_text(self) -> tuple[str | bytes, list[tuple[Hashable, int]]]:


### PR DESCRIPTION
* urwid.widget.attr_wrap
* urwid.widget.edit
* urwid.widget.filler
* urwid.widget.line_box
* urwid.widget.listbox
* urwid.widget.popup
* urwid.widget.text - discourage `bytes` in markup
* urwid.numedit
* urwid.graphis

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

Partial #1146