### PR TITLE
Maintenance: adjust type checking and coverage rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,8 +67,8 @@ pylint = [
 ]
 pytest = [
   "pytest",
+  "pytest-asyncio",
   "pytest-cov",
-  "pytest-asyncio"
 ]
 
 [tool.setuptools]
@@ -288,6 +288,15 @@ module = "urwid.display.curses"
 disable_error_code = [
   "union-attr", # chacking for started state before each operation if too expensive
 ]
+
+[[tool.mypy.overrides]]
+module = "urwid.display._win32"
+disable_error_code = [
+  # `ctypes.windll` and friends exist only on Windows in typeshed, while this module is Windows-only by design:
+  # checking it from a non-Windows host produces platform-specific noise instead of real issues.
+  "attr-defined",
+]
+
 [[tool.mypy.overrides]]
 module = "urwid.widget.constants"
 disable_error_code = [
@@ -296,6 +305,7 @@ disable_error_code = [
   # the underlying values are disjoint. The public API must accept both string and enum forms.
   "overload-overlap",
 ]
+
 [[tool.mypy.overrides]]
 module = [ "gi.*", "serial.*", "trio.*" ]
 ignore_missing_imports = true
@@ -320,10 +330,16 @@ exclude_lines = [
 
   # Don't complain if tests don't hit defensive assertion code:
   "raise NotImplementedError",
+  "raise AssertionError",
+  "assert False",
+  "typing\\.assert_never",
+  "assert_never\\(",
 
-  # Exclude methods marked as abstract
+  # Exclude methods marked as abstract / overload stubs
   "@abstractmethod",
   "@abc.abstractmethod",
+  "@typing\\.overload",
+  "@overload",
 
   # Exclude import statements
   "^from\\b",
@@ -332,10 +348,12 @@ exclude_lines = [
   # Exclude variable declarations that are executed when file is loaded
   "^[a-zA-Z_]+\\b\\s=",
 
-  # Code for static analysis is never covered:
-  "if typing.TYPE_CHECKING:",
-  "@typing.overload",
-  "@overload",
+  # Code for static analysis / type narrowing is never covered at runtime:
+  "if TYPE_CHECKING:",
+  "if typing\\.TYPE_CHECKING:",
+  "typing\\.cast\\(",
+  "cast\\(",
+  "\\.\\.\\.",
 
   # Protocols
   "@runtime_checkable",
@@ -369,9 +387,11 @@ ignore = [ "FURB104", "FURB144", "FURB146" ]
 [[tool.refurb.amend]]
 path = "urwid/__init__.py"
 ignore = [ "FURB107" ]
+
 [[tool.refurb.amend]]
 path = "urwid/display/__init__.py"
 ignore = [ "FURB107" ]
+
 [[tool.refurb.amend]]
 path = "urwid/event_loop/__init__.py"
 ignore = [ "FURB107" ]


### PR DESCRIPTION
* Do not count coverage on unreachable code
* Win32 specific imports can not be used on other platforms

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
