### PR TITLE
Raw display: do not crash on a last row of a single wide grapheme

### DIFF
--- a/tests/test_raw_display.py
+++ b/tests/test_raw_display.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import unittest
 
 import urwid
+from urwid.util import set_temporary_encoding
 
 
 class TestRawDisplay(unittest.TestCase):
@@ -12,3 +13,25 @@ class TestRawDisplay(unittest.TestCase):
         a2e = s._attrspec_to_escape
         self.assertEqual("\x1b[0;33;42m", a2e(s.AttrSpec("brown", "dark green")))
         self.assertEqual("\x1b[0;38;5;229;4;48;5;164m", a2e(s.AttrSpec("#fea,underline", "#d0d")))
+
+    def test_last_row_without_preceding_segment(self):
+        """A last row holding a single grapheme has no character to slide back."""
+        s = urwid.display.raw.Screen()
+        row = [(None, None, "日".encode())]
+
+        self.assertEqual((row, 0, None), s._last_row(row))
+
+    def test_draw_screen_two_columns_wide_characters(self):
+        """Drawing double width text on a two column screen used to raise IndexError."""
+        s = urwid.display.raw.Screen()
+        written: list[str] = []
+        s.write = written.append
+        s.flush = lambda: None
+        s._started = True
+
+        with set_temporary_encoding("utf-8"):
+            canvas = urwid.Text("日本語").render((2,))
+            s.draw_screen((2, canvas.rows()), canvas)
+
+        self.assertEqual(3, canvas.rows())
+        self.assertIn("語", "".join(written))

--- a/urwid/display/_raw_display_base.py
+++ b/urwid/display/_raw_display_base.py
@@ -757,7 +757,7 @@ class Screen(BaseScreen, RealTerminal):
     ) -> tuple[
         list[tuple[AttrSpec | str | None, Literal["0", "U"] | None, bytes]],
         int,
-        tuple[AttrSpec | str | None, Literal["0", "U"] | None, bytes],
+        tuple[AttrSpec | str | None, Literal["0", "U"] | None, bytes] | None,
     ]:
         """On the last row we need to slide the bottom right character into place.
 
@@ -767,6 +767,10 @@ class Screen(BaseScreen, RealTerminal):
         XXXXXXXXXXXXXXXXXXXXYZ
 
         Y will be drawn after Z, shifting Z into position.
+
+        When the whole row is a single grapheme, as happens with a double width
+        character on a two column screen, there is no Y to draw after Z.
+        The row is then returned untouched and no insert sequence is produced.
         """
 
         new_row: list[tuple[AttrSpec | str | None, Literal["0", "U"] | None, bytes]] = row[:-1]
@@ -774,6 +778,8 @@ class Screen(BaseScreen, RealTerminal):
         last_cols = str_util.calc_width(last_text, 0, len(last_text))
         last_offs, z_col = str_util.calc_text_pos(last_text, 0, len(last_text), last_cols - 1)
         if last_offs == 0:
+            if not new_row:
+                return row, 0, None
             z_text = last_text
             del new_row[-1]
             # we need another segment


### PR DESCRIPTION
##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [ ] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

On `tox`: I only have Windows with Python 3.13 here, so I ran the CI test command plus `ruff` and `pylint` rather than the full matrix. Details under Testing.

##### Description:

Fixes #468.

`_last_row` builds `new_row = row[:-1]` and then, when the last segment holds a single grapheme, borrows a character from `row[-2]` to draw after it. If the row is made of exactly one segment there is no `row[-2]`, and `del new_row[-1]` runs against an empty list:

```
File "urwid/display/_raw_display_base.py", line 778, in _last_row
    del new_row[-1]
IndexError: list assignment index out of range
```

That is the traceback in the issue. It shows up whenever the last row of the canvas is a single grapheme wider than one column, which on a two column screen means any CJK character or emoji:

```python
>>> import urwid
>>> [list(r) for r in urwid.Text("日本語").render((2,)).content()]
[[(None, None, b'\xe6\x97\xa5')], [(None, None, b'\xe6\x9c\xac')], [(None, None, b'\xe8\xaa\x9e')]]
```

There is nothing to slide here. The trick needs a character before the last one so it can be drawn afterwards, and a row that is one grapheme wide does not have one. The change returns the row untouched with no insert sequence, so the row is drawn the ordinary way. The bottom right cell loses the insert trick, which costs one cell of cosmetics, and the alternative today is the application dying.

If you would rather guard at the call site in `draw_screen`, or fail with something more specific than a bare `IndexError`, say the word and I will change it.

##### Testing

Two tests in `tests/test_raw_display.py`. Both fail on `master` with the IndexError above and pass with the change:

- `test_last_row_without_preceding_segment` calls `_last_row` directly, following the style already used in that file.
- `test_draw_screen_two_columns_wide_characters` goes through `draw_screen`, which is the path in the reported traceback.

Ran on Windows with Python 3.13.7:

- `python -m unittest discover -s tests`: 444 tests, 16 errors. The same 16 fail on `master` without this change, and all of them are Windows specific (`os.O_NONBLOCK`, `fcntl`, the vterm module).
- `ruff format --check .` and `ruff check .` on the two touched files: clean. The findings elsewhere are all in `docs/examples/`, where the symlinks land as text files on a Windows checkout.
- `pylint urwid/display/_raw_display_base.py`: 10.00/10.

I also checked by hand that the normal path still slides: on an eight column screen the output is `abcdefh`, backspace, `\x1b[1@`, `g`, so `g` is still inserted after `h`. Emoji on two columns and a wide character on three columns both draw without raising.

The full `tox` matrix I could not run, so 3.9 through 3.14 are untested from my side. The change uses nothing newer than 3.9.

Disclosure: I used an AI coding assistant while working on this. Every command and result reported above I ran and checked myself.
