### PR TITLE
Typing: silence checks where not relevant

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -353,7 +353,7 @@ exclude_lines = [
   "if typing\\.TYPE_CHECKING:",
   "typing\\.cast\\(",
   "cast\\(",
-  "\\.\\.\\.",
+  "^\\s*\\.\\.\\.\\s*$",
 
   # Protocols
   "@runtime_checkable",

--- a/urwid/widget/scrollable.py
+++ b/urwid/widget/scrollable.py
@@ -194,7 +194,7 @@ class Scrollable(WidgetDecoration[WrappedScrollWidget]):
                             st = no
 
                     if st and hasattr(st, "key_timeout") and callable(getattr(st, "keypress", None)):
-                        st.keypress(None, None)
+                        st.keypress(None, None)  # type: ignore[arg-type]  # Do not break legacy API
 
                     break
 

--- a/urwid/widget/widget.py
+++ b/urwid/widget/widget.py
@@ -862,7 +862,7 @@ def delegate_to_widget_mixin(attribute_name: str) -> type[Widget]:
             return get_delegate(self).sizing
 
         @property
-        def pack(self) -> Callable[[tuple[()] | tuple[int] | tuple[int, int], bool], tuple[int, int]]:
+        def pack(self) -> Callable[[tuple[()] | tuple[int] | tuple[int, int], bool], tuple[int, int]]:  # type: ignore[override]
             return get_delegate(self).pack
 
     return DelegateToWidgetMixin


### PR DESCRIPTION
"Legacy" `Scrollable` API for autoscroll
`delegate_to_widget_mixin` pack (temporary magic with `property`)

Fix ellipsis case for skipping coverage

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

Partial #1142