### PR TITLE
Typing: partially annotate examples and fix annotations

### DIFF
--- a/examples/bigtext.py
+++ b/examples/bigtext.py
@@ -48,7 +48,7 @@ class SwitchingPadding(urwid.Padding[_Wrapped]):
 
 
 class BigTextDisplay:
-    palette: typing.ClassVar[list[tuple[str, str, str, ...]]] = [
+    palette: typing.ClassVar[list[tuple[str, str, str] | tuple[str, str, str, str]]] = [
         ("body", "black", "light gray", "standout"),
         ("header", "white", "dark red", "bold"),
         ("button normal", "light gray", "dark blue", "standout"),

--- a/examples/browse.py
+++ b/examples/browse.py
@@ -178,9 +178,9 @@ class DirectoryNode(urwid.ParentNode):
         parent.set_child_node(self.get_key(), self)
         return parent
 
-    def load_child_keys(self):
-        dirs = []
-        files = []
+    def load_child_keys(self) -> list[str] | list[None]:
+        dirs: list[str] = []
+        files: list[str] = []
         try:
             path = self.get_value()
             # separate dirs and files
@@ -207,7 +207,7 @@ class DirectoryNode(urwid.ParentNode):
             keys = [None]
         return keys
 
-    def load_child_node(self, key) -> EmptyNode | DirectoryNode | FileNode:
+    def load_child_node(self, key: Hashable) -> EmptyNode | DirectoryNode | FileNode:
         """Return either a FileNode or DirectoryNode"""
         index = self.get_child_index(key)
         if key is None:
@@ -225,11 +225,11 @@ class DirectoryNode(urwid.ParentNode):
 
 
 class DirectoryBrowser:
-    palette: typing.ClassVar[list[tuple[str, str, str, ...]]] = [
+    palette: typing.ClassVar[list[tuple[str, ...] | tuple[str, str, str, str]]] = [
         ("body", "black", "light gray"),
-        ("flagged", "black", "dark green", ("bold", "underline")),
+        ("flagged", "black", "dark green", "bold,underline"),
         ("focus", "light gray", "dark blue", "standout"),
-        ("flagged focus", "yellow", "dark cyan", ("bold", "standout", "underline")),
+        ("flagged focus", "yellow", "dark cyan", "bold,standout,underline"),
         ("head", "yellow", "black", "standout"),
         ("foot", "light gray", "black"),
         ("key", "light cyan", "black", "underline"),

--- a/examples/calc.py
+++ b/examples/calc.py
@@ -40,7 +40,7 @@ import typing
 import urwid
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Hashable
+    from collections.abc import Hashable, Iterable
 
 # use appropriate Screen class
 if urwid.display.web.is_web_request():
@@ -99,7 +99,7 @@ class CalcEvent(Exception):
     def __init__(self, message: str | tuple[Hashable, str] | list[str | tuple[Hashable, str]]) -> None:
         self.message = message
 
-    def widget(self):
+    def widget(self) -> urwid.AttrMap[urwid.Text]:
         """Return a widget containing event information"""
         text = urwid.Text(self.message, urwid.CENTER)
         return urwid.AttrMap(text, self.attr)
@@ -110,7 +110,7 @@ class ColumnDeleteEvent(CalcEvent):
 
     attr = "confirm"
 
-    def __init__(self, letter: str, from_parent=0) -> None:
+    def __init__(self, letter: str, from_parent: int = 0) -> None:
         super().__init__(["Press ", ("key", "BACKSPACE"), " again to confirm column removal."])
         self.letter = letter
 
@@ -120,14 +120,14 @@ class UpdateParentEvent(Exception):
 
 
 class Cell:
-    def __init__(self, op) -> None:
+    def __init__(self, op: str | None) -> None:
         self.op = op
         self.is_top = op is None
         self.child = None
         self.setup_edit()
         self.result = urwid.Text("", layout=CALC_LAYOUT)
 
-    def show_result(self, next_cell) -> bool:
+    def show_result(self, next_cell: Cell | None) -> bool:
         """Return whether this widget should display its result.
 
         next_cell -- the cell following self or None"""
@@ -192,7 +192,7 @@ class Cell:
 class ParentEdit(urwid.Edit):
     """Edit widget modified to link to a child column"""
 
-    def __init__(self, op, letter: str) -> None:
+    def __init__(self, op: str | None, letter: str) -> None:
         """Use the operator and letter of the child column as caption
 
         op -- operator or None
@@ -226,20 +226,23 @@ class ParentEdit(urwid.Edit):
 
 
 class CellWalker(urwid.ListWalker):
-    def __init__(self, content):
+    def __init__(self, content: Iterable[Cell]) -> None:
         self.content = urwid.MonitoredList(content)
-        self.content.modified = self._modified
+        self.content.set_modified_callback(self._modified)
         self.focus = (0, 0)
         # everyone can share the same divider widget
         self.div = urwid.Divider("-")
 
-    def get_cell(self, i):
+    def get_cell(self, i: int) -> Cell | None:
         if i < 0 or i >= len(self.content):
             return None
 
         return self.content[i]
 
-    def _get_at_pos(self, pos):
+    def _get_at_pos(
+        self,
+        pos: tuple[int, int],
+    ) -> tuple[urwid.Divider | urwid.AttrMap[urwid.IntEdit] | urwid.Text, tuple[int, int]] | tuple[None, None]:
         i, sub = pos
         assert sub in {0, 1, 2}  # noqa: S101  # for examples "assert" is acceptable
         if i < 0 or i >= len(self.content):
@@ -252,13 +255,18 @@ class CellWalker(urwid.ListWalker):
 
         return self.content[i].result, pos
 
-    def get_focus(self):
+    def get_focus(
+        self,
+    ) -> tuple[urwid.Divider | urwid.AttrMap[urwid.IntEdit] | urwid.Text, tuple[int, int]] | tuple[None, None]:
         return self._get_at_pos(self.focus)
 
-    def set_focus(self, focus) -> None:
+    def set_focus(self, focus: tuple[int, int]) -> None:
         self.focus = focus
 
-    def get_next(self, position):
+    def get_next(
+        self,
+        position: tuple[int, int],
+    ) -> tuple[urwid.Divider | urwid.AttrMap[urwid.IntEdit] | urwid.Text, tuple[int, int]] | tuple[None, None]:
         i, sub = position
         assert sub in {0, 1, 2}  # noqa: S101  # for examples "assert" is acceptable
         if sub == 0:
@@ -272,7 +280,10 @@ class CellWalker(urwid.ListWalker):
 
         return self._get_at_pos((i + 1, 0))
 
-    def get_prev(self, position):
+    def get_prev(
+        self,
+        position: tuple[int, int],
+    ) -> tuple[urwid.Divider | urwid.AttrMap[urwid.IntEdit] | urwid.Text, tuple[int, int]] | tuple[None, None]:
         i, sub = position
         assert sub in {0, 1, 2}  # noqa: S101  # for examples "assert" is acceptable
         if sub == 0:
@@ -289,7 +300,7 @@ class CellWalker(urwid.ListWalker):
         return self._get_at_pos((i, 1))
 
 
-class CellColumn(urwid.WidgetWrap):
+class CellColumn(urwid.WidgetWrap[urwid.Frame[urwid.WidgetWrap[urwid.Text], urwid.ListBox, None]]):
     def __init__(self, letter: str) -> None:
         self.walker = CellWalker([Cell(None)])
         self.content = self.walker.content
@@ -304,7 +315,7 @@ class CellColumn(urwid.WidgetWrap):
         header = urwid.AttrMap(urwid.Text(["Column ", ("key", letter)], layout=CALC_LAYOUT), "colhead")
         self.frame = urwid.Frame(self.listbox, header)
 
-    def keypress(self, size, key: str) -> str | None:
+    def keypress(self, size: tuple[int, int], key: str) -> str | None:
         key = self.frame.keypress(size, key)
         if key is None:
             changed = self.update_results()
@@ -387,7 +398,7 @@ class CellColumn(urwid.WidgetWrap):
             return None
         return key
 
-    def move_focus_next(self, size) -> None:
+    def move_focus_next(self, size: tuple[int, int]) -> None:
         _f, (i, _sub) = self.walker.get_focus()
         assert i < len(self.content) - 1  # noqa: S101  # for examples "assert" is acceptable
 
@@ -396,7 +407,7 @@ class CellColumn(urwid.WidgetWrap):
             self.frame.keypress(size, "down")
             _nf, (ni, _nsub) = self.walker.get_focus()
 
-    def move_focus_prev(self, size) -> None:
+    def move_focus_prev(self, size: tuple[int, int]) -> None:
         _f, (i, _sub) = self.walker.get_focus()
         assert i > 0  # noqa: S101  # for examples "assert" is acceptable
 
@@ -442,7 +453,7 @@ class CellColumn(urwid.WidgetWrap):
 
         return True
 
-    def create_child(self, letter):
+    def create_child(self, letter: str) -> tuple[Cell, CellColumn] | tuple[None, None]:
         """Return (parent cell,child column) or None,None on failure."""
         _f, (i, sub) = self.walker.get_focus()
         if sub != 0:
@@ -479,7 +490,7 @@ class CellColumn(urwid.WidgetWrap):
 
         return "".join(lines)
 
-    def get_result(self):
+    def get_result(self) -> int | None:
         """Return the result of the last cell in the column."""
 
         return self.content[-1].get_result()
@@ -541,7 +552,7 @@ class HelpColumn(urwid.Widget):
         self.body = urwid.AttrMap(self.listbox, "help")
         self.frame = urwid.Frame(self.body, header=self.head)
 
-    def render(self, size, focus: bool = False) -> urwid.Canvas:
+    def render(self, size: tuple[int, int], focus: bool = False) -> urwid.Canvas:
         maxcol, maxrow = size
         head_rows = self.head.rows((maxcol,))
         if "bottom" in self.listbox.ends_visible((maxcol, maxrow - head_rows)):
@@ -551,17 +562,17 @@ class HelpColumn(urwid.Widget):
 
         return self.frame.render((maxcol, maxrow), focus)
 
-    def keypress(self, size, key: str) -> str | None:
+    def keypress(self, size: tuple[int, int], key: str) -> str | None:
         return self.frame.keypress(size, key)
 
 
 class CalcDisplay:
-    palette: typing.ClassVar[list[tuple[str, str, str, ...]]] = [
+    palette: typing.ClassVar[list[tuple[str, str, str] | tuple[str, str, str, str]]] = [
         ("body", "white", "dark blue"),
         ("edit", "yellow", "dark blue"),
         ("editfocus", "yellow", "dark cyan", "bold"),
-        ("key", "dark cyan", "light gray", ("standout", "underline")),
-        ("title", "white", "light gray", ("bold", "standout")),
+        ("key", "dark cyan", "light gray", "standout,underline"),
+        ("title", "white", "light gray", "bold,standout"),
         ("help", "black", "light gray", "standout"),
         ("helpnote", "dark green", "light gray"),
         ("colhead", "black", "light gray", "standout"),
@@ -586,7 +597,7 @@ class CalcDisplay:
         print(expression)
         print("Result:", result)
 
-    def input_filter(self, data, raw_input):
+    def input_filter(self, data: list[str | tuple[str, int, int, int]], raw_input: list[int]) -> list[str]:
         if "q" in data or "Q" in data:
             raise urwid.ExitMainLoop()
 
@@ -604,7 +615,7 @@ class CalcDisplay:
         # remove all input from further processing by MainLoop
         return []
 
-    def wrap_keypress(self, key: str) -> None:
+    def wrap_keypress(self, key: str | tuple[str, int, int, int]) -> None:
         """Handle confirmation and throw event on bad input."""
 
         try:
@@ -633,7 +644,7 @@ class CalcDisplay:
         if key not in EDIT_KEYS and key not in MOVEMENT_KEYS:
             raise CalcEvent(E_invalid_key % key.upper())
 
-    def keypress(self, key: str) -> str | None:
+    def keypress(self, key: str | tuple[str, int, int, int]) -> str | None:
         """Handle a keystroke."""
 
         self.loop.process_input([key])
@@ -774,7 +785,7 @@ class CalcNumLayout(urwid.TextLayout):
     the last line for the cursor.
     """
 
-    def layout(self, text, width: int, align, wrap):
+    def layout(self, text: str | bytes, width: int, align: typing.Any, wrap: typing.Any):
         """
         Return layout structure for calculator number display.
         """

--- a/examples/edit.py
+++ b/examples/edit.py
@@ -51,10 +51,10 @@ class LineWalker(urwid.ListWalker):
         if self.file is not None:
             self.file.close()
 
-    def get_focus(self):
+    def get_focus(self) -> tuple[urwid.Edit, int] | tuple[None, None]:
         return self._get_at_pos(self.focus)
 
-    def set_focus(self, focus) -> None:
+    def set_focus(self, focus: int) -> None:
         self.focus = focus
         self._modified()
 
@@ -145,7 +145,7 @@ class LineWalker(urwid.ListWalker):
 
 
 class EditDisplay:
-    palette: typing.ClassVar[list[tuple[str, str, str, ...]]] = [
+    palette: typing.ClassVar[list[tuple[str, str, str] | tuple[str, str, str, str]]] = [
         ("body", "default", "default"),
         ("foot", "dark cyan", "dark blue", "bold"),
         ("key", "light cyan", "dark blue", "underline"),
@@ -231,7 +231,7 @@ class EditDisplay:
                 prefix = "\n"
 
 
-def re_tab(s) -> str:
+def re_tab(s: str) -> str:
     """Return a tabbed string from an expanded one."""
     line = []
     p = 0

--- a/examples/fib.py
+++ b/examples/fib.py
@@ -58,12 +58,12 @@ class FibonacciWalker(urwid.ListWalker):
         self.focus = focus
         self._modified()
 
-    def get_next(self, position) -> tuple[urwid.Text, tuple[int, int]]:
+    def get_next(self, position: tuple[int, int]) -> tuple[urwid.Text, tuple[int, int]]:
         a, b = position
         focus = b, a + b
         return self._get_at_pos(focus)
 
-    def get_prev(self, position) -> tuple[urwid.Text, tuple[int, int]]:
+    def get_prev(self, position: tuple[int, int]) -> tuple[urwid.Text, tuple[int, int]]:
         a, b = position
         focus = b - a, a
         return self._get_at_pos(focus)

--- a/examples/graph.py
+++ b/examples/graph.py
@@ -33,6 +33,9 @@ import typing
 
 import urwid
 
+if typing.TYPE_CHECKING:
+    from collections.abc import Callable
+
 UPDATE_INTERVAL = 0.2
 
 
@@ -52,7 +55,7 @@ class GraphModel:
 
     data_max_value = 100
 
-    def __init__(self):
+    def __init__(self) -> None:
         data = [
             ("Saw", list(range(0, 100, 2)) * 2),
             ("Square", [0] * 30 + [100] * 30),
@@ -66,13 +69,13 @@ class GraphModel:
             self.modes.append(m)
             self.data[m] = d
 
-    def get_modes(self):
+    def get_modes(self) -> list[str]:
         return self.modes
 
-    def set_mode(self, m) -> None:
+    def set_mode(self, m: str) -> None:
         self.current_mode = m
 
-    def get_data(self, offset, r):
+    def get_data(self, offset: int, r):
         """
         Return the data in [offset:offset+r], the maximum value
         for items returned, and the offset at which the data
@@ -95,7 +98,7 @@ class GraphView(urwid.WidgetWrap):
     graph display.
     """
 
-    palette: typing.ClassVar[tuple[str, str, str, ...]] = [
+    palette: typing.ClassVar[list[tuple[str, str, str] | tuple[str, str, str, str]]] = [
         ("body", "black", "light gray", "standout"),
         ("header", "white", "dark red", "bold"),
         ("screen edge", "light blue", "dark cyan"),
@@ -118,7 +121,7 @@ class GraphView(urwid.WidgetWrap):
     graph_num_bars = 5
     graph_offset_per_second = 5
 
-    def __init__(self, controller):
+    def __init__(self, controller) -> None:
         self.controller = controller
         self.started = True
         self.start_time = None
@@ -126,7 +129,7 @@ class GraphView(urwid.WidgetWrap):
         self.last_offset = None
         super().__init__(self.main_window())
 
-    def get_offset_now(self):
+    def get_offset_now(self) -> int:
         if self.start_time is None:
             return 0
         if not self.started:
@@ -134,7 +137,7 @@ class GraphView(urwid.WidgetWrap):
         tdelta = time.time() - self.start_time
         return int(self.offset + (tdelta * self.graph_offset_per_second))
 
-    def update_graph(self, force_update=False):
+    def update_graph(self, force_update: bool = False) -> bool:
         o = self.get_offset_now()
         if o == self.last_offset and not force_update:
             return False
@@ -164,32 +167,32 @@ class GraphView(urwid.WidgetWrap):
         self.animate_progress.current = prog
         return True
 
-    def on_animate_button(self, button):
+    def on_animate_button(self, button: urwid.AttrMap[urwid.Button]) -> None:
         """Toggle started state and button text."""
         if self.started:  # stop animation
-            button.base_widget.set_label("Start")
+            button.set_label("Start")
             self.offset = self.get_offset_now()
             self.started = False
             self.controller.stop_animation()
         else:
-            button.base_widget.set_label("Stop")
+            button.set_label("Stop")
             self.started = True
             self.start_time = time.time()
             self.controller.animate_graph()
 
-    def on_reset_button(self, w):
+    def on_reset_button(self, w: urwid.Button) -> None:
         self.offset = 0
         self.start_time = time.time()
         self.update_graph(True)
 
-    def on_mode_button(self, button, state):
+    def on_mode_button(self, button: urwid.RadioButton, state: bool) -> None:
         """Notify the controller of a new mode setting."""
         if state:
             # The new mode is the label of the button
             self.controller.set_mode(button.get_label())
         self.last_offset = None
 
-    def on_mode_change(self, m):
+    def on_mode_change(self, m: str) -> None:
         """Handle external mode change by updating radio buttons."""
         for rb in self.mode_buttons:
             if rb.base_widget.label == m:
@@ -197,7 +200,7 @@ class GraphView(urwid.WidgetWrap):
                 break
         self.last_offset = None
 
-    def on_unicode_checkbox(self, w, state):
+    def on_unicode_checkbox(self, w: urwid.CheckBox, state: bool) -> None:
         self.graph = self.bar_graph(state)
         self.graph_wrap._w = self.graph
         self.animate_progress = self.progress_bar(state)
@@ -235,30 +238,42 @@ class GraphView(urwid.WidgetWrap):
         )
         return w
 
-    def bar_graph(self, smooth=False):
+    def bar_graph(self, smooth: bool = False) -> urwid.BarGraph:
         satt = None
         if smooth:
             satt = {(1, 0): "bg 1 smooth", (2, 0): "bg 2 smooth"}
         w = urwid.BarGraph(["bg background", "bg 1", "bg 2"], satt=satt)
         return w
 
-    def button(self, t, fn):
+    def button(
+        self,
+        t: str,
+        fn: Callable[[urwid.Button], None],
+    ) -> urwid.AttrMap[urwid.Button]:
         w = urwid.Button(t, fn)
         w = urwid.AttrMap(w, "button normal", "button select")
         return w
 
-    def radio_button(self, g, label, fn):
+    def radio_button(
+        self,
+        g: list[urwid.RadioButton],
+        label: str,
+        fn: Callable[[urwid.RadioButton, bool], None],
+    ) -> urwid.AttrMap[urwid.RadioButton]:
         w = urwid.RadioButton(g, label, False, on_state_change=fn)
         w = urwid.AttrMap(w, "button normal", "button select")
         return w
 
-    def progress_bar(self, smooth=False):
-        if smooth:
-            return urwid.ProgressBar("pg normal", "pg complete", 0, 1, "pg smooth")
+    def progress_bar(self, smooth: bool = False) -> urwid.ProgressBar:
+        return urwid.ProgressBar(
+            "pg normal",
+            "pg complete",
+            0,
+            1,
+            "pg smooth" if smooth else None,
+        )
 
-        return urwid.ProgressBar("pg normal", "pg complete", 0, 1)
-
-    def exit_program(self, w):
+    def exit_program(self, w) -> typing.NoReturn:
         raise urwid.ExitMainLoop()
 
     def graph_controls(self):
@@ -271,7 +286,7 @@ class GraphView(urwid.WidgetWrap):
             self.mode_buttons.append(rb)
         # setup animate button
         self.animate_button = self.button("", self.on_animate_button)
-        self.on_animate_button(self.animate_button)
+        self.on_animate_button(self.animate_button.original_widget)
         self.offset = 0
         self.animate_progress = self.progress_bar()
         animate_controls = urwid.GridFlow(

--- a/examples/input_test.py
+++ b/examples/input_test.py
@@ -91,7 +91,7 @@ else:
         logging.captureWarnings(True)
 
 
-def key_test():
+def key_test() -> None:
     screen = Screen()
     header = urwid.AttrMap(
         urwid.Text("Values from get_input(). Q exits."),
@@ -104,7 +104,7 @@ def key_test():
     )
     top = urwid.Frame(listbox, header)
 
-    def input_filter(keys, raw):
+    def input_filter(keys: list[str | tuple[str, int, int, int]], raw: list[int]) -> list[str]:
         if "q" in keys or "Q" in keys:
             raise urwid.ExitMainLoop
 

--- a/examples/pop_up.py
+++ b/examples/pop_up.py
@@ -7,12 +7,12 @@ import typing
 import urwid
 
 
-class PopUpDialog(urwid.WidgetWrap):
+class PopUpDialog(urwid.WidgetWrap[urwid.AttrMap[urwid.Filler[urwid.Pile]]]):
     """A dialog that appears with nothing but a close button"""
 
     signals: typing.ClassVar[list[str]] = ["close"]
 
-    def __init__(self):
+    def __init__(self) -> None:
         close_button = urwid.Button("that's pretty cool")
         urwid.connect_signal(close_button, "click", lambda button: self._emit("close"))
         pile = urwid.Pile(
@@ -24,7 +24,7 @@ class PopUpDialog(urwid.WidgetWrap):
         super().__init__(urwid.AttrMap(urwid.Filler(pile), "popbg"))
 
 
-class ThingWithAPopUp(urwid.PopUpLauncher):
+class ThingWithAPopUp(urwid.PopUpLauncher[urwid.Button]):
     def __init__(self) -> None:
         super().__init__(urwid.Button("click-me"))
         urwid.connect_signal(self.original_widget, "click", lambda button: self.open_pop_up())

--- a/examples/terminal.py
+++ b/examples/terminal.py
@@ -43,17 +43,17 @@ def main() -> None:
         ),
     )
 
-    def set_title(widget, title: str) -> None:
+    def set_title(widget: urwid.Terminal, title: str) -> None:
         mainframe.set_title(title)
 
-    def execute_quit(*args, **kwargs) -> typing.NoReturn:
+    def execute_quit(*args: typing.Any, **kwargs: typing.Any) -> typing.NoReturn:
         raise urwid.ExitMainLoop()
 
     def handle_key(key: str | tuple[str, int, int, int]) -> None:
         if key in {"q", "Q"}:
             execute_quit()
 
-    def handle_resize(widget, size: tuple[int, int]) -> None:
+    def handle_resize(widget: urwid.Terminal, size: tuple[int, int]) -> None:
         size_widget.set_text(f"Terminal size: [{size[0]}, {size[1]}]")
 
     urwid.connect_signal(term, "title", set_title)

--- a/examples/tour.py
+++ b/examples/tour.py
@@ -159,7 +159,7 @@ def main():
         " widget is used to keep the instructions at the top of the screen.",
     ]
 
-    def button_press(button):
+    def button_press(button: urwid.Button) -> None:
         frame.footer = urwid.AttrMap(urwid.Text(["Pressed: ", button.get_label()]), "header")
 
     radio_button_group = []
@@ -355,11 +355,11 @@ def main():
         ("body", "black", "light gray", "standout"),
         ("reverse", "light gray", "black"),
         ("header", "white", "dark red", "bold"),
-        ("important", "dark blue", "light gray", ("standout", "underline")),
+        ("important", "dark blue", "light gray", "standout,underline"),
         ("editfc", "white", "dark blue", "bold"),
         ("editbx", "light gray", "dark blue"),
         ("editcp", "black", "light gray", "standout"),
-        ("bright", "dark gray", "light gray", ("bold", "standout")),
+        ("bright", "dark gray", "light gray", "bold,standout"),
         ("buttn", "black", "dark cyan"),
         ("buttnf", "white", "dark blue", "bold"),
     ]

--- a/examples/treesample.py
+++ b/examples/treesample.py
@@ -38,7 +38,14 @@ import typing
 import urwid
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Hashable, Iterable
+    from collections.abc import Hashable
+
+    from typing_extensions import NotRequired
+
+
+class SampleTree(typing.TypedDict):
+    name: str
+    children: NotRequired[list[SampleTree]]
 
 
 class ExampleTreeWidget(urwid.TreeWidget):
@@ -61,11 +68,11 @@ class ExampleParentNode(urwid.ParentNode):
     def load_widget(self) -> ExampleTreeWidget:
         return ExampleTreeWidget(self)
 
-    def load_child_keys(self) -> Iterable[int]:
+    def load_child_keys(self) -> tuple[int, ...]:
         data = self.get_value()
-        return range(len(data["children"]))
+        return tuple(range(len(data["children"])))
 
-    def load_child_node(self, key) -> ExampleParentNode | ExampleNode:
+    def load_child_node(self, key: int) -> ExampleParentNode | ExampleNode:
         """Return either an ExampleNode or ExampleParentNode"""
         childdata = self.get_value()["children"][key]
         childdepth = self.get_depth() + 1
@@ -77,7 +84,7 @@ class ExampleParentNode(urwid.ParentNode):
 
 
 class ExampleTreeBrowser:
-    palette: typing.ClassVar[tuple[str, str, str, ...]] = [
+    palette: typing.ClassVar[list[tuple[str, str, str] | tuple[str, str, str, str]]] = [
         ("body", "black", "light gray"),
         ("focus", "light gray", "dark blue", "standout"),
         ("head", "yellow", "black", "standout"),
@@ -112,7 +119,7 @@ class ExampleTreeBrowser:
         ("key", "Q"),
     ]
 
-    def __init__(self, data=None) -> None:
+    def __init__(self, data: SampleTree) -> None:
         self.topnode = ExampleParentNode(data)
         self.listbox = urwid.TreeListBox(urwid.TreeWalker(self.topnode))
         self.listbox.offset_rows = 1
@@ -135,9 +142,9 @@ class ExampleTreeBrowser:
             raise urwid.ExitMainLoop()
 
 
-def get_example_tree():
+def get_example_tree() -> SampleTree:
     """generate a quick 100 leaf tree for demo purposes"""
-    retval = {"name": "parent", "children": []}
+    retval: SampleTree = {"name": "parent", "children": []}
     for i in range(10):
         retval["children"].append({"name": f"child {i!s}"})
         retval["children"][i]["children"] = []

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -7,7 +7,7 @@ import urwid
 from urwid import TreeNode
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Collection, Hashable, Iterable
+    from collections.abc import Hashable, Iterable
 
 
 class SelfRegisteringParent(urwid.ParentNode):
@@ -30,7 +30,7 @@ class SelfRegisteringParent(urwid.ParentNode):
             self._child_keys.append(key)
             child.set_parent(self)
 
-    def load_child_keys(self) -> Collection[Hashable]:
+    def load_child_keys(self) -> list[Hashable]:
         return list(self._children)
 
     def set_child_node(self, key: Hashable, node: TreeNode) -> None:

--- a/urwid/display/common.py
+++ b/urwid/display/common.py
@@ -1094,7 +1094,7 @@ class BaseScreen(abc.ABC, metaclass=signals.MetaSignals):
         name: str | None,
         foreground: str,
         background: str,
-        mono: str | None = None,
+        mono: str | tuple[str, ...] | None = None,
         foreground_high: str | None = None,
         background_high: str | None = None,
     ) -> None:
@@ -1156,8 +1156,7 @@ class BaseScreen(abc.ABC, metaclass=signals.MetaSignals):
         basic = AttrSpec(foreground, background, 16)
 
         if isinstance(mono, tuple):
-            # old style of specifying mono attributes was to put them
-            # in a tuple.  convert to comma-separated string
+            # old style of specifying mono attributes was to put them in a tuple.  convert to comma-separated string
             mono = ",".join(mono)
         if mono is None:
             mono = DEFAULT

--- a/urwid/display/web.py
+++ b/urwid/display/web.py
@@ -165,7 +165,7 @@ class Screen(BaseScreen):
         name: str | None,
         foreground: str,
         background: str,
-        mono: str | None = None,
+        mono: str | None = None,  # type: ignore[override]
         foreground_high: str | None = None,
         background_high: str | None = None,
     ) -> None:

--- a/urwid/event_loop/main_loop.py
+++ b/urwid/event_loop/main_loop.py
@@ -116,7 +116,7 @@ class MainLoop:
         ] = (),
         screen: BaseScreen | None = None,
         handle_mouse: bool = True,
-        input_filter: Callable[[list[str], list[int]], list[str]] | None = None,
+        input_filter: Callable[[list[str | tuple[str, int, int, int]], list[int]], list[str]] | None = None,
         unhandled_input: Callable[[str | tuple[str, int, int, int]], bool | None] | None = None,
         event_loop: EventLoop | None = None,
         pop_ups: bool = False,
@@ -424,7 +424,7 @@ class MainLoop:
             raise
         self.stop()
 
-    def _update(self, keys: list[str], raw: list[int]) -> None:
+    def _update(self, keys: list[str | tuple[str, int, int, int]], raw: list[int]) -> None:
         """
         >>> w = _refl("widget")
         >>> w.selectable_rval = True
@@ -464,7 +464,7 @@ class MainLoop:
             if not next_alarm and self.event_loop._alarms:
                 next_alarm = heapq.heappop(self.event_loop._alarms)
 
-            keys: list[str] = []
+            keys: list[str | tuple[str, int, int, int]] = []
             raw: list[int] = []
             while not keys:
                 if next_alarm:
@@ -587,7 +587,11 @@ class MainLoop:
         True
         """
 
-    def input_filter(self, keys: list[str], raw: list[int]) -> list[str]:
+    def input_filter(
+        self,
+        keys: list[str | tuple[str, int, int, int]],
+        raw: list[int],
+    ) -> list[str | tuple[str, int, int, int]]:
         """
         This function is passed each all the input events and raw keystroke
         values. These values are passed to the *input_filter* function

--- a/urwid/widget/big_text.py
+++ b/urwid/widget/big_text.py
@@ -28,7 +28,6 @@ class BigText(Widget):
         self.text: str = ""
         self.attrib: list[tuple[Hashable, int]] = []
         self.font: Font = font
-        self.set_font(font)
         self.set_text(markup)
 
     def set_text(self, markup: _TagMarkup) -> None:

--- a/urwid/widget/box_adapter.py
+++ b/urwid/widget/box_adapter.py
@@ -8,7 +8,10 @@ from urwid.canvas import CompositeCanvas
 from .constants import Sizing
 from .widget_decoration import WidgetDecoration, WidgetError
 
-WrappedWidget = typing.TypeVar("WrappedWidget")
+if typing.TYPE_CHECKING:
+    from urwid import Widget
+
+WrappedWidget = typing.TypeVar("WrappedWidget", bound="Widget")
 
 
 class BoxAdapterError(WidgetError):
@@ -127,7 +130,7 @@ class BoxAdapter(WidgetDecoration[WrappedWidget]):
         canv = CompositeCanvas(self._original_widget.render((maxcol, self.height), focus))
         return canv
 
-    def __getattr__(self, name: str):
+    def __getattr__(self, name: str) -> typing.Any:
         """
         Pass calls to box widget.
         """

--- a/urwid/widget/container.py
+++ b/urwid/widget/container.py
@@ -14,11 +14,17 @@ if typing.TYPE_CHECKING:
     _KT_contra = typing.TypeVar("_KT_contra", contravariant=True)
 
     class WidgetContainerProto(typing.Protocol[_KT_contra]):
-        def __getitem__(self, index: _KT_contra) -> tuple[Widget, typing.Unpack[tuple[typing.Any, ...]] | None]: ...
+        def __getitem__(
+            self,
+            index: _KT_contra,
+        ) -> tuple[Widget, typing.Unpack[tuple[typing.Any, ...]] | None]: ...  # type: ignore[valid-type]  # unpack
 
     class WidgetContainerMixinProto(typing.Protocol[_KT_contra]):
         @property
         def contents(self) -> WidgetContainerProto[_KT_contra]: ...
+
+        @property
+        def focus(self) -> Widget: ...
 
         @property
         def focus_position(self) -> int | str: ...
@@ -30,9 +36,6 @@ if typing.TYPE_CHECKING:
         def base_widget(self) -> Widget: ...
 else:
     _KT_contra = typing.TypeVar("_KT_contra", contravariant=True)
-
-    class WidgetContainerMixinProto(typing.Generic[_KT_contra]):
-        pass
 
 
 _WidgetParams = typing.TypeVar("_WidgetParams", bound=tuple[typing.Any, ...])
@@ -81,12 +84,15 @@ class _ContainerElementSizingFlag(enum.IntEnum):
         return "|".join(sorted(mode.upper() for mode in sizing)) + render_string
 
 
-class WidgetContainerMixin(WidgetContainerMixinProto[_KT_contra]):
+class WidgetContainerMixin(typing.Generic[_KT_contra]):
     """
     Mixin class for widget containers implementing common container methods
     """
 
-    def __getitem__(self, position: _KT_contra) -> Widget:
+    def __getitem__(
+        self: WidgetContainerMixinProto[_KT_contra],
+        position: _KT_contra,
+    ) -> Widget:
         """
         Container short-cut for self.contents[position][0].base_widget
         which means "give me the child widget at position without any
@@ -99,7 +105,7 @@ class WidgetContainerMixin(WidgetContainerMixinProto[_KT_contra]):
         """
         return self.contents[position][0].base_widget
 
-    def get_focus_path(self) -> list[int | str]:
+    def get_focus_path(self: WidgetContainerMixinProto[_KT_contra]) -> list[int | str]:
         """
         Return the .focus_position values starting from this container
         and proceeding along each child widget until reaching a leaf
@@ -113,9 +119,12 @@ class WidgetContainerMixin(WidgetContainerMixinProto[_KT_contra]):
             except IndexError:
                 return out
             out.append(p)
-            w = w.focus.base_widget  # type: ignore[assignment]
+            w = w.focus.base_widget  # type: ignore[assignment,attr-defined]
 
-    def set_focus_path(self, positions: Iterable[int | str]) -> None:
+    def set_focus_path(
+        self: WidgetContainerMixinProto[_KT_contra],
+        positions: Iterable[int | str],
+    ) -> None:
         """
         Set the .focus_position property starting from this container
         widget and proceeding along newly focused child widgets.

--- a/urwid/widget/frame.py
+++ b/urwid/widget/frame.py
@@ -19,8 +19,8 @@ if typing.TYPE_CHECKING:
     from collections.abc import Iterator
 
 BodyWidget = typing.TypeVar("BodyWidget", bound=Widget)
-HeaderWidget = typing.TypeVar("HeaderWidget", bound=Widget)
-FooterWidget = typing.TypeVar("FooterWidget", bound=Widget)
+HeaderWidget = typing.TypeVar("HeaderWidget", bound=typing.Union[Widget, None])
+FooterWidget = typing.TypeVar("FooterWidget", bound=typing.Union[Widget, None])
 
 
 class FrameError(WidgetError):
@@ -375,11 +375,11 @@ class Frame(
         except (ValueError, TypeError) as exc:
             raise FrameError(f"added content invalid: {value!r}").with_traceback(exc.__traceback__) from exc
         if key == "body":
-            self.body = value_w
+            self.body = value_w  # type: ignore[assignment]
         elif key == "footer":
-            self.footer = value_w
+            self.footer = value_w  # type: ignore[assignment]
         else:
-            self.header = value_w
+            self.header = value_w  # type: ignore[assignment]
 
     def _contents__delitem__(self, key: Literal["header", "footer"]) -> None:
         if key not in {"header", "footer"}:
@@ -414,10 +414,10 @@ class Frame(
         frows = hrows = 0
 
         if self.header:
-            hrows = self.header.rows((maxcol,), self.focus_part == "header" and focus)
+            hrows = self.header.rows((maxcol,), self.focus_part == "header" and focus)  # type: ignore[union-attr]
 
         if self.footer:
-            frows = self.footer.rows((maxcol,), self.focus_part == "footer" and focus)
+            frows = self.footer.rows((maxcol,), self.focus_part == "footer" and focus)  # type: ignore[union-attr]
 
         remaining = maxrow
 
@@ -465,7 +465,7 @@ class Frame(
             head = Filler(self.header, VAlign.TOP).render((maxcol, htrim), focus and self.focus_part == "header")
         elif htrim:
             head = self.header.render((maxcol,), focus and self.focus_part == "header")
-            if head.rows() != hrows:
+            if head.rows() != hrows:  # type: ignore[union-attr]
                 raise RuntimeError("rows, render mismatch")
         if head:
             combinelist.append((head, "header", self.focus_part == "header"))
@@ -481,7 +481,7 @@ class Frame(
             foot = Filler(self.footer, VAlign.BOTTOM).render((maxcol, ftrim), focus and self.focus_part == "footer")
         elif ftrim:
             foot = self.footer.render((maxcol,), focus and self.focus_part == "footer")
-            if foot.rows() != frows:
+            if foot.rows() != frows:  # type: ignore[union-attr]
                 raise RuntimeError("rows, render mismatch")
         if foot:
             combinelist.append((foot, "footer", self.focus_part == "footer"))
@@ -509,9 +509,9 @@ class Frame(
             return key
         remaining = maxrow
         if self.header is not None:
-            remaining -= self.header.rows((maxcol,))
+            remaining -= self.header.rows((maxcol,))  # type: ignore[attr-defined]
         if self.footer is not None:
-            remaining -= self.footer.rows((maxcol,))
+            remaining -= self.footer.rows((maxcol,))  # type: ignore[attr-defined]
         if remaining <= 0:
             return key
 
@@ -537,19 +537,23 @@ class Frame(
 
         if row < htrim:  # within header
             focus = focus and self.focus_part == "header"
-            if is_mouse_press(event) and button == 1 and self.header.selectable():
+            if is_mouse_press(event) and button == 1 and self.header.selectable():  # type: ignore[union-attr]
                 self.focus_position = "header"
-            if not hasattr(self.header, "mouse_event"):
-                return False
-            return self.header.mouse_event((maxcol,), event, button, col, row, focus)
+
+            if (header_mouse_event := getattr(self.header, "mouse_event", None)) is not None:
+                return header_mouse_event((maxcol,), event, button, col, row, focus)
+
+            return False
 
         if row >= maxrow - ftrim:  # within footer
             focus = focus and self.focus_part == "footer"
-            if is_mouse_press(event) and button == 1 and self.footer.selectable():
+            if is_mouse_press(event) and button == 1 and self.footer.selectable():  # type: ignore[union-attr]
                 self.focus_position = "footer"
-            if not hasattr(self.footer, "mouse_event"):
-                return False
-            return self.footer.mouse_event((maxcol,), event, button, col, row - maxrow + ftrim, focus)
+
+            if (footer_mouse_event := getattr(self.footer, "mouse_event", None)) is not None:
+                return footer_mouse_event((maxcol,), event, button, col, row - maxrow + ftrim, focus)
+
+            return False
 
         # within body
         focus = focus and self.focus_part == "body"
@@ -562,7 +566,7 @@ class Frame(
 
     def get_cursor_coords(self, size: tuple[int, int]) -> tuple[int, int] | None:
         """Return the cursor coordinates of the focus widget."""
-        if not self.focus.selectable():
+        if not self.focus.selectable():  # type: ignore[union-attr]  # mypy bug on union
             return None
         if not hasattr(self.focus, "get_cursor_coords"):
             return None
@@ -573,13 +577,13 @@ class Frame(
 
         if fp == "header":
             row_adjust = 0
-            coords = self.header.get_cursor_coords((maxcol,))
+            coords = self.header.get_cursor_coords((maxcol,))  # type: ignore[union-attr]  # expect not None
         elif fp == "body":
             row_adjust = hrows
             coords = self.body.get_cursor_coords((maxcol, maxrow - hrows - frows))
         else:
             row_adjust = maxrow - frows
-            coords = self.footer.get_cursor_coords((maxcol,))
+            coords = self.footer.get_cursor_coords((maxcol,))  # type: ignore[union-attr]  # expect not None
 
         if coords is None:
             return None

--- a/urwid/widget/line_box.py
+++ b/urwid/widget/line_box.py
@@ -17,7 +17,7 @@ if typing.TYPE_CHECKING:
 
     from .widget import Widget
 
-WrappedWidget = typing.TypeVar("WrappedWidget")
+WrappedWidget = typing.TypeVar("WrappedWidget", bound="Widget")
 
 
 class LineBox(WidgetDecoration[WrappedWidget], delegate_to_widget_mixin("_wrapped_widget")):
@@ -120,13 +120,16 @@ class LineBox(WidgetDecoration[WrappedWidget], delegate_to_widget_mixin("_wrappe
             if title_align not in {Align.LEFT, Align.CENTER, Align.RIGHT}:
                 raise ValueError('title_align must be one of "left", "right", or "center"')
             if title_align == Align.LEFT:
-                tline_widgets = [(WHSettings.PACK, self.title_widget), w_tline]
+                tline_widgets: list[tuple[Literal[WHSettings.PACK], Widget] | Widget] = [
+                    (WHSettings.PACK, self.title_widget),
+                    w_tline,
+                ]
             else:
                 tline_widgets = [w_tline, (WHSettings.PACK, self.title_widget)]
                 if title_align == Align.CENTER:
                     tline_widgets.append(w_tline)
 
-            self.tline_widget = Columns(tline_widgets)
+            self.tline_widget: Columns | None = Columns(tline_widgets)
             top = Columns(
                 (
                     (int(bool(tlcorner and lline)), w_tlcorner),
@@ -158,7 +161,7 @@ class LineBox(WidgetDecoration[WrappedWidget], delegate_to_widget_mixin("_wrappe
         else:
             bottom = None
 
-        pile_widgets = []
+        pile_widgets: list[tuple[Literal[WHSettings.PACK], Widget] | Widget] = []
         if top:
             pile_widgets.append((WHSettings.PACK, top))
         pile_widgets.append(middle)
@@ -177,7 +180,7 @@ class LineBox(WidgetDecoration[WrappedWidget], delegate_to_widget_mixin("_wrappe
     def original_widget(self, original_widget: WrappedWidget) -> None:
         v_index = int(bool(self.tline_widget))  # we care only about top
         h_index = 1  # constant
-        middle: Columns = typing.cast("Columns", self._wrapped_widget[v_index])
+        middle: Columns = typing.cast("Columns", self._wrapped_widget[v_index])  # type: ignore[misc]
         _old_widget, options = middle.contents[h_index]
         middle.contents[h_index] = (original_widget, options)
         WidgetDecoration.original_widget.fset(self, original_widget)  # pylint: disable=no-member

--- a/urwid/widget/listbox.py
+++ b/urwid/widget/listbox.py
@@ -151,7 +151,7 @@ class SimpleListWalker(MonitoredList[_T], ListWalker):
         """
         if not isinstance(contents, Iterable):
             raise ListWalkerError(f"SimpleListWalker expecting list like object, got: {contents!r}")
-        MonitoredList.__init__(self, contents)
+        super().__init__(contents)
         self.focus = 0
         self.wrap_around = wrap_around
 
@@ -235,7 +235,7 @@ class SimpleFocusListWalker(ListWalker, MonitoredFocusList[_T]):
         """
         if not isinstance(contents, Iterable):
             raise ListWalkerError(f"SimpleFocusListWalker expecting iterable object, got: {contents!r}")
-        MonitoredFocusList.__init__(self, contents)
+        super().__init__(contents)
         self.wrap_around = wrap_around
 
     def set_modified_callback(self, callback: typing.Any) -> typing.NoReturn:
@@ -823,7 +823,7 @@ class ListBox(Widget, WidgetContainerMixin):
     def set_focus_valign(
         self,
         valign: Literal["top", "middle", "bottom"] | VAlign | tuple[Literal["relative", WHSettings.RELATIVE], int],
-    ):
+    ) -> None:
         """Set the focus widget's display offset and inset.
 
         :param valign: one of: 'top', 'middle', 'bottom' ('relative', percentage 0=top 100=bottom)
@@ -842,6 +842,7 @@ class ListBox(Widget, WidgetContainerMixin):
         """
         if coming_from not in {"above", "below", None}:
             raise ListBoxError(f"coming_from value invalid: {coming_from!r}")
+
         focus_widget, focus_pos = self._body.get_focus()
         if focus_widget is None:
             raise IndexError("Can't set focus, ListBox is empty")
@@ -952,7 +953,7 @@ class ListBox(Widget, WidgetContainerMixin):
         """
         return self._contents()
 
-    def options(self):
+    def options(self) -> None:
         """
         There are currently no options for ListBox contents.
 
@@ -1309,7 +1310,7 @@ class ListBox(Widget, WidgetContainerMixin):
                 self.make_cursor_visible((maxcol, maxrow))
                 return None
 
-        def actual_key(unhandled) -> str | None:
+        def actual_key(unhandled: str | bool | None) -> str | None:
             if unhandled:
                 return key
             return None
@@ -1328,10 +1329,10 @@ class ListBox(Widget, WidgetContainerMixin):
             return actual_key(self._keypress_page_down((maxcol, maxrow)))
 
         if self._command_map[key] == Command.MAX_LEFT:
-            return actual_key(self._keypress_max_left((maxcol, maxrow)))
+            return actual_key(self._keypress_max_left((maxcol, maxrow)))  # type: ignore[func-returns-value]
 
         if self._command_map[key] == Command.MAX_RIGHT:
-            return actual_key(self._keypress_max_right((maxcol, maxrow)))
+            return actual_key(self._keypress_max_right((maxcol, maxrow)))  # type: ignore[func-returns-value]
 
         return key
 

--- a/urwid/widget/monitored_list.py
+++ b/urwid/widget/monitored_list.py
@@ -546,7 +546,12 @@ class MonitoredFocusList(MonitoredList[_T], typing.Generic[_T]):
         self.focus = max(0, len(self) - self._focus - 1)
         return rval
 
-    def sort(self, **kwargs) -> None:
+    def sort(
+        self,
+        *,
+        key: Callable[[_T], typing.Any] | None = None,
+        reverse: bool = False,
+    ) -> None:
         """
         >>> ml = MonitoredFocusList([-2, 0, 1, -3, 2, -1, 3], focus=4)
         >>> ml.sort()
@@ -556,7 +561,7 @@ class MonitoredFocusList(MonitoredList[_T], typing.Generic[_T]):
         if not self:
             return None
         value = self[self._focus]
-        rval = super().sort(**kwargs)
+        rval = super().sort(key=key, reverse=reverse)
         self.focus = self.index(value)
         return rval
 
@@ -568,7 +573,7 @@ class MonitoredFocusList(MonitoredList[_T], typing.Generic[_T]):
             self.focus = focus
 
 
-def _test():
+def _test() -> None:
     import doctest
 
     doctest.testmod()

--- a/urwid/widget/padding.py
+++ b/urwid/widget/padding.py
@@ -24,7 +24,9 @@ if typing.TYPE_CHECKING:
 
     from typing_extensions import Literal
 
-WrappedWidget = typing.TypeVar("WrappedWidget")
+    from urwid import Widget
+
+WrappedWidget = typing.TypeVar("WrappedWidget", bound="Widget")
 
 
 class PaddingError(WidgetError):
@@ -48,7 +50,7 @@ class Padding(WidgetDecoration[WrappedWidget], typing.Generic[WrappedWidget]):
             int
             | Literal["pack", "clip", WHSettings.PACK, WHSettings.CLIP]
             | tuple[Literal["relative", WHSettings.RELATIVE, "fixed left", "fixed right"], int]
-        ) = RELATIVE_100,
+        ) = RELATIVE_100,  # type: ignore[assignment]
         min_width: int | None = None,
         left: int = 0,
         right: int = 0,
@@ -75,8 +77,7 @@ class Padding(WidgetDecoration[WrappedWidget], typing.Generic[WrappedWidget]):
             ``'clip'``
               to enable clipping mode for a fixed widget
 
-        :param min_width: the minimum number of columns for
-            self.original_widget or ``None``
+        :param min_width: the minimum number of columns for self.original_widget or ``None``
         :type min_width: int | None
 
         :param left: a fixed number of columns to pad on the left
@@ -140,7 +141,7 @@ class Padding(WidgetDecoration[WrappedWidget], typing.Generic[WrappedWidget]):
                 left = width[1]
             else:
                 right = width[1]
-            width = RELATIVE_100
+            width = RELATIVE_100  # type: ignore[assignment]
 
         # convert old clipping mode width=None to width='clip'
         if width is None:
@@ -148,8 +149,13 @@ class Padding(WidgetDecoration[WrappedWidget], typing.Generic[WrappedWidget]):
 
         self.left = left
         self.right = right
-        self._align_type, self._align_amount = normalize_align(align, PaddingError)
-        self._width_type, self._width_amount = normalize_width(width, PaddingError)
+        self._align_type: Align | Literal[WHSettings.RELATIVE]
+        self._align_amount: int | None
+        self._width_type: WHSettings
+        self._width_amount: int | float | None
+
+        self._align_type, self._align_amount = normalize_align(align, PaddingError)  # type: ignore[arg-type]
+        self._width_type, self._width_amount = normalize_width(width, PaddingError)  # type: ignore[arg-type]
         self.min_width = min_width
 
     def sizing(self) -> frozenset[Sizing]:
@@ -218,15 +224,11 @@ class Padding(WidgetDecoration[WrappedWidget], typing.Generic[WrappedWidget]):
     @property
     def width(
         self,
-    ) -> (
-        Literal["clip", "pack", WHSettings.CLIP, WHSettings.PACK]
-        | int
-        | tuple[Literal["relative", WHSettings.RELATIVE], int]
-    ):
+    ) -> Literal[WHSettings.CLIP, WHSettings.PACK] | int | tuple[Literal[WHSettings.RELATIVE], int]:
         """
         Return the padding width.
         """
-        return simplify_width(self._width_type, self._width_amount)
+        return simplify_width(self._width_type, self._width_amount)  # type: ignore[call-overload]
 
     @width.setter
     def width(
@@ -265,9 +267,11 @@ class Padding(WidgetDecoration[WrappedWidget], typing.Generic[WrappedWidget]):
                     stacklevel=3,
                 )
 
+            width_amount = typing.cast("int", self._width_amount)
+
             return (
-                max(self._width_amount, self.min_width or 1) + expand,
-                self.original_widget.rows((self._width_amount,), focus),
+                max(width_amount, self.min_width or 1) + expand,
+                self.original_widget.rows((width_amount,), focus),  # type: ignore[attr-defined]  # we warned
             )
 
         if Sizing.FIXED not in w_sizing:
@@ -282,7 +286,8 @@ class Padding(WidgetDecoration[WrappedWidget], typing.Generic[WrappedWidget]):
             return max(width, self.min_width or 1) + expand, height
 
         if self._width_type == WHSettings.RELATIVE:
-            return max(int(width * 100 / self._width_amount + 0.5), self.min_width or 1) + expand, height
+            width_amount = typing.cast("int | float", self._width_amount)  # type: ignore[assignment]  # branch-local
+            return max(int(width * 100 / width_amount + 0.5), self.min_width or 1) + expand, height
 
         raise PaddingError(f"Unexpected width type: {self._width_type.upper()})")
 
@@ -297,7 +302,7 @@ class Padding(WidgetDecoration[WrappedWidget], typing.Generic[WrappedWidget]):
             canv = self._original_widget.render((), focus)
         elif size:
             maxcol = size[0] - (left + right)
-            if self._width_type == WHSettings.GIVEN and maxcol < self._width_amount:
+            if self._width_type == WHSettings.GIVEN and maxcol < self._width_amount:  # type: ignore[operator]
                 warnings.warn(
                     f"{self}.render(size={size}, focus={focus}): too narrow size ({maxcol!r} < {self._width_amount!r})",
                     PaddingWarning,
@@ -305,11 +310,14 @@ class Padding(WidgetDecoration[WrappedWidget], typing.Generic[WrappedWidget]):
                 )
             canv = self._original_widget.render((maxcol, *size[1:]), focus)
         elif self._width_type == WHSettings.GIVEN:
-            canv = self._original_widget.render((self._width_amount, *size[1:]), focus)
+            canv = self._original_widget.render((typing.cast("int", self._width_amount), *size[1:]), focus)
         else:
             canv = self._original_widget.render((), focus)
 
         if canv.cols() == 0:
+            if not size:
+                raise ValueError(f"{self}.render(size={size}, focus={focus}): size is required for empty widget")
+
             canv = SolidCanvas(" ", size[0], canv.rows())
             canv = CompositeCanvas(canv)
             canv.set_depends([self._original_widget])
@@ -368,15 +376,20 @@ class Padding(WidgetDecoration[WrappedWidget], typing.Generic[WrappedWidget]):
         if size:
             maxcol = size[0]
         elif self._width_type == WHSettings.GIVEN:
-            maxcol = self._width_amount + self.left + self.right
+            maxcol = typing.cast("int", self._width_amount) + self.left + self.right  # type: ignore[operator]
         else:
             maxcol = (
-                max(self._original_widget.pack((), focus=focus)[0] * 100 // self._width_amount, self.min_width or 1)
+                max(  # type: ignore[assignment]  # `//` will produce int
+                    self._original_widget.pack((), focus=focus)[0]
+                    * 100
+                    // typing.cast("int | float", self._width_amount),
+                    self.min_width or 1,
+                )
                 + self.left
                 + self.right
             )
 
-        return calculate_left_right_padding(
+        return calculate_left_right_padding(  # type: ignore[misc]  # too many unions...
             maxcol,
             self._align_type,
             self._align_amount,
@@ -397,7 +410,7 @@ class Padding(WidgetDecoration[WrappedWidget], typing.Generic[WrappedWidget]):
         if self._width_type == WHSettings.CLIP:
             _fcols, frows = self._original_widget.pack((), focus)
             return frows
-        return self._original_widget.rows((maxcol - left - right,), focus=focus)
+        return self._original_widget.rows((maxcol - left - right,), focus=focus)  # type: ignore[attr-defined]
 
     def keypress(self, size: tuple[()] | tuple[int] | tuple[int, int], key: str) -> str | None:
         """Pass keypress to self._original_widget."""
@@ -497,10 +510,49 @@ class Padding(WidgetDecoration[WrappedWidget], typing.Generic[WrappedWidget]):
         return x
 
 
+@typing.overload
+def calculate_left_right_padding(
+    maxcol: int,
+    align_type: Literal["relative", WHSettings.RELATIVE],
+    align_amount: int,
+    width_type: Literal["fixed", "relative", "clip", "given", WHSettings.RELATIVE, WHSettings.CLIP, WHSettings.GIVEN],
+    width_amount: int,
+    min_width: int | None,
+    left: int,
+    right: int,
+) -> tuple[int, int]: ...
+
+
+@typing.overload
+def calculate_left_right_padding(
+    maxcol: int,
+    align_type: Literal["relative", WHSettings.RELATIVE],
+    align_amount: None,
+    width_type: Literal["fixed", "relative", "clip", "given", WHSettings.RELATIVE, WHSettings.CLIP, WHSettings.GIVEN],
+    width_amount: int,
+    min_width: int | None,
+    left: int,
+    right: int,
+) -> typing.NoReturn: ...
+
+
+@typing.overload
 def calculate_left_right_padding(
     maxcol: int,
     align_type: Literal["left", "center", "right"] | Align,
-    align_amount: int,
+    align_amount: int | None,
+    width_type: Literal["fixed", "relative", "clip", "given", WHSettings.RELATIVE, WHSettings.CLIP, WHSettings.GIVEN],
+    width_amount: int,
+    min_width: int | None,
+    left: int,
+    right: int,
+) -> tuple[int, int]: ...
+
+
+def calculate_left_right_padding(
+    maxcol: int,
+    align_type: Literal["left", "center", "right", "relative", WHSettings.RELATIVE] | Align,
+    align_amount: int | None,
     width_type: Literal["fixed", "relative", "clip", "given", WHSettings.RELATIVE, WHSettings.CLIP, WHSettings.GIVEN],
     width_amount: int,
     min_width: int | None,
@@ -514,8 +566,7 @@ def calculate_left_right_padding(
     align_type -- 'left', 'center', 'right', 'relative'
     align_amount -- a percentage when align_type=='relative'
     width_type -- 'fixed', 'relative', 'clip'
-    width_amount -- a percentage when width_type=='relative'
-        otherwise equal to the width of the widget
+    width_amount -- a percentage when width_type=='relative' otherwise equal to the width of the widget
     min_width -- a desired minimum width for the widget or None
     left -- a fixed number of columns to pad on the left
     right -- a fixed number of columns to pad on the right
@@ -542,6 +593,9 @@ def calculate_left_right_padding(
     >>> clrp(20, "relative", 30, "relative", 60, 14, 0, 0)
     (2, 4)
     """
+    if align_type == WHSettings.RELATIVE and align_amount is None:
+        raise TypeError("align_amount must be specified when align_type is relative")
+
     if width_type == WHSettings.RELATIVE:
         maxwidth = max(maxcol - left - right, 0)
         width = int(maxwidth * width_amount / 100 + 0.5)
@@ -550,7 +604,11 @@ def calculate_left_right_padding(
     else:
         width = width_amount
 
-    align = {Align.LEFT: 0, Align.CENTER: 50, Align.RIGHT: 100}.get(align_type, align_amount)
+    align: int = {  # type: ignore[assignment]  # we filtered not allowed None
+        Align.LEFT: 0,
+        Align.CENTER: 50,
+        Align.RIGHT: 100,
+    }.get(align_type, align_amount)  # type: ignore[arg-type]  # we filtered not allowed None
 
     # add the remainder of left/right the padding
     padding = maxcol - width - left - right

--- a/urwid/widget/popup.py
+++ b/urwid/widget/popup.py
@@ -148,7 +148,7 @@ class PopUpTarget(WidgetDecoration[WrappedWidget]):
 
     def mouse_event(
         self,
-        size: tuple[int, int],
+        size: tuple[int, int],  # type: ignore[override]
         event: str,
         button: int,
         col: int,
@@ -158,7 +158,11 @@ class PopUpTarget(WidgetDecoration[WrappedWidget]):
         self._update_overlay(size, focus)
         return self._current_widget.mouse_event(size, event, button, col, row, focus)
 
-    def pack(self, size: tuple[int, int] | None = None, focus: bool = False) -> tuple[int, int]:
+    def pack(
+        self,
+        size: tuple[int, int] | None = None,  # type: ignore[override]
+        focus: bool = False,
+    ) -> tuple[int, int]:
         self._update_overlay(size, focus)
         return self._current_widget.pack(size)
 

--- a/urwid/widget/treetools.py
+++ b/urwid/widget/treetools.py
@@ -30,6 +30,7 @@ Features:
 from __future__ import annotations
 
 import typing
+import warnings
 
 from .columns import Columns
 from .constants import WHSettings
@@ -56,10 +57,22 @@ class TreeWidget(WidgetWrap[Padding[typing.Union[Text, Columns]]]):
     unexpanded_icon = SelectableIcon("+", 0)
     expanded_icon = SelectableIcon("-", 0)
 
-    def __init__(self, node: TreeNode) -> None:
+    def __init__(self, node: TreeNode | ParentNode) -> None:
         self._node = node
         self._innerwidget: Text | None = None
-        self.is_leaf = not hasattr(node, "get_first_child")
+        if not isinstance(node, ParentNode):
+            if hasattr(node, "get_first_child"):
+                warnings.warn(
+                    f"get_first_child is defined, but node is not a ParentNode instance: {type(node)}",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                self.is_leaf = False
+            else:
+                self.is_leaf = True
+        else:
+            self.is_leaf = False
+
         self.expanded = True
         widget = self.get_indented_widget()
         super().__init__(widget)
@@ -95,7 +108,7 @@ class TreeWidget(WidgetWrap[Padding[typing.Union[Text, Columns]]]):
         return typing.cast("Text", self._innerwidget)
 
     def load_inner_widget(self) -> Text:
-        return Text(self.get_display_text())
+        return Text(self.get_display_text())  # type: ignore[arg-type]
 
     def get_node(self) -> TreeNode:
         return self._node
@@ -273,10 +286,12 @@ class TreeNode:
             self._parent = self.load_parent()
         return typing.cast("ParentNode", self._parent)
 
-    def load_parent(self):
-        """Provide TreeNode with a parent for the current node.  This function
-        is only required if the tree was instantiated from a child node
-        (virtual function)"""
+    def load_parent(self) -> ParentNode:
+        """Provide TreeNode with a parent for the current node.
+
+        This function is only required if the tree was instantiated from a child node
+        (virtual function)
+        """
         raise TreeWidgetError("virtual function.  Implement in subclass")
 
     def get_value(self):
@@ -329,12 +344,12 @@ class ParentNode(TreeNode):
         """Provide ParentNode with an ordered list of child keys (virtual function)"""
         raise TreeWidgetError("virtual function.  Implement in subclass")
 
-    def get_child_widget(self, key) -> TreeWidget:
+    def get_child_widget(self, key: Hashable) -> TreeWidget:
         """Return the widget for a given key.  Create if necessary."""
 
         return self.get_child_node(key).get_widget()
 
-    def get_child_node(self, key, reload: bool = False) -> TreeNode:
+    def get_child_node(self, key: Hashable, reload: bool = False) -> TreeNode:
         """Return the child node for a given key. Create if necessary."""
         if key not in self._children or reload:
             self._children[key] = self.load_child_node(key)
@@ -402,26 +417,26 @@ class TreeWalker(ListWalker):
 
     positions are TreeNodes."""
 
-    def __init__(self, start_from) -> None:
+    def __init__(self, start_from: TreeNode) -> None:
         """start_from: TreeNode with the initial focus."""
         self.focus = start_from
 
-    def get_focus(self):
+    def get_focus(self) -> tuple[TreeWidget, TreeNode]:
         widget = self.focus.get_widget()
         return widget, self.focus
 
-    def set_focus(self, focus) -> None:
+    def set_focus(self, focus: TreeNode) -> None:
         self.focus = focus
         self._modified()
 
     # pylint: disable=arguments-renamed  # its bad, but we should not change API
-    def get_next(self, start_from) -> tuple[TreeWidget, TreeNode] | tuple[None, None]:
+    def get_next(self, start_from: TreeNode) -> tuple[TreeWidget, TreeNode] | tuple[None, None]:
         if (target := start_from.get_widget().next_inorder()) is not None:
             return target, target.get_node()
 
         return None, None
 
-    def get_prev(self, start_from) -> tuple[TreeWidget, TreeNode] | tuple[None, None]:
+    def get_prev(self, start_from: TreeNode) -> tuple[TreeWidget, TreeNode] | tuple[None, None]:
         if (target := start_from.get_widget().prev_inorder()) is not None:
             return target, target.get_node()
 
@@ -431,17 +446,15 @@ class TreeWalker(ListWalker):
 
 
 class TreeListBox(ListBox):
-    """A ListBox with special handling for navigation and
-    collapsing of TreeWidgets"""
+    """A ListBox with special handling for navigation and collapsing of TreeWidgets"""
 
     def keypress(
         self,
         size: tuple[int, int],  # type: ignore[override]
         key: str,
     ) -> str | None:
-        key: str | None = super().keypress(size, key)
-        if key:
-            return self.unhandled_input(size, key)
+        if unhandled := super().keypress(size, key):
+            return self.unhandled_input(size, unhandled)
         return None
 
     def unhandled_input(self, size: tuple[int, int], data: str) -> str | None:


### PR DESCRIPTION
Fixes:
* `register_palette_entry` accept `tuple[str, ...]` for mono ("old-style" API)
* `input_filter`: annotate mouse input scenario
* `WidgetContainerMixin` should not subclass protocol for mixin (special case: annotate `self` following MyPy docs)
* `Frame`: `HeaderWidget` and `FooterWidget` can be `None`
* `BigText` do not trigger `invalidate` twice on init
* Partially annotate `treetools`
* `TreeWidget`: validate `node` type for `is_leaf` (`get_first_child` is not full API and need to use proper base)

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [X] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

Partial #1146 