### PR TITLE
Typing: simplify internal annotations

### DIFF
--- a/urwid/widget/container.py
+++ b/urwid/widget/container.py
@@ -5,11 +5,10 @@ import enum
 import typing
 
 from .constants import Sizing, WHSettings
+from .widget import AbstractWidget
 
 if typing.TYPE_CHECKING:
     from collections.abc import Iterable, Iterator, MutableSequence, Sequence
-
-    from .widget import AbstractWidget
 
     _KT_contra = typing.TypeVar("_KT_contra", contravariant=True)
 
@@ -17,7 +16,7 @@ if typing.TYPE_CHECKING:
         def __getitem__(
             self,
             index: _KT_contra,
-        ) -> tuple[AbstractWidget, typing.Unpack[tuple[typing.Any, ...]] | None]: ...
+        ) -> tuple[AbstractWidget, typing.Any]: ...
 
     class WidgetContainerMixinProto(AbstractWidget, typing.Protocol[_KT_contra]):
         @property
@@ -36,7 +35,7 @@ else:
         """Generic protocol support."""
 
 
-_ContentsItem = typing.TypeVar("_ContentsItem", bound=tuple[typing.Any, ...])
+_ContentsItem = typing.TypeVar("_ContentsItem", bound=tuple[AbstractWidget, typing.Any])
 
 
 # Ideally, we would like to use an IntFlag coupled with enum.auto().

--- a/urwid/widget/filler.py
+++ b/urwid/widget/filler.py
@@ -108,7 +108,7 @@ class Filler(WidgetDecoration[WrappedWidget]):
                 bottom = valign[1]
                 normalized_valign = VAlign.BOTTOM
             else:
-                normalized_valign = valign
+                normalized_valign = valign  # type: ignore[assignment]
 
         elif not isinstance(valign, (VAlign, str)):
             raise FillerError(f"invalid valign: {valign!r}")

--- a/urwid/widget/frame.py
+++ b/urwid/widget/frame.py
@@ -602,7 +602,7 @@ class Frame(
             coords = self.header.get_cursor_coords((maxcol,))  # type: ignore[union-attr]  # expect not None
         elif fp == "body":
             row_adjust = hrows
-            coords = self.body.get_cursor_coords((maxcol, maxrow - hrows - frows))
+            coords = self.body.get_cursor_coords((maxcol, maxrow - hrows - frows))  # type: ignore[attr-defined]
         else:
             row_adjust = maxrow - frows
             coords = self.footer.get_cursor_coords((maxcol,))  # type: ignore[union-attr]  # expect not None

--- a/urwid/widget/grid_flow.py
+++ b/urwid/widget/grid_flow.py
@@ -30,10 +30,14 @@ class GridFlowWarning(WidgetWarning):
     """GridFlow specific warning."""
 
 
+GridFlowOptions = tuple[Literal[WHSettings.GIVEN], int]
+GridFlowContentsItem = tuple[AbstractFlowWidget, GridFlowOptions]
+
+
 class GridFlow(
     WidgetWrap[typing.Union[Pile, Divider]],
     WidgetContainerMixin[int],
-    WidgetContainerListContentsMixin[tuple[AbstractFlowWidget, tuple[Literal[WHSettings.GIVEN], int]]],
+    WidgetContainerListContentsMixin[GridFlowContentsItem],
 ):
     """
     The GridFlow widget is a flow widget that renders all the widgets it contains the same width,
@@ -68,7 +72,7 @@ class GridFlow(
             'left', 'center', 'right', ('relative', percentage 0=left 100=right)
         :param focus: widget index or widget instance to focus on
         """
-        prepared_contents: list[tuple[AbstractFlowWidget, tuple[Literal[WHSettings.GIVEN], int]]] = []
+        prepared_contents: list[GridFlowContentsItem] = []
         focus_position: int = -1
 
         for idx, widget in enumerate(cells):
@@ -78,11 +82,9 @@ class GridFlow(
 
         focus_position = max(focus_position, 0)
 
-        self._contents: MonitoredFocusList[tuple[AbstractFlowWidget, tuple[Literal[WHSettings.GIVEN], int]]] = (
-            MonitoredFocusList(
-                prepared_contents,
-                focus=focus_position,
-            )
+        self._contents: MonitoredFocusList[GridFlowContentsItem] = MonitoredFocusList(
+            prepared_contents,
+            focus=focus_position,
         )
         self._contents.set_modified_callback(self._invalidate)
         self._contents.set_focus_changed_callback(lambda f: self._invalidate())
@@ -132,7 +134,7 @@ class GridFlow(
     def _contents_modified(
         self,
         _slc: tuple[int, int, int],
-        new_items: Iterable[tuple[AbstractFlowWidget, tuple[Literal["given", WHSettings.GIVEN], int]]],
+        new_items: Iterable[GridFlowContentsItem],
     ) -> None:
         for item in new_items:
             try:
@@ -196,7 +198,7 @@ class GridFlow(
         self._cell_width = width
 
     @property
-    def contents(self) -> MonitoredFocusList[tuple[AbstractFlowWidget, tuple[Literal[WHSettings.GIVEN], int]]]:
+    def contents(self) -> MonitoredFocusList[GridFlowContentsItem]:
         """
         The contents of this GridFlow as a list of (widget, options)
         tuples.
@@ -213,14 +215,14 @@ class GridFlow(
         return self._contents
 
     @contents.setter
-    def contents(self, c: Sequence[tuple[AbstractFlowWidget, tuple[Literal[WHSettings.GIVEN], int]]]) -> None:
+    def contents(self, c: Sequence[GridFlowContentsItem]) -> None:
         self._contents[:] = c
 
     def options(
         self,
         width_type: Literal["given", WHSettings.GIVEN] = WHSettings.GIVEN,
         width_amount: int | None = None,
-    ) -> tuple[Literal[WHSettings.GIVEN], int]:
+    ) -> GridFlowOptions:
         """
         Return a new options tuple for use in a GridFlow's .contents list.
 
@@ -393,7 +395,7 @@ class GridFlow(
             # increase size of divider
             divider.top = self.v_sep - 1
 
-        c = None
+        c: Columns | None = None
         p = Pile([])
         used_space = 0
 
@@ -413,7 +415,7 @@ class GridFlow(
             # Columns will use empty widget in case of GIVEN width > maxcol
             c.contents.append(
                 (
-                    typing.cast("AbstractFlowWidget", w),
+                    w,
                     typing.cast(
                         "tuple[Literal[WHSettings.GIVEN], int, Literal[False]]",
                         c.options(
@@ -428,7 +430,7 @@ class GridFlow(
                 column_focused = True
             if i == self.focus_position:
                 p.focus_position = len(p.contents) - 1
-            used_space = sum(x[1][1] for x in c.contents) + self.h_sep * len(c.contents)
+            used_space = sum(typing.cast("int", x[1][1]) for x in c.contents) + self.h_sep * len(c.contents)
             pad.width = used_space - self.h_sep
 
         if self.v_sep:
@@ -456,7 +458,7 @@ class GridFlow(
         pile_focus = self._w.focus
         if not pile_focus:
             return
-        c = pile_focus.base_widget
+        c = typing.cast("Columns", pile_focus.base_widget)
         if c.focus:
             col_focus_position = c.focus_position
         else:

--- a/urwid/widget/overlay.py
+++ b/urwid/widget/overlay.py
@@ -72,10 +72,13 @@ class OverlayOptions(typing.NamedTuple):
     bottom: int
 
 
+OverlayContentsItem = tuple[typing.Union[TopWidget, BottomWidget], OverlayOptions]
+
+
 class Overlay(
     Widget,
     WidgetContainerMixin[Literal[0, 1]],
-    WidgetContainerListContentsMixin[tuple[typing.Union[TopWidget, BottomWidget], OverlayOptions]],
+    WidgetContainerListContentsMixin[OverlayContentsItem],
     typing.Generic[TopWidget, BottomWidget],
 ):
     """Overlay contains two widgets and renders one on top of the other.
@@ -609,7 +612,7 @@ class Overlay(
             raise IndexError(f"Overlay widget focus_position currently must always be set to 1, not {position}")
 
     @property
-    def contents(self) -> MutableSequence[tuple[TopWidget | BottomWidget, OverlayOptions]]:
+    def contents(self) -> MutableSequence[OverlayContentsItem]:
         """
         a list-like object similar to::
 
@@ -633,14 +636,7 @@ class Overlay(
         """
 
         # noinspection PyMethodParameters
-        class OverlayContents(
-            MutableSequence[
-                tuple[
-                    typing.Union[TopWidget, BottomWidget],
-                    OverlayOptions,
-                ]
-            ]
-        ):
+        class OverlayContents(MutableSequence[OverlayContentsItem]):
             # pylint: disable=no-self-argument
             def __len__(inner_self) -> int:
                 return 2
@@ -661,14 +657,14 @@ class Overlay(
                 for val in inner_self:
                     yield None, val
 
-            def __iter__(inner_self) -> Iterator[tuple[TopWidget | BottomWidget, OverlayOptions]]:
+            def __iter__(inner_self) -> Iterator[OverlayContentsItem]:
                 for idx in range(2):
                     yield inner_self[idx]  # type: ignore[arg-type]
 
         return OverlayContents()
 
     @contents.setter
-    def contents(self, new_contents: Sequence[tuple[TopWidget | BottomWidget, OverlayOptions]]) -> None:
+    def contents(self, new_contents: Sequence[OverlayContentsItem]) -> None:
         if len(new_contents) != 2:
             raise ValueError("Contents length for overlay should be only 2")
         self.contents[0] = new_contents[0]
@@ -813,7 +809,7 @@ class Overlay(
                 self.align_type,
                 self.align_amount,
                 WHSettings.CLIP,
-                width,
+                typing.cast("int", width),
                 None,
                 self.left,
                 self.right,
@@ -824,7 +820,7 @@ class Overlay(
                 self.align_type,
                 self.align_amount,
                 self.width_type,
-                self.width_amount,
+                typing.cast("int", self.width_amount),
                 self.min_width,
                 self.left,
                 self.right,


### PR DESCRIPTION
* Reduce copy-paste for grid_flow and container
* Ignore known places for frame and filler

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

Partial #1146 