### PR TITLE
Typing: fix `WidgetContainerListContentsMixin` typing

### DIFF
--- a/urwid/widget/columns.py
+++ b/urwid/widget/columns.py
@@ -15,12 +15,18 @@ from urwid.util import is_mouse_press
 from .constants import Align, Sizing, WHSettings
 from .container import WidgetContainerListContentsMixin, WidgetContainerMixin, _ContainerElementSizingFlag
 from .monitored_list import MonitoredFocusList, MonitoredList
-from .widget import AbstractWidget, Widget, WidgetError, WidgetWarning
+from .widget import (
+    AbstractBoxWidget,
+    AbstractFixedWidget,
+    AbstractFlowWidget,
+    AbstractWidget,
+    Widget,
+    WidgetError,
+    WidgetWarning,
+)
 
 if typing.TYPE_CHECKING:
     from collections.abc import Collection, Iterable, Iterator, Sequence
-
-    from .widget import AbstractBoxWidget, AbstractFixedWidget, AbstractFlowWidget
 
 
 class ColumnsError(WidgetError):
@@ -36,9 +42,17 @@ class Columns(
     WidgetContainerMixin[int],
     WidgetContainerListContentsMixin[
         typing.Union[
-            tuple[Literal[WHSettings.PACK], None, bool],
-            tuple[Literal[WHSettings.GIVEN], int, bool],
-            tuple[Literal[WHSettings.WEIGHT], typing.Union[int, float], bool],
+            tuple[
+                typing.Union[AbstractFlowWidget, AbstractFixedWidget],
+                tuple[Literal[WHSettings.PACK], None, bool],
+            ],
+            tuple[
+                typing.Union[AbstractBoxWidget, AbstractFlowWidget],
+                typing.Union[
+                    tuple[Literal[WHSettings.GIVEN], int, bool],
+                    tuple[Literal[WHSettings.WEIGHT], typing.Union[int, float], bool],
+                ],
+            ],
         ]
     ],
 ):
@@ -215,7 +229,8 @@ class Columns(
     def __init__(
         self,
         widget_list: Iterable[
-            AbstractWidget
+            AbstractBoxWidget
+            | AbstractFlowWidget
             | tuple[Literal["pack", WHSettings.PACK], AbstractFlowWidget | AbstractFixedWidget]
             | tuple[int, AbstractBoxWidget | AbstractFlowWidget]
             | tuple[Literal["given", WHSettings.GIVEN], int, AbstractBoxWidget | AbstractFlowWidget]
@@ -263,11 +278,13 @@ class Columns(
         super().__init__()
         self._contents: MonitoredFocusList[
             tuple[
-                AbstractWidget,
-                tuple[Literal[WHSettings.PACK], None, bool]
-                | tuple[Literal[WHSettings.GIVEN], int, bool]
-                | tuple[Literal[WHSettings.WEIGHT], int | float, bool],
-            ],
+                AbstractFlowWidget | AbstractFixedWidget,
+                tuple[Literal[WHSettings.PACK], None, bool],
+            ]
+            | tuple[
+                AbstractBoxWidget | AbstractFlowWidget,
+                tuple[Literal[WHSettings.GIVEN], int, bool] | tuple[Literal[WHSettings.WEIGHT], int | float, bool],
+            ]
         ] = MonitoredFocusList()
         self._contents.set_modified_callback(self._contents_modified)
         self._contents.set_focus_changed_callback(lambda f: self._invalidate())
@@ -283,11 +300,27 @@ class Columns(
                 self.contents.append((w, (WHSettings.WEIGHT, 1, i in box_columns)))
 
             elif len(w) == 2:
-                width, w = w
+                width, w = w  # type: ignore[assignment]  # we match later
                 if width in {Sizing.FLOW, WHSettings.PACK}:  # 'pack' used to be called 'flow'
-                    self.contents.append((w, (WHSettings.PACK, None, i in box_columns)))
+                    if i in box_columns:
+                        warnings.warn(
+                            f"Widget {w} is listed as a box column, but sizing is {width} (Counted as PACK).",
+                            ColumnsWarning,
+                            stacklevel=2,
+                        )
+                    self.contents.append(
+                        (
+                            typing.cast("AbstractFlowWidget | AbstractFixedWidget", w),
+                            (WHSettings.PACK, None, False),
+                        )
+                    )
                 else:
-                    self.contents.append((w, (WHSettings.GIVEN, typing.cast("int", width), i in box_columns)))
+                    self.contents.append(
+                        (
+                            typing.cast("AbstractBoxWidget | AbstractFlowWidget", w),
+                            (WHSettings.GIVEN, typing.cast("int", width), i in box_columns),
+                        )
+                    )
 
             elif w[0] in {Sizing.FIXED, WHSettings.GIVEN}:  # backwards compatibility: FIXED -> GIVEN
                 width, w = w[-2:]
@@ -300,7 +333,7 @@ class Columns(
             else:
                 raise ColumnsError(f"initial widget list item invalid: {original!r}")
 
-            if focus_column == w or (focus_column is None and w.selectable()):
+            if focus_column == w or (focus_column is None and w.selectable()):  # type: ignore[union-attr]
                 focus_column = i
 
             if not isinstance(w, AbstractWidget):
@@ -333,6 +366,7 @@ class Columns(
         return remove_defaults(attrs, Columns.__init__)
 
     def __rich_repr__(self) -> Iterator[tuple[str | None, typing.Any] | typing.Any]:
+        # We do not care about exact typing here: used only for debug purposes
         widget_list: list[
             AbstractWidget
             | tuple[Literal[WHSettings.PACK] | int, AbstractWidget]
@@ -374,10 +408,12 @@ class Columns(
         slc: tuple[int, int, int],
         new_items: Collection[
             tuple[
-                AbstractWidget,
-                tuple[Literal[WHSettings.PACK], None, bool]
-                | tuple[Literal[WHSettings.GIVEN], int, bool]
-                | tuple[Literal[WHSettings.WEIGHT], int | float, bool],
+                AbstractFlowWidget | AbstractFixedWidget,
+                tuple[Literal[WHSettings.PACK], None, bool],
+            ]
+            | tuple[
+                AbstractBoxWidget | AbstractFlowWidget,
+                tuple[Literal[WHSettings.GIVEN], int, bool] | tuple[Literal[WHSettings.WEIGHT], int | float, bool],
             ]
         ],
     ) -> None:
@@ -432,7 +468,7 @@ class Columns(
         focus_position = self.focus_position
         self.contents = [
             # need to grow contents list if widgets is longer
-            (new, options)
+            (new, options)  # type: ignore[misc]  # deprecated API, historic code lack support of FIXED
             for (new, (w, options)) in zip(
                 widgets,
                 chain(self.contents, repeat((None, (WHSettings.WEIGHT, 1, False)))),
@@ -552,11 +588,13 @@ class Columns(
         self,
     ) -> MonitoredFocusList[
         tuple[
-            AbstractWidget,
-            tuple[Literal[WHSettings.PACK], None, bool]
-            | tuple[Literal[WHSettings.GIVEN], int, bool]
-            | tuple[Literal[WHSettings.WEIGHT], int | float, bool],
-        ],
+            AbstractFlowWidget | AbstractFixedWidget,
+            tuple[Literal[WHSettings.PACK], None, bool],
+        ]
+        | tuple[
+            AbstractBoxWidget | AbstractFlowWidget,
+            tuple[Literal[WHSettings.GIVEN], int, bool] | tuple[Literal[WHSettings.WEIGHT], int | float, bool],
+        ]
     ]:
         """
         The contents of this Columns as a list of `(widget, options)` tuples.
@@ -572,10 +610,12 @@ class Columns(
         self,
         c: Sequence[
             tuple[
-                AbstractWidget,
-                tuple[Literal[WHSettings.PACK], None, bool]
-                | tuple[Literal[WHSettings.GIVEN], int, bool]
-                | tuple[Literal[WHSettings.WEIGHT], int | float, bool],
+                AbstractFlowWidget | AbstractFixedWidget,
+                tuple[Literal[WHSettings.PACK], None, bool],
+            ]
+            | tuple[
+                AbstractBoxWidget | AbstractFlowWidget,
+                tuple[Literal[WHSettings.GIVEN], int, bool] | tuple[Literal[WHSettings.WEIGHT], int | float, bool],
             ]
         ],
     ) -> None:
@@ -594,7 +634,7 @@ class Columns(
         | tuple[Literal[WHSettings.WEIGHT], int | float, bool]
     ):
         """
-        Return a new options tuple for use in a Pile's .contents list.
+        Return a new options tuple for use in a Columns .contents list.
 
         This sets an entry's width type: one of the following:
 
@@ -900,7 +940,7 @@ class Columns(
                     raise ColumnsError(f"Unsupported combination of {size_kind} box={is_box!r} for {widget}")
 
             elif size_kind == WHSettings.PACK and Sizing.FIXED in w_sizing and not is_box:
-                width, height = widget.pack((), focused)
+                width, height = typing.cast("AbstractFixedWidget", widget).pack((), focused)
                 widths[i] = width
                 heights[i] = height
                 w_h_args[i] = ()
@@ -915,7 +955,7 @@ class Columns(
 
             elif Sizing.FLOW in w_sizing or is_box:
                 if Sizing.FIXED in w_sizing:
-                    width, height = widget.pack((), focused)
+                    width, height = typing.cast("AbstractFixedWidget", widget).pack((), focused)
                 else:
                     width = self.min_width
 
@@ -998,7 +1038,10 @@ class Columns(
 
             elif size_kind == WHSettings.PACK:
                 if width > 0:
-                    heights[i] = widget.pack((), focus and i == self.focus_position)[1]
+                    heights[i] = typing.cast("AbstractFixedWidget", widget).pack(
+                        (),
+                        focus and i == self.focus_position,
+                    )[1]
                 else:
                     heights[i] = 0
                 w_h_args[i] = ()
@@ -1067,7 +1110,8 @@ class Columns(
                 width += self.dividechars  # noqa: PLW2901
             data.append(
                 (
-                    w.render(w_size, focus=focus and self.focus_position == i),
+                    # widget kind and size arguments matched separately
+                    w.render(w_size, focus=focus and self.focus_position == i),  # type: ignore[arg-type]
                     i,
                     self.focus_position == i,
                     width,
@@ -1193,7 +1237,8 @@ class Columns(
                 )
                 return False
 
-            return w.mouse_event(w_size, event, button, col - x, row, focus)
+            # widget kind and size arguments matched separately
+            return w.mouse_event(w_size, event, button, col - x, row, focus)  # type: ignore[arg-type]
         return False
 
     def get_pref_col(self, size: tuple[()] | tuple[int] | tuple[int, int]) -> Literal["left", "right"] | int | None:
@@ -1257,7 +1302,8 @@ class Columns(
         if self._command_map[key] not in {Command.UP, Command.DOWN, Command.PAGE_UP, Command.PAGE_DOWN}:
             self.pref_col = None
         if w.selectable():
-            if (processed := w.keypress(size_args[i], key)) is not None:
+            # widget kind and size arguments matched separately
+            if (processed := w.keypress(size_args[i], key)) is not None:  # type: ignore[arg-type]
                 key = processed
             else:
                 return None

--- a/urwid/widget/container.py
+++ b/urwid/widget/container.py
@@ -36,7 +36,7 @@ else:
         """Generic protocol support."""
 
 
-_WidgetParams = typing.TypeVar("_WidgetParams", bound=tuple[typing.Any, ...])
+_ContentsItem = typing.TypeVar("_ContentsItem", bound=tuple[typing.Any, ...])
 
 
 # Ideally, we would like to use an IntFlag coupled with enum.auto().
@@ -161,7 +161,7 @@ class WidgetContainerMixin(WidgetContainerMixinProto[_KT_contra]):
         """
 
 
-class WidgetContainerListContentsMixin(typing.Generic[_WidgetParams]):
+class WidgetContainerListContentsMixin(typing.Generic[_ContentsItem]):
     """
     Mixin class for widget containers whose positions are indexes into
     a list available as self.contents.
@@ -186,11 +186,11 @@ class WidgetContainerListContentsMixin(typing.Generic[_WidgetParams]):
 
     @property
     @abc.abstractmethod
-    def contents(self) -> MutableSequence[tuple[AbstractWidget, _WidgetParams]]:
+    def contents(self) -> MutableSequence[_ContentsItem]:
         """The contents of container as a list of (widget, options)"""
 
     @contents.setter
-    def contents(self, new_contents: Sequence[tuple[AbstractWidget, _WidgetParams]]) -> None:
+    def contents(self, new_contents: Sequence[_ContentsItem]) -> None:
         """The contents of container as a list of (widget, options)"""
 
     @property

--- a/urwid/widget/grid_flow.py
+++ b/urwid/widget/grid_flow.py
@@ -14,14 +14,12 @@ from .divider import Divider
 from .monitored_list import MonitoredFocusList, MonitoredList
 from .padding import Padding
 from .pile import Pile
-from .widget import AbstractWidget, WidgetError, WidgetWarning, WidgetWrap
+from .widget import AbstractFlowWidget, WidgetError, WidgetWarning, WidgetWrap
 
 if typing.TYPE_CHECKING:
     from collections.abc import Iterable, Iterator, Sequence
 
     from urwid.canvas import Canvas
-
-    from .widget import AbstractFixedWidget, AbstractFlowWidget
 
 
 class GridFlowError(WidgetError):
@@ -35,7 +33,7 @@ class GridFlowWarning(WidgetWarning):
 class GridFlow(
     WidgetWrap[typing.Union[Pile, Divider]],
     WidgetContainerMixin[int],
-    WidgetContainerListContentsMixin[tuple[Literal[WHSettings.GIVEN], int]],
+    WidgetContainerListContentsMixin[tuple[AbstractFlowWidget, tuple[Literal[WHSettings.GIVEN], int]]],
 ):
     """
     The GridFlow widget is a flow widget that renders all the widgets it contains the same width,
@@ -53,12 +51,12 @@ class GridFlow(
 
     def __init__(
         self,
-        cells: Iterable[AbstractFlowWidget | AbstractFixedWidget],
+        cells: Iterable[AbstractFlowWidget],
         cell_width: int,
         h_sep: int,
         v_sep: int,
         align: Literal["left", "center", "right"] | Align | tuple[Literal["relative", WHSettings.RELATIVE], int],
-        focus: int | AbstractWidget | None = None,
+        focus: int | AbstractFlowWidget | None = None,
     ) -> None:
         """
         :param cells: iterable of flow widgets to display
@@ -70,7 +68,7 @@ class GridFlow(
             'left', 'center', 'right', ('relative', percentage 0=left 100=right)
         :param focus: widget index or widget instance to focus on
         """
-        prepared_contents: list[tuple[AbstractWidget, tuple[Literal[WHSettings.GIVEN], int]]] = []
+        prepared_contents: list[tuple[AbstractFlowWidget, tuple[Literal[WHSettings.GIVEN], int]]] = []
         focus_position: int = -1
 
         for idx, widget in enumerate(cells):
@@ -80,7 +78,7 @@ class GridFlow(
 
         focus_position = max(focus_position, 0)
 
-        self._contents: MonitoredFocusList[tuple[AbstractWidget, tuple[Literal[WHSettings.GIVEN], int]]] = (
+        self._contents: MonitoredFocusList[tuple[AbstractFlowWidget, tuple[Literal[WHSettings.GIVEN], int]]] = (
             MonitoredFocusList(
                 prepared_contents,
                 focus=focus_position,
@@ -134,7 +132,7 @@ class GridFlow(
     def _contents_modified(
         self,
         _slc: tuple[int, int, int],
-        new_items: Iterable[tuple[AbstractWidget, tuple[Literal["given", WHSettings.GIVEN], int]]],
+        new_items: Iterable[tuple[AbstractFlowWidget, tuple[Literal["given", WHSettings.GIVEN], int]]],
     ) -> None:
         for item in new_items:
             try:
@@ -145,7 +143,7 @@ class GridFlow(
                 raise GridFlowError(f"added content invalid {item!r}").with_traceback(exc.__traceback__) from exc
 
     @property
-    def cells(self) -> MonitoredList[AbstractWidget]:
+    def cells(self) -> MonitoredList[AbstractFlowWidget]:
         """
         A list of the widgets in this GridFlow
 
@@ -169,7 +167,7 @@ class GridFlow(
         return ml
 
     @cells.setter
-    def cells(self, widgets: MonitoredList[AbstractWidget]) -> None:
+    def cells(self, widgets: MonitoredList[AbstractFlowWidget]) -> None:
         warnings.warn(
             "only for backwards compatibility."
             "You should use the new standard container property `contents` to modify GridFlow."
@@ -198,7 +196,7 @@ class GridFlow(
         self._cell_width = width
 
     @property
-    def contents(self) -> MonitoredFocusList[tuple[AbstractWidget, tuple[Literal[WHSettings.GIVEN], int]]]:
+    def contents(self) -> MonitoredFocusList[tuple[AbstractFlowWidget, tuple[Literal[WHSettings.GIVEN], int]]]:
         """
         The contents of this GridFlow as a list of (widget, options)
         tuples.
@@ -215,7 +213,7 @@ class GridFlow(
         return self._contents
 
     @contents.setter
-    def contents(self, c: Sequence[tuple[AbstractWidget, tuple[Literal[WHSettings.GIVEN], int]]]) -> None:
+    def contents(self, c: Sequence[tuple[AbstractFlowWidget, tuple[Literal[WHSettings.GIVEN], int]]]) -> None:
         self._contents[:] = c
 
     def options(
@@ -235,7 +233,7 @@ class GridFlow(
             width_amount = self._cell_width
         return (WHSettings.GIVEN, width_amount)
 
-    def set_focus(self, cell: AbstractWidget | int) -> None:
+    def set_focus(self, cell: AbstractFlowWidget | int) -> None:
         """
         Set the cell in focus, for backwards compatibility.
 
@@ -270,13 +268,13 @@ class GridFlow(
         raise ValueError(f"Widget not found in GridFlow contents: {cell!r}")
 
     @property
-    def focus(self) -> AbstractWidget | None:
+    def focus(self) -> AbstractFlowWidget | None:
         """the child widget in focus or None when GridFlow is empty"""
         if not self.contents:
             return None
         return self.contents[self.focus_position][0]
 
-    def get_focus(self) -> AbstractWidget | None:
+    def get_focus(self) -> AbstractFlowWidget | None:
         """
         Return the widget in focus, for backwards compatibility.
 
@@ -295,7 +293,7 @@ class GridFlow(
         return self.contents[self.focus_position][0]
 
     @property
-    def focus_cell(self) -> AbstractWidget | None:
+    def focus_cell(self) -> AbstractFlowWidget | None:
         warnings.warn(
             "only for backwards compatibility."
             "You may also use the new standard container property"
@@ -307,7 +305,7 @@ class GridFlow(
         return self.focus
 
     @focus_cell.setter
-    def focus_cell(self, cell: AbstractWidget) -> None:
+    def focus_cell(self, cell: AbstractFlowWidget) -> None:
         warnings.warn(
             "only for backwards compatibility."
             "You may also use the new standard container property"
@@ -403,17 +401,28 @@ class GridFlow(
             if c is None or maxcol - used_space < width_amount:
                 # starting a new row
                 if self.v_sep:
-                    p.contents.append((divider, p.options()))
+                    p.contents.append((divider, typing.cast("tuple[Literal[WHSettings.WEIGHT], int]", p.options())))
                 c = Columns([], self.h_sep)
                 column_focused = False
                 pad = Padding(c, self.align)
                 # extra attribute to reference contents position
                 pad.first_position = i
-                p.contents.append((pad, p.options()))
+                p.contents.append((pad, typing.cast("tuple[Literal[WHSettings.WEIGHT], int]", p.options())))
 
             # Use width == maxcol in case of maxcol < width amount
             # Columns will use empty widget in case of GIVEN width > maxcol
-            c.contents.append((w, c.options(WHSettings.GIVEN, min(width_amount, maxcol))))
+            c.contents.append(
+                (
+                    typing.cast("AbstractFlowWidget", w),
+                    typing.cast(
+                        "tuple[Literal[WHSettings.GIVEN], int, Literal[False]]",
+                        c.options(
+                            WHSettings.GIVEN,
+                            min(width_amount, maxcol),
+                        ),
+                    ),
+                )
+            )
             if (i == self.focus_position) or (not column_focused and w.selectable()):
                 c.focus_position = len(c.contents) - 1
                 column_focused = True

--- a/urwid/widget/overlay.py
+++ b/urwid/widget/overlay.py
@@ -75,7 +75,7 @@ class OverlayOptions(typing.NamedTuple):
 class Overlay(
     Widget,
     WidgetContainerMixin[Literal[0, 1]],
-    WidgetContainerListContentsMixin[OverlayOptions],
+    WidgetContainerListContentsMixin[tuple[typing.Union[TopWidget, BottomWidget], OverlayOptions]],
     typing.Generic[TopWidget, BottomWidget],
 ):
     """Overlay contains two widgets and renders one on top of the other.
@@ -608,7 +608,7 @@ class Overlay(
         if position != 1:
             raise IndexError(f"Overlay widget focus_position currently must always be set to 1, not {position}")
 
-    @property  # type: ignore[override]
+    @property
     def contents(self) -> MutableSequence[tuple[TopWidget | BottomWidget, OverlayOptions]]:
         """
         a list-like object similar to::
@@ -667,7 +667,7 @@ class Overlay(
 
         return OverlayContents()
 
-    @contents.setter  # type: ignore[override]
+    @contents.setter
     def contents(self, new_contents: Sequence[tuple[TopWidget | BottomWidget, OverlayOptions]]) -> None:
         if len(new_contents) != 2:
             raise ValueError("Contents length for overlay should be only 2")

--- a/urwid/widget/pile.py
+++ b/urwid/widget/pile.py
@@ -15,12 +15,18 @@ from urwid.util import is_mouse_press
 from .constants import Sizing, WHSettings
 from .container import WidgetContainerListContentsMixin, WidgetContainerMixin, _ContainerElementSizingFlag
 from .monitored_list import MonitoredFocusList, MonitoredList
-from .widget import AbstractWidget, Widget, WidgetError, WidgetWarning
+from .widget import (
+    AbstractBoxWidget,
+    AbstractFixedWidget,
+    AbstractFlowWidget,
+    AbstractWidget,
+    Widget,
+    WidgetError,
+    WidgetWarning,
+)
 
 if typing.TYPE_CHECKING:
     from collections.abc import Collection, Iterable, Iterator, Sequence
-
-    from .widget import AbstractBoxWidget, AbstractFixedWidget, AbstractFlowWidget
 
 
 class PileError(WidgetError):
@@ -36,9 +42,18 @@ class Pile(
     WidgetContainerMixin[int],
     WidgetContainerListContentsMixin[
         typing.Union[
-            tuple[Literal[WHSettings.PACK], None],
-            tuple[Literal[WHSettings.GIVEN], int],
-            tuple[Literal[WHSettings.WEIGHT], typing.Union[int, float]],
+            tuple[
+                typing.Union[AbstractFlowWidget, AbstractFixedWidget],
+                tuple[Literal[WHSettings.PACK], None],
+            ],
+            tuple[
+                AbstractBoxWidget,
+                tuple[Literal[WHSettings.GIVEN], int],
+            ],
+            tuple[
+                typing.Union[AbstractBoxWidget, AbstractFlowWidget],
+                tuple[Literal[WHSettings.WEIGHT], typing.Union[int, float]],
+            ],
         ]
     ],
 ):
@@ -211,10 +226,16 @@ class Pile(
         super().__init__()
         self._contents: MonitoredFocusList[
             tuple[
-                AbstractWidget,
-                tuple[Literal[WHSettings.PACK], None]
-                | tuple[Literal[WHSettings.GIVEN], int]
-                | tuple[Literal[WHSettings.WEIGHT], int | float],
+                AbstractFlowWidget | AbstractFixedWidget,
+                tuple[Literal[WHSettings.PACK], None],
+            ]
+            | tuple[
+                AbstractBoxWidget,
+                tuple[Literal[WHSettings.GIVEN], int],
+            ]
+            | tuple[
+                AbstractBoxWidget | AbstractFlowWidget,
+                tuple[Literal[WHSettings.WEIGHT], int | float],
             ]
         ] = MonitoredFocusList()
         self._contents.set_modified_callback(self._contents_modified)
@@ -228,16 +249,45 @@ class Pile(
             elif len(original) == 2:
                 if original[0] in {Sizing.FLOW, WHSettings.PACK}:  # 'pack' used to be called 'flow'
                     w = original[-1]
-                    self.contents.append((w, (WHSettings.PACK, None)))
+                    self.contents.append(
+                        (
+                            typing.cast("AbstractFlowWidget | AbstractFixedWidget", w),
+                            (WHSettings.PACK, None),
+                        )
+                    )
                 else:
                     height, w = original
-                    self.contents.append((w, (WHSettings.GIVEN, typing.cast("int", height))))
+                    self.contents.append(
+                        (
+                            typing.cast("AbstractBoxWidget", w),
+                            (
+                                WHSettings.GIVEN,
+                                typing.cast("int", height),
+                            ),
+                        )
+                    )
             elif len(original) == 3:
                 settings, height, w = original  # type: ignore[assignment]
                 if settings in {Sizing.FIXED, WHSettings.GIVEN}:  # backwards compatibility
-                    self.contents.append((w, (WHSettings.GIVEN, typing.cast("int", height))))
+                    self.contents.append(
+                        (
+                            typing.cast("AbstractBoxWidget", w),
+                            (
+                                WHSettings.GIVEN,
+                                typing.cast("int", height),
+                            ),
+                        )
+                    )
                 elif settings == WHSettings.WEIGHT:
-                    self.contents.append((w, (WHSettings.WEIGHT, typing.cast("int | float", height))))
+                    self.contents.append(
+                        (
+                            typing.cast("AbstractBoxWidget | AbstractFlowWidget", w),
+                            (
+                                WHSettings.WEIGHT,
+                                typing.cast("int | float", height),
+                            ),
+                        )
+                    )
                 else:
                     raise PileError(f"initial widget list item invalid {original!r}")
             else:
@@ -351,7 +401,7 @@ class Pile(
     def widget_list(self, widgets: MonitoredList[AbstractWidget]) -> None:
         focus_position = self.focus_position
         self.contents = [
-            (new, options)
+            (new, options)  # type: ignore[misc]  # deprecated API, historic code lack support of FIXED
             for (new, (w, options)) in zip(
                 widgets,
                 # need to grow contents list if widgets is longer
@@ -436,10 +486,16 @@ class Pile(
         self,
     ) -> MonitoredFocusList[
         tuple[
-            AbstractWidget,
-            tuple[Literal[WHSettings.PACK], None]
-            | tuple[Literal[WHSettings.GIVEN], int]
-            | tuple[Literal[WHSettings.WEIGHT], int | float],
+            AbstractFlowWidget | AbstractFixedWidget,
+            tuple[Literal[WHSettings.PACK], None],
+        ]
+        | tuple[
+            AbstractBoxWidget,
+            tuple[Literal[WHSettings.GIVEN], int],
+        ]
+        | tuple[
+            AbstractBoxWidget | AbstractFlowWidget,
+            tuple[Literal[WHSettings.WEIGHT], int | float],
         ]
     ]:
         """
@@ -475,10 +531,16 @@ class Pile(
         self,
         c: Sequence[
             tuple[
-                AbstractWidget,
-                tuple[Literal[WHSettings.PACK], None]
-                | tuple[Literal[WHSettings.GIVEN], int]
-                | tuple[Literal[WHSettings.WEIGHT], int | float],
+                AbstractFlowWidget | AbstractFixedWidget,
+                tuple[Literal[WHSettings.PACK], None],
+            ]
+            | tuple[
+                AbstractBoxWidget,
+                tuple[Literal[WHSettings.GIVEN], int],
+            ]
+            | tuple[
+                AbstractBoxWidget | AbstractFlowWidget,
+                tuple[Literal[WHSettings.WEIGHT], int | float],
             ]
         ],
     ) -> None:
@@ -672,7 +734,7 @@ class Pile(
             focused = focus and self.focus == widget
             if size_kind == WHSettings.PACK:
                 if Sizing.FIXED in w_sizing:
-                    widths[idx], heights[idx] = widget.pack((), focused)
+                    widths[idx], heights[idx] = typing.cast("AbstractFixedWidget", widget).pack((), focused)
                     w_h_args[idx] = ()
                 if Sizing.FLOW in w_sizing:
                     # re-calculate height at the end
@@ -696,7 +758,7 @@ class Pile(
                     w_h_args[idx] = (0, 0)
 
             elif Sizing.FIXED in w_sizing and w_sizing & {Sizing.BOX, Sizing.FLOW}:
-                width, height = widget.pack((), focused)
+                width, height = typing.cast("AbstractFixedWidget", widget).pack((), focused)
                 widths[idx] = width  # We're fitting everything in case of FIXED
 
                 if Sizing.BOX in w_sizing:
@@ -782,7 +844,7 @@ class Pile(
                 heights.append(typing.cast("AbstractFlowWidget", w).rows((maxcol,), focus=focused))
                 w_h_args.append((maxcol,))
             elif Sizing.FIXED in w_sizing and f == WHSettings.PACK:
-                heights.append(w.pack((), focused)[1])
+                heights.append(typing.cast("AbstractFixedWidget", w).pack((), focused)[1])
                 w_h_args.append(())
             else:
                 warnings.warn(
@@ -847,7 +909,8 @@ class Pile(
                     )
                     w_h_arg = (maxcol,)
 
-                item_height = w.pack(w_h_arg, focused)[1]
+                # widget kind and size arguments matched separately
+                item_height = w.pack(w_h_arg, focused)[1]  # type: ignore[arg-type]
                 heights[i] = item_height
                 w_h_args[i] = w_h_arg
                 remaining -= item_height
@@ -940,7 +1003,8 @@ class Pile(
             item_focus = self.focus == w
             canv = None
             if height > 0:
-                canv = w.render(w_size, focus=focus and item_focus)
+                # widget kind and size arguments matched separately
+                canv = w.render(w_size, focus=focus and item_focus)  # type: ignore[arg-type]
 
             if canv:
                 combinelist.append((canv, i, item_focus))
@@ -1099,4 +1163,12 @@ class Pile(
             )
             return False
 
-        return w.mouse_event(w_size, event, button, col, target_row, focus and self.focus == w)
+        # widget kind and size arguments matched separately
+        return w.mouse_event(
+            w_size,  # type: ignore[arg-type]
+            event,
+            button,
+            col,
+            target_row,
+            focus and self.focus == w,
+        )


### PR DESCRIPTION
Extend detalisation for `Columns`, `GridFlow`, `Overlay` and `Pile`:
* Widget kind and sizing combination
* `contents`
* `_contents`

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

Partial #1146 