### PR TITLE
Fix MRO for SimpleFocusListWalker: wrong order causes delayed invalidate

### DIFF
--- a/urwid/widget/listbox.py
+++ b/urwid/widget/listbox.py
@@ -239,7 +239,7 @@ class SimpleListWalker(MonitoredList[_T], ListWalker[int, _T]):
         return range(len(self))
 
 
-class SimpleFocusListWalker(MonitoredFocusList[_T], ListWalker[int, _T]):
+class SimpleFocusListWalker(ListWalker[int, _T], MonitoredFocusList[_T]):
     def __init__(self, contents: Iterable[_T], wrap_around: bool = False) -> None:
         """
         contents -- list to copy into this object


### PR DESCRIPTION
Fix #1203

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
