### PR TITLE
Fix Edit cursor wrapping at full lines

### DIFF
--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -118,7 +118,7 @@ class EditRenderTest(unittest.TestCase):
         self.rtest(w, ["blah", "blah"], (0, 1))
 
         w.set_edit_pos(9)
-        self.rtest(w, ["blah", "lah "], (3, 1))
+        self.rtest(w, ["blah", "blah", "    "], (0, 2))
 
     def test2_ClipWrap(self):
         w = urwid.Edit("", "blah\nblargh", 1)
@@ -147,3 +147,8 @@ class EditRenderTest(unittest.TestCase):
 
         w.keypress((4,), "left")
         self.rtest(w, ["  hi"], (3, 0))
+
+    def test5_FullLineWrapsCursor(self):
+        w = urwid.Edit("", "blah")
+
+        self.rtest(w, ["blah", "    "], (0, 1))

--- a/urwid/widget/edit.py
+++ b/urwid/widget/edit.py
@@ -621,6 +621,15 @@ class Edit(Text):
 
         text, _ignore = self.get_text()
         x, y = text_layout.calc_coords(text, trans, self.edit_pos + len(self.caption))
+        if (
+            self._wrap_mode in {WrapMode.SPACE, WrapMode.ANY}
+            and self._align_mode == Align.LEFT
+            and self.edit_pos == len(self.edit_text)
+            and y == len(trans) - 1
+            and x == maxcol
+        ):
+            return [*trans[:y], trans[y][:-1], [(0, self.edit_pos + len(self.caption))]]
+
         if x < 0:
             return [
                 *trans[:y],


### PR DESCRIPTION
##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [ ] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (not applicable; this is a bug fix)

##### Description:
Fixes #1053. When a left-aligned `Edit` ended exactly at the wrap width, cursor visibility shifted the last line left by one column; this keeps the line intact and places the cursor on a new wrapped line while preserving clipped and aligned behavior. The focused widget and text-layout tests pass (40 tests).
