### PR TITLE
Copy signal handlers before emission

### DIFF
--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -25,6 +25,30 @@ class SiglnalsTest(unittest.TestCase):
         edit.set_edit_text("another text")
         handler.assert_not_called()
 
+    def test_handler_mutation_during_emit(self):
+        emitter = self.EmClass()
+        calls = []
+
+        def third():
+            calls.append("third")
+
+        def first():
+            calls.append("first")
+            disconnect_signal(emitter, "test", first)
+            connect_signal(emitter, "test", third)
+
+        def second():
+            calls.append("second")
+
+        connect_signal(emitter, "test", first)
+        connect_signal(emitter, "test", second)
+
+        emit_signal(emitter, "test")
+        self.assertEqual(calls, ["first", "second"])
+
+        emit_signal(emitter, "test")
+        self.assertEqual(calls, ["first", "second", "second", "third"])
+
     @unittest.skipIf(sys.implementation.name == "pypy", "WeakRef works differently on PyPy")
     def test_weak_del(self):
         emitter = SiglnalsTest.EmClass()

--- a/urwid/signals.py
+++ b/urwid/signals.py
@@ -293,7 +293,7 @@ class Signals:
         """
         result = False
         handlers = getattr(obj, self._signal_attr, {}).get(name, [])
-        for _key, callback, user_arg, (weak_args, user_args) in handlers:
+        for _key, callback, user_arg, (weak_args, user_args) in handlers.copy():
             result |= self._call_callback(callback, user_arg, weak_args, user_args, args)
         return result
 


### PR DESCRIPTION
##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
Signal callbacks could mutate the live handler list during emission, skipping existing callbacks and invoking newly connected callbacks in the same dispatch. Iterate over a snapshot and add a regression test covering both disconnect and connect mutations.

Fixes #306.
