### PR TITLE
Fix IndexError in decompose_tagmarkup when a nested sublist is empty

### DIFF
--- a/urwid/util.py
+++ b/urwid/util.py
@@ -483,7 +483,7 @@ def _tagmarkup_recurse(
         ral: list[tuple[Hashable, int]] = []
         for element in tm:
             tl, al = _tagmarkup_recurse(element, attr)
-            if ral:
+            if ral and al:
                 # merge attributes when possible
                 last_attr, last_run = ral[-1]
                 top_attr, top_run = al[0]


### PR DESCRIPTION
## Problem

`urwid.decompose_tagmarkup` raises an `IndexError` whenever a nested list
element resolves to empty tagmarkup (e.g. `[]`):

```python
>>> import urwid
>>> urwid.decompose_tagmarkup([("attr", "hello"), []])
IndexError: list index out of range
```

### Root cause

In `_tagmarkup_recurse` (`urwid/util.py`), when recursing into a list the
attribute-merge block checks `if ral:` (the accumulated list is non-empty)
and immediately dereferences `al[0]`.  But if the current element is an
empty list `[]`, the recursive call returns `([], [])`, so `al` is empty and
`al[0]` raises.

```python
tl, al = _tagmarkup_recurse(element, attr)
if ral:          # ral is non-empty, so we enter the block…
    top_attr, top_run = al[0]   # …but al may be empty → IndexError
```

## Fix

Add `and al` to the guard so an empty sub-result is safely skipped:

```python
if ral and al:
```

One character change, no behavioural change for non-empty elements.

## Tests

All existing `TagMarkupTest` cases still pass.  The crash is now gone for
all empty-sublist positions (before, after, and between non-empty elements).

This pull request was prepared with the assistance of AI, under my direction and review.