### PR TITLE
GridFlow: keep the focus a callback set during keypress or mouse event

### DIFF
--- a/tests/test_grid_flow.py
+++ b/tests/test_grid_flow.py
@@ -155,6 +155,56 @@ class GridFlowTest(unittest.TestCase):
         self.assertEqual(gf.keypress((20,), "enter"), None)
         call_back.assert_called_with(button)
 
+    def test_keypress_callback_can_set_focus_position(self):
+        """
+        A callback fired by the keypress may set the focus itself.
+        https://github.com/urwid/urwid/issues/194
+        """
+        gf = urwid.GridFlow(
+            [urwid.Button(f"b{idx}", lambda _btn: setattr(gf, "focus_position", 1)) for idx in range(4)],
+            10,
+            1,
+            0,
+            "left",
+        )
+        gf.focus_position = 2
+
+        self.assertEqual(gf.keypress((80,), "enter"), None)
+        self.assertEqual(1, gf.focus_position)
+
+    def test_keypress_without_callback_still_follows_the_display_widget(self):
+        gf = urwid.GridFlow([urwid.Button(f"b{idx}") for idx in range(4)], 10, 1, 0, "left")
+        gf.focus_position = 0
+
+        self.assertEqual(gf.keypress((80,), "right"), None)
+        self.assertEqual(1, gf.focus_position)
+
+    def test_mouse_event_callback_can_set_focus_position(self):
+        """
+        Same as the keypress case, for a callback fired by a click.
+        """
+        gf = urwid.GridFlow(
+            [urwid.Button(f"b{idx}", lambda _btn: setattr(gf, "focus_position", 1)) for idx in range(4)],
+            10,
+            1,
+            0,
+            "left",
+        )
+        gf.focus_position = 0
+        gf.render((80,))
+
+        # column 35 is inside the fourth cell
+        self.assertTrue(gf.mouse_event((80,), "mouse press", 1, 35, 0, True))
+        self.assertEqual(1, gf.focus_position)
+
+    def test_mouse_event_without_callback_still_follows_the_display_widget(self):
+        gf = urwid.GridFlow([urwid.Button(f"b{idx}") for idx in range(4)], 10, 1, 0, "left")
+        gf.focus_position = 0
+        gf.render((80,))
+
+        self.assertTrue(gf.mouse_event((80,), "mouse press", 1, 35, 0, True))
+        self.assertEqual(3, gf.focus_position)
+
     def test_length(self):
         grid = urwid.GridFlow((urwid.Text(c) for c in "ABC"), 1, 0, 0, "left")
         self.assertEqual(3, len(grid))

--- a/urwid/widget/grid_flow.py
+++ b/urwid/widget/grid_flow.py
@@ -476,11 +476,15 @@ class GridFlow(
         Captures focus changes.
         """
         self.get_display_widget(size)
+        focus_before = self.contents.focus
 
         if (processed := super().keypress(size, key)) is not None:  # type: ignore[safe-super]  # dynamic base
             return processed
 
-        self._set_focus_from_display_widget()
+        # The display widget was built before the keypress was dispatched, so a callback
+        # that set the focus itself is the more recent value and must not be overwritten.
+        if self.contents.focus == focus_before:
+            self._set_focus_from_display_widget()
         return None
 
     def pack(
@@ -530,8 +534,12 @@ class GridFlow(
         focus: bool,
     ) -> Literal[True]:
         self.get_display_widget(size)
+        focus_before = self.contents.focus
         super().mouse_event(size, event, button, col, row, focus)  # type: ignore[safe-super]  # dynamic base
-        self._set_focus_from_display_widget()
+        # Same as in keypress: a callback that set the focus itself wins over the
+        # display widget, which was built before the event was dispatched.
+        if self.contents.focus == focus_before:
+            self._set_focus_from_display_widget()
         return True  # at a minimum we adjusted our focus
 
     def get_pref_col(self, size: tuple[int] | tuple[()]) -> int:


### PR DESCRIPTION
##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [ ] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

On `tox`: same situation as in #1229, I only have Windows with Python 3.13 here, so I ran the CI test command plus `ruff` and `pylint` instead of the full matrix. Details under Testing.

##### Description:

Fixes #194.

`keypress` builds the display widget, dispatches the event, and then copies the focus back out of that display widget:

```python
self.get_display_widget(size)

if (processed := super().keypress(size, key)) is not None:
    return processed

self._set_focus_from_display_widget()
```

If a callback runs during the dispatch and sets `focus_position` itself, the setter writes `contents.focus` and the registered callback only invalidates, it does not rebuild `_w`. So by the time `_set_focus_from_display_widget()` runs, `self._w` still holds the position from before the callback, and it overwrites the newer value.

```python
def on_press(btn):
    grid.focus_position = 1

grid = urwid.GridFlow([urwid.Button(f"b{i}", on_press) for i in range(4)], 10, 1, 0, "left")
grid.focus_position = 2
grid.keypress((80,), "enter")
# focus_position is 2, the callback's 1 is gone
```

`mouse_event` has the same shape and the same defect. I checked it: clicking the fourth cell with that callback ends on 3, not on 1.

This is the only container that behaves this way. I ran the same callback through `Columns`, `Pile` and `ListBox` and all three end on 1. `docs/manual/widgets.rst` lists `GridFlow` among the containers with integer `focus_position` and says writing a new value "will be reflected in `container.focus`", so the current behaviour also disagrees with the documented contract.

The change skips the copy when `contents.focus` changed while the event was being dispatched. I kept `_set_focus_from_display_widget` and its signature untouched, and left `move_cursor_to_coords` alone, since no user callback runs on that path.

If you would rather fix this structurally, by rebuilding `_w` on demand or by having the focus-changed callback do more than invalidate, I am happy to redo it that way.

##### Testing

Four tests in `tests/test_grid_flow.py`, next to the existing `test_keypress_v_sep_0`:

- `test_keypress_callback_can_set_focus_position` and `test_mouse_event_callback_can_set_focus_position` are the bug. Both fail on `master` with `1 != 2` and `1 != 3`.
- `test_keypress_without_callback_still_follows_the_display_widget` and `test_mouse_event_without_callback_still_follows_the_display_widget` are the regression guard: without a callback, arrow keys and clicks must keep moving the focus. Both pass before and after, which is the point of having them.

Ran on Windows with Python 3.13.7:

- `python -m unittest discover -s tests`: 446 tests, 16 errors. The same 16 fail on `master`, and all of them are Windows specific (`os.O_NONBLOCK`, `fcntl`, the vterm module).
- `ruff format --check` and `pylint urwid/widget/grid_flow.py` (10.00/10) are clean. `ruff check` reports one `B009` in `tests/test_grid_flow.py`, at line 219 inside `test_common`, which is already there on `master` and is not touched by this change.

I could not run the full `tox` matrix, so 3.9 through 3.14 are untested from my side. The change uses nothing newer than 3.9.

Disclosure: I used an AI coding assistant while working on this. Every command and result reported above I ran and checked myself.
