### PR TITLE
typing: extend widget_decoration module typing coverage

### DIFF
--- a/urwid/display/_posix_raw_display.py
+++ b/urwid/display/_posix_raw_display.py
@@ -333,7 +333,7 @@ class Screen(_raw_display_base.Screen):
             input_ready = selector.select(0)
             while input_ready:
                 chunk = os.read(fd, 1024)
-                if len(chunk) == 0:
+                if not chunk:
                     raise RuntimeError("stdin has been closed")
                 chars.extend(chunk)
                 input_ready = selector.select(0)

--- a/urwid/display/_raw_display_base.py
+++ b/urwid/display/_raw_display_base.py
@@ -483,7 +483,7 @@ class Screen(BaseScreen, RealTerminal):
         try:
             while codes:
                 run, remaining_codes = escape.process_keyqueue(codes, wait_for_more)
-                codes = list(remaining_codes)
+                codes = remaining_codes.copy()
                 decoded_codes.extend(run)
         except escape.MoreInputRequired:
             # Set a timer to wait for the rest of the input; if it goes off
@@ -587,9 +587,7 @@ class Screen(BaseScreen, RealTerminal):
             run: bytes,
             last: bool,
         ) -> None:
-            nonlocal last_charset_flag  # type: ignore[misc]
-            nonlocal last_attributes  # type: ignore[misc]
-            nonlocal first  # type: ignore[misc]
+            nonlocal last_charset_flag, last_attributes, first  # type: ignore[misc]
 
             if not isinstance(run, bytes):  # canvases render with bytes
                 raise TypeError(run)

--- a/urwid/split_repr.py
+++ b/urwid/split_repr.py
@@ -52,7 +52,7 @@ def split_repr(self: Widget) -> str:
     >>> Bar()
     <Bar words here too attrs='appear too' barttr=42>
     """
-    alist = sorted((str(k), normalize_repr(v)) for k, v in self._repr_attrs().items())
+    alist = sorted((k, normalize_repr(v)) for k, v in self._repr_attrs().items())
 
     words = self._repr_words()
     if not words and not alist:

--- a/urwid/widget/pile.py
+++ b/urwid/widget/pile.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import itertools
 import typing
 import warnings
 from itertools import chain, repeat
@@ -869,16 +870,16 @@ class Pile(
             # Try to move to the center
             offset = len(before) - len(after)
             if not offset:
-                indexes: Iterable[int] = (element for pair in zip(after[::-1], before) for element in pair)
+                indexes: Iterable[int] = itertools.chain.from_iterable(zip(after[::-1], before))
             elif offset > 0:
                 indexes = (
                     *before[:offset],
-                    *(element for pair in zip(after[::-1], before[offset:]) for element in pair),
+                    *itertools.chain.from_iterable(zip(after[::-1], before[offset:])),
                 )
             else:
                 indexes = (
                     *after[-1 : offset - 1 : -1],
-                    *(element for pair in zip(after[offset - 1 :: -1], before) for element in pair),
+                    *itertools.chain.from_iterable(zip(after[offset - 1 :: -1], before)),
                 )
 
             for idx in indexes:

--- a/urwid/widget/widget_decoration.py
+++ b/urwid/widget/widget_decoration.py
@@ -46,10 +46,7 @@ class WidgetDecoration(Widget, typing.Generic[WrappedWidget]):  # pylint: disabl
     """
 
     def __init__(self, original_widget: WrappedWidget) -> None:
-        # TODO(Aleksei): reduce amount of multiple inheritance usage
-        # Special case: subclasses with multiple inheritance causes `super` call wrong way
-        # Call parent __init__ explicit
-        Widget.__init__(self)
+        super().__init__()
         if not isinstance(original_widget, Widget):
             obj_class_path = f"{original_widget.__class__.__module__}.{original_widget.__class__.__name__}"
             warnings.warn(
@@ -133,9 +130,17 @@ class WidgetDisable(WidgetDecoration[WrappedWidget]):
     def sizing(self) -> frozenset[Sizing]:
         return self._original_widget.sizing()
 
-    def pack(self, size, focus: bool = False) -> tuple[int, int]:
+    def pack(
+        self,
+        size: tuple[()] | tuple[int] | tuple[int, int],
+        focus: bool = False,
+    ) -> tuple[int, int]:
         return self._original_widget.pack(size, False)
 
-    def render(self, size, focus: bool = False) -> CompositeCanvas:
+    def render(
+        self,
+        size: tuple[()] | tuple[int] | tuple[int, int],
+        focus: bool = False,
+    ) -> CompositeCanvas:
         canv = self._original_widget.render(size, False)
         return CompositeCanvas(canv)


### PR DESCRIPTION
* for `WidgetDisable` we can not know actual expected sizing statically -> use `Widget`.
* Code changes finally allowed clean `super()` call for `WidgetDecoration`
* Fix some refurb warnings for code

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

Partial #1146 