### PR TITLE
Maintenance: reduce mypy errors for code checking

### DIFF
--- a/urwid/str_util.py
+++ b/urwid/str_util.py
@@ -277,7 +277,7 @@ def calc_width(text: str | bytes, start_offs: int, end_offs: int) -> int:
             return wcwidth.width(text[start_offs:end_offs].decode("utf-8"), control_codes="ignore")
         except UnicodeDecodeError as exc:
             warnings.warn(
-                "`calc_width` with text encoded to bytes can produce incorrect results"
+                "`calc_width` with text encoded to bytes can produce incorrect results "
                 f"due to possible offset in the middle of character: {exc}",
                 UnicodeWarning,
                 stacklevel=2,

--- a/urwid/widget/popup.py
+++ b/urwid/widget/popup.py
@@ -121,7 +121,7 @@ class PopUpTarget(WidgetDecoration[WrappedWidget]):
                     top=top,
                 )
             else:
-                typing.cast("Overlay", self._current_widget).set_overlay_parameters(
+                typing.cast("Overlay[AbstractWidget, WrappedWidget]", self._current_widget).set_overlay_parameters(
                     align=Align.LEFT,
                     width=overlay_width,
                     valign=VAlign.TOP,
@@ -143,10 +143,18 @@ class PopUpTarget(WidgetDecoration[WrappedWidget]):
 
     def get_cursor_coords(self, size: tuple[int, int]) -> tuple[int, int] | None:
         self._update_overlay(size, True)
+
+        if not hasattr(self._current_widget, "get_cursor_coords"):
+            raise TypeError(f"widget {type(self._current_widget)} has no get_cursor_coords method")
+
         return self._current_widget.get_cursor_coords(size)
 
     def get_pref_col(self, size: tuple[int, int]) -> int:
         self._update_overlay(size, True)
+
+        if not hasattr(self._current_widget, "get_pref_col"):
+            raise TypeError(f"widget {type(self._current_widget)} has no get_pref_col method")
+
         return self._current_widget.get_pref_col(size)
 
     def keypress(
@@ -159,6 +167,10 @@ class PopUpTarget(WidgetDecoration[WrappedWidget]):
 
     def move_cursor_to_coords(self, size: tuple[int, int], x: int, y: int) -> bool:
         self._update_overlay(size, True)
+
+        if not hasattr(self._current_widget, "move_cursor_to_coords"):
+            raise TypeError(f"widget {type(self._current_widget)} has no move_cursor_to_coords method")
+
         return self._current_widget.move_cursor_to_coords(size, x, y)
 
     def mouse_event(

--- a/urwid/widget/scrollable.py
+++ b/urwid/widget/scrollable.py
@@ -37,6 +37,7 @@ if typing.TYPE_CHECKING:
 
     from urwid import Canvas, CompositeCanvas
 
+    from .container import WidgetContainerListContentsMixin
     from .widget import AbstractFixedWidget, AbstractFlowWidget
 
 
@@ -164,7 +165,7 @@ class Scrollable(WidgetDecoration[WrappedScrollWidget]):
             ch = 0
             last_hidden = False
             first_visible = False
-            for pwi, (w, _o) in enumerate(ow.contents):
+            for pwi, (w, _o) in enumerate(typing.cast("WidgetContainerListContentsMixin", ow).contents):
                 wcanv = w.render((maxcol,))
 
                 if wh := wcanv.rows():
@@ -180,14 +181,13 @@ class Scrollable(WidgetDecoration[WrappedScrollWidget]):
                     if not w.selectable():
                         continue
 
-                    ow.focus_position = pwi
+                    typing.cast("WidgetContainerListContentsMixin", ow).focus_position = pwi
 
                     st = None
                     nf = ow.focus
                     if hasattr(nf, "key_timeout"):
                         st = nf
-                    elif hasattr(nf, "original_widget"):
-                        no = nf.original_widget
+                    elif (no := getattr(nf, "original_widget", None)) is not None:
                         if hasattr(no, "original_widget"):
                             st = no.original_widget
                         elif hasattr(no, "key_timeout"):

--- a/urwid/widget/widget.py
+++ b/urwid/widget/widget.py
@@ -842,7 +842,7 @@ def delegate_to_widget_mixin(attribute_name: str) -> type[Widget]:
             return get_delegate(self).keypress(size, key)
 
         @property
-        def move_cursor_to_coords(self) -> Callable[[[tuple[()] | tuple[int] | tuple[int, int], int, int]], bool]:
+        def move_cursor_to_coords(self) -> Callable[[tuple[()] | tuple[int] | tuple[int, int], int, int], bool]:
             # TODO(Aleksei):  Get rid of property usage after getting rid of "if getattr"
             return get_delegate(self).move_cursor_to_coords
 


### PR DESCRIPTION
* use protocol casts where applicable
* guard methods calls in `PopUpTarget` as we do not have static information about real target
* fix typo in `move_cursor_to_coords` in `delegate_to_widget_minin`
* fix missed space in warning for `calc_width` against not decodable bytes

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
