### PR TITLE
Fix web display broken by token_urlsafe session ids

### DIFF
--- a/urwid/display/web.py
+++ b/urwid/display/web.py
@@ -65,6 +65,12 @@ MAX_ROWS = 100
 MAX_READ = 4096
 BUF_SZ = 16384
 
+# Characters that may appear in an id produced by secrets.token_urlsafe():
+# the URL-safe base64 alphabet. Used to validate client-supplied ids before
+# they are interpolated into pipe file names.
+_URWID_ID_CHARS = frozenset(string.ascii_letters + string.digits + "-_")
+_URWID_ID_MAX_LEN = 43  # len(secrets.token_urlsafe(32)); generous upper bound
+
 _code_colours = {
     "black": "0",
     "dark red": "1",
@@ -522,23 +528,22 @@ def handle_short_request() -> bool:
         return False
 
     urwid_id = os.environ["HTTP_X_URWID_ID"]
-    if len(urwid_id) > 20:
+    if len(urwid_id) > _URWID_ID_MAX_LEN:
         # invalid. handle by ignoring
         # assert 0, "urwid id too long!"
         sys.stdout.write("Status: 414 URI Too Long\r\n\r\n")
         return True
-    for c in urwid_id:
-        if c not in string.digits:
-            # invald. handle by ignoring
-            # assert 0, "invalid chars in id!"
-            sys.stdout.write("Status: 403 Forbidden\r\n\r\n")
-            return True
+    if any(c not in _URWID_ID_CHARS for c in urwid_id):
+        # invalid. handle by ignoring
+        # assert 0, "invalid chars in id!"
+        sys.stdout.write("Status: 403 Forbidden\r\n\r\n")
+        return True
 
     if os.environ.get("HTTP_X_URWID_METHOD", None) == "polling":
         # this is a screen update request
         s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         try:
-            s.connect(os.path.join(_prefs.pipe_dir, f"urwid{urwid_id}.update"))
+            s.connect(os.path.join(_prefs.pipe_dir, f"urwid_{urwid_id}.update"))
             data = f"Content-type: text/plain\r\n\r\n{s.recv(BUF_SZ).decode('utf-8')}"
             while data:
                 sys.stdout.write(data)
@@ -550,7 +555,7 @@ def handle_short_request() -> bool:
 
     # this is a keyboard input request
     try:
-        fd = os.open((os.path.join(_prefs.pipe_dir, f"urwid{urwid_id}.in")), os.O_WRONLY)
+        fd = os.open((os.path.join(_prefs.pipe_dir, f"urwid_{urwid_id}.in")), os.O_WRONLY)
     except OSError:
         sys.stdout.write("Status: 404 Not Found\r\n\r\n")
         return True


### PR DESCRIPTION
The "more complex identifiers" change switched session id generation to `secrets.token_urlsafe(16)`, but two spots were not updated to match, so every keyboard-input / polling request to the web display is rejected:

This regression was introduced by 24acd12 (#1137) when fixing CVE-2026-9323 (web display used an insecure PRNG for session id generation): that change switched generation to `secrets.token_urlsafe(16)`, but left the id validator and pipe-name lookup still assuming the old short numeric format.

1. `handle_short_request()` still validated the client-supplied id against `len <= 20` and a digits-only charset, while `token_urlsafe(16)` returns a 22-char URL-safe base64 string. Legitimate ids were answered with `414 URI Too Long` / `403 Forbidden`. The validator now accepts the URL-safe base64 alphabet (which is filesystem-safe, so path-traversal is still rejected) with a generous length bound.

2. The pipe name is created as `urwid_{id}` but the request handler opened `urwid{id}` (missing underscore), so even a valid id resulted in `404 Not Found`. The handler now uses the same `urwid_{id}` prefix.

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [ ] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
*(P. S. If this pull requests fixes an existing issue, please specify which one.)*
