### PR TITLE
ScrollBar: decide the scrollbar hitbox before the event is passed on

### DIFF
--- a/tests/test_scrollable.py
+++ b/tests/test_scrollable.py
@@ -208,6 +208,84 @@ class TestScrollBarScrollable(unittest.TestCase):
         self.assertFalse(widget.mouse_event(reduced_size, "mouse press", 1, 2, 2, False))
         self.assertEqual(0, scrollable.get_scrollpos())
 
+    def test_mouse_left_click_scrollbar_over_selectable_content(self):
+        """The scrollbar keeps its columns even when the wrapped widget consumes every click."""
+        clicked: list[int] = []
+        buttons = []
+        for index in range(20):
+            button = urwid.Button(f"b{index}")
+            urwid.connect_signal(button, "click", lambda _button, idx=index: clicked.append(idx))
+            buttons.append(button)
+
+        reduced_size = (14, 5)
+        widget = urwid.ScrollBar(urwid.Scrollable(urwid.Pile(buttons)))
+        scrollable = widget.original_widget
+        scrollbar_col = reduced_size[0] - 1
+
+        widget.render(reduced_size, True)
+        self.assertEqual(0, scrollable.get_scrollpos())
+
+        # Button.mouse_event answers any left press without looking at the column,
+        # so delegating first would turn a click on the scrollbar into a button press.
+        self.assertTrue(widget.mouse_event(reduced_size, "mouse press", 1, scrollbar_col, 4, True))
+        self.assertEqual([], clicked)
+        self.assertEqual(15, scrollable.get_scrollpos())
+
+        # A click on the content columns still reaches the buttons.
+        self.assertTrue(widget.mouse_event(reduced_size, "mouse press", 1, 2, 0, True))
+        self.assertEqual([15], clicked)
+
+    def test_mouse_left_click_left_side_scrollbar_over_selectable_content(self):
+        """The same protection applies to a left-aligned scrollbar."""
+        clicked: list[int] = []
+        buttons = []
+        for index in range(20):
+            button = urwid.Button(f"b{index}")
+            urwid.connect_signal(button, "click", lambda _button, idx=index: clicked.append(idx))
+            buttons.append(button)
+
+        reduced_size = (14, 5)
+        widget = urwid.ScrollBar(urwid.Scrollable(urwid.Pile(buttons)), side="left")
+        scrollable = widget.original_widget
+
+        widget.render(reduced_size, True)
+        self.assertEqual(0, scrollable.get_scrollpos())
+
+        self.assertTrue(widget.mouse_event(reduced_size, "mouse press", 1, 0, 4, True))
+        self.assertEqual([], clicked)
+        self.assertEqual(15, scrollable.get_scrollpos())
+
+    def test_mouse_event_translates_column_for_left_side_scrollbar(self):
+        """A left-aligned scrollbar shifts the wrapped widget, so the column has to be shifted back."""
+
+        class ColumnRecorder(urwid.Text):
+            def __init__(self, markup) -> None:
+                super().__init__(markup)
+                self.seen: list[tuple[int, int]] = []
+
+            def selectable(self) -> bool:
+                return True
+
+            def mouse_event(self, size, event, button, col, row, focus) -> bool:
+                self.seen.append((col, row))
+                return False
+
+        content = ColumnRecorder("\n".join(f"line{index}" for index in range(20)))
+        reduced_size = (10, 5)
+        widget = urwid.ScrollBar(urwid.Scrollable(content), side="left")
+        sb_width = widget.scrollbar_width
+
+        widget.render(reduced_size, True)
+
+        # Screen column ``sb_width`` is the first column the wrapped widget draws into.
+        widget.mouse_event(reduced_size, "mouse press", 1, sb_width, 0, True)
+        self.assertEqual([(0, 0)], content.seen)
+
+        # The last screen column maps to the last column the wrapped widget owns.
+        content.seen.clear()
+        widget.mouse_event(reduced_size, "mouse press", 1, reduced_size[0] - 1, 0, True)
+        self.assertEqual([(reduced_size[0] - 1 - sb_width, 0)], content.seen)
+
     def test_alt_symbols(self):
         long_content = urwid.Text(LGPL_HEADER)
         reduced_size = (40, 5)

--- a/urwid/widget/scrollable.py
+++ b/urwid/widget/scrollable.py
@@ -684,11 +684,38 @@ class ScrollBar(WidgetDecoration[WrappedScrollableWidget]):
     ) -> bool | None:
         ow = self._original_widget
         ow_size = self._original_widget_size
-        handled: bool | None = False
-        if hasattr(ow, "mouse_event"):
-            handled = ow.mouse_event(ow_size, event, button, col, row, focus)
+        supports_scroll = hasattr(ow, "set_scrollpos")
+        on_scrollbar = False
+        ow_col = col
 
-        if not handled and hasattr(ow, "set_scrollpos"):
+        if supports_scroll:
+            # The geometry is needed before the event is passed on: the wrapped widget cannot tell
+            # that a column belongs to the scrollbar, and would answer a click that is not its own.
+            layout = self._scrollbar_layout(size, focus)
+            if layout is not None:
+                if self._scrollbar_side == SCROLLBAR_LEFT:
+                    on_scrollbar = col < layout.sb_width
+                    # The wrapped widget is drawn after the scrollbar, so its own column 0 sits at
+                    # screen column sb_width and the offset has to be taken back out.
+                    ow_col = col - layout.sb_width
+                else:
+                    on_scrollbar = col >= layout.ow_size[0]
+
+                if on_scrollbar and button == 1:
+                    # Move the thumb top to the clicked row, inverting the placement done during render.
+                    thumb_travel = size[1] - layout.thumb_height
+                    if thumb_travel > 0:
+                        newpos = round(row * layout.posmax / thumb_travel)
+                    else:
+                        newpos = 0
+                    ow.set_scrollpos(max(0, min(layout.posmax, newpos)))
+                    return True
+
+        handled: bool | None = False
+        if not on_scrollbar and hasattr(ow, "mouse_event"):
+            handled = ow.mouse_event(ow_size, event, button, ow_col, row, focus)
+
+        if not handled and supports_scroll:
             if button == 4:  # scroll wheel up
                 pos = ow.get_scrollpos(ow_size)
                 newpos = max(pos - 1, 0)
@@ -698,22 +725,5 @@ class ScrollBar(WidgetDecoration[WrappedScrollableWidget]):
                 pos = ow.get_scrollpos(ow_size)
                 ow.set_scrollpos(pos + 1)
                 return True
-            if button == 1:  # left click may target the scrollbar itself
-                layout = self._scrollbar_layout(size, focus)
-                if layout is not None:
-                    if self._scrollbar_side == SCROLLBAR_LEFT:
-                        on_scrollbar = col < layout.sb_width
-                    else:
-                        on_scrollbar = col >= layout.ow_size[0]
-
-                    if on_scrollbar:
-                        # Move the thumb top to the clicked row, inverting the placement done during render.
-                        thumb_travel = size[1] - layout.thumb_height
-                        if thumb_travel > 0:
-                            newpos = round(row * layout.posmax / thumb_travel)
-                        else:
-                            newpos = 0
-                        ow.set_scrollpos(max(0, min(layout.posmax, newpos)))
-                        return True
 
         return handled


### PR DESCRIPTION
##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- ~~[ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)~~

##### Description:

No issue for this one, I ran into it while reading the left click handling added in #1192.

`ScrollBar.mouse_event` hands the event to the wrapped widget first and only looks at the scrollbar afterwards, inside the `if not handled` branch:

```python
handled = ow.mouse_event(ow_size, event, button, col, row, focus)

if not handled and hasattr(ow, "set_scrollpos"):
    ...
    if button == 1:  # left click may target the scrollbar itself
```

The hitbox test is correct, it just runs too late. Any wrapped widget that answers a left press without checking the column claims the click first, and `Button.mouse_event` is exactly that: it returns `True` for every button 1 press and never looks at `x`. So on `ScrollBar(Scrollable(Pile([Button, ...])))` the click that visually landed on the scrollbar fires a button instead, and the view stays put. Measured on master at 76a473c, size `(14, 5)`:

```
render:   ('< b0        >█', '< b1        > ', '< b2        > ', '< b3        > ', '< b4        > ')
click at col 13, row 4  ->  handled True, b4 emitted "click", get_scrollpos() still 0
```

`ListBox` behaves the same way, the click moves `focus_position` instead of scrolling.

There is a second problem in the same method. The column is passed on untranslated, so with `side="left"` the wrapped widget receives screen coordinates while it was drawn `sb_width` columns to the right:

```
render:   ('█line0    ', ' line1    ', ...)          # size (10, 5), child is 9 wide
click at screen col 1  ->  child receives col 1, though its own column 0 is there
click at screen col 9  ->  child receives col 9, which is outside its 0..8 range
```

Every other container translates before delegating: `Padding` does the bounds check plus `col - left`, `Columns` subtracts the column offset, and `Overlay`, `Frame` and `LineBox` do the same. `ScrollBar` was the one that did not.

The change moves both decisions ahead of the delegation. A left click on the scrollbar columns moves the thumb and returns without consulting the wrapped widget, and the column is shifted back by `sb_width` when the scrollbar sits on the left. Wheel events keep going through the wrapped widget first and fall back to the scrollbar exactly as before, including when the pointer is over the scrollbar itself, which I checked separately since it was the part most at risk from the reordering.

One tradeoff worth naming: `_scrollbar_layout` is now computed on any mouse event that reaches a scrollable wrapped widget, where before it was only computed for a left click that the wrapped widget had already refused. It is the same call `render` makes on every draw, so the extra cost is bounded by what a redraw already pays, but it is a real change and I would rather point at it than have it found in review.

##### Testing

Three tests added to `tests/test_scrollable.py`, next to the existing mouse tests:

- `test_mouse_left_click_scrollbar_over_selectable_content`: clicking the scrollbar of a `Pile` of buttons scrolls to 15 and emits no click, and a click on the content columns still reaches the button.
- `test_mouse_left_click_left_side_scrollbar_over_selectable_content`: the same with `side="left"`.
- `test_mouse_event_translates_column_for_left_side_scrollbar`: a small `Text` subclass records the coordinates it receives, and asserts that screen column `sb_width` arrives as column 0 and the last screen column arrives as the last column the child owns.

All three fail on master. The existing mouse tests keep passing because they wrap `Text`, which has no `mouse_event` and therefore never competes for the click.

`python -m unittest discover -s tests` gives 447 tests with 16 errors, all in `test_web`, `test_event_loops` and `test_vterm`. Those same 16 fail on a clean master checkout here, they are a Windows environment limitation on my side and none of them touch this code. `ruff format --check`, `ruff check` and `pylint` are clean on both changed files, pylint at 10.00/10.

Disclosure: I used an AI coding assistant while working on this. Every command and result reported above I ran and checked myself.
