### PR TITLE
Typing: fix misc strict mypy warnings

### DIFF
--- a/urwid/command_map.py
+++ b/urwid/command_map.py
@@ -45,16 +45,16 @@ class Command(str, enum.Enum):
     SELECT_PREVIOUS = "prev selectable"
 
 
-REDRAW_SCREEN = Command.REDRAW_SCREEN
-CURSOR_UP = Command.UP
-CURSOR_DOWN = Command.DOWN
-CURSOR_LEFT = Command.LEFT
-CURSOR_RIGHT = Command.RIGHT
-CURSOR_PAGE_UP = Command.PAGE_UP
-CURSOR_PAGE_DOWN = Command.PAGE_DOWN
-CURSOR_MAX_LEFT = Command.MAX_LEFT
-CURSOR_MAX_RIGHT = Command.MAX_RIGHT
-ACTIVATE = Command.ACTIVATE
+REDRAW_SCREEN: typing.Literal[Command.REDRAW_SCREEN] = Command.REDRAW_SCREEN
+CURSOR_UP: typing.Literal[Command.UP] = Command.UP
+CURSOR_DOWN: typing.Literal[Command.DOWN] = Command.DOWN
+CURSOR_LEFT: typing.Literal[Command.LEFT] = Command.LEFT
+CURSOR_RIGHT: typing.Literal[Command.RIGHT] = Command.RIGHT
+CURSOR_PAGE_UP: typing.Literal[Command.PAGE_UP] = Command.PAGE_UP
+CURSOR_PAGE_DOWN: typing.Literal[Command.PAGE_DOWN] = Command.PAGE_DOWN
+CURSOR_MAX_LEFT: typing.Literal[Command.MAX_LEFT] = Command.MAX_LEFT
+CURSOR_MAX_RIGHT: typing.Literal[Command.MAX_RIGHT] = Command.MAX_RIGHT
+ACTIVATE: typing.Literal[Command.ACTIVATE] = Command.ACTIVATE
 
 
 class CommandMap(MutableMapping[str, typing.Union[str, Command, None]]):

--- a/urwid/numedit.py
+++ b/urwid/numedit.py
@@ -29,9 +29,9 @@ import warnings
 from urwid import Edit
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Container, Hashable
+    from collections.abc import Container
 
-    _TagMarkup = typing.Union[str, tuple[Hashable, typing.Union[str]], list["_TagMarkup"]]
+    from urwid.util import _TagMarkup
 
 
 class NumEdit(Edit):

--- a/urwid/signals.py
+++ b/urwid/signals.py
@@ -71,7 +71,7 @@ class Key:
 
 if typing.TYPE_CHECKING:
     # ``weak_args`` (converted to weakrefs) and ``user_args`` as prepared by ``_prepare_user_args``.
-    _UserArgs = tuple[Collection[weakref.ReferenceType], Collection[typing.Any]]
+    _UserArgs = tuple[Collection[weakref.ReferenceType[typing.Any]], Collection[typing.Any]]
     # A single connected handler: (key, callback, deprecated user_arg, prepared args).
     _SignalHandler = tuple[Key, Callable[..., typing.Any], typing.Any, _UserArgs]
     # Per-sender storage attached to ``obj`` under ``Signals._signal_attr``.
@@ -215,10 +215,10 @@ class Signals:
 
     def _prepare_user_args(
         self,
-        weak_args: Iterable[typing.Any] = (),
+        weak_args: Iterable[_T] = (),
         user_args: Iterable[typing.Any] = (),
-        callback: Callable[[weakref.ReferenceType[typing.Any]], typing.Any] | None = None,
-    ) -> tuple[Collection[weakref.ReferenceType], Collection[typing.Any]]:
+        callback: Callable[[weakref.ReferenceType[_T]], typing.Any] | None = None,
+    ) -> tuple[Collection[weakref.ReferenceType[_T]], Collection[typing.Any]]:
         # Turn weak_args into weakrefs and prepend them to user_args
         w_args = tuple(weakref.ref(w_arg, callback) for w_arg in weak_args)
         args = tuple(user_args) or ()
@@ -312,7 +312,7 @@ class Signals:
         self,
         callback: Callable[..., typing.Any],  # we cannot use type signature here due to args decomposition
         user_arg: typing.Any,
-        weak_args: Iterable[weakref.ReferenceType],
+        weak_args: Iterable[weakref.ReferenceType[typing.Any]],
         user_args: Iterable[typing.Any],
         emit_args: Iterable[typing.Any],
     ) -> bool:

--- a/urwid/split_repr.py
+++ b/urwid/split_repr.py
@@ -58,7 +58,7 @@ def split_repr(self: Widget) -> str:
     if not words and not alist:
         # if we're just going to print the classname fall back
         # to the previous __repr__ implementation instead
-        return typing.cast("str", super(self.__class__, self).__repr__())
+        return super(self.__class__, self).__repr__()
     if words and alist:
         words.append("")
     return f"<{self.__class__.__name__} {' '.join(words) + ' '.join([f'{k}={v}' for k, v in alist])}>"

--- a/urwid/util.py
+++ b/urwid/util.py
@@ -30,7 +30,7 @@ from contextlib import suppress
 from urwid import str_util
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Generator, Hashable, Iterable, MutableSequence
+    from collections.abc import Generator, Hashable, Iterable, Iterator, MutableSequence
     from types import TracebackType
 
     from typing_extensions import Literal, Protocol, Self
@@ -38,7 +38,24 @@ if typing.TYPE_CHECKING:
     class CanBeStopped(Protocol):
         def stop(self) -> None: ...
 
-    _TagMarkup = typing.Union[str, bytes, tuple[Hashable, typing.Union[str, bytes]], list["_TagMarkup"]]
+    class _TagMarkupList(Protocol):
+        """List of markup parts joined together by `decompose_tagmarkup`.
+
+        `_tagmarkup_recurse` traverses only `list` instances as containers of parts,
+        while a `tuple` always means a single (display attribute, markup) pair,
+        so `tuple` must not be accepted here.
+        A protocol is used instead of `list["_TagMarkup"]` because `list` is invariant:
+        a plain `list[str | tuple[Hashable, str]]` is not a `list["_TagMarkup"]`.
+        `reverse` is required only to exclude `tuple`, elements are never modified.
+        """
+
+        def __iter__(self) -> Iterator[_TagMarkup]: ...
+
+        def __len__(self) -> int: ...
+
+        def reverse(self) -> None: ...
+
+    _TagMarkup = typing.Union[str, bytes, tuple[Hashable, "_TagMarkup"], "_TagMarkupList"]
 
 
 def __getattr__(name: str) -> typing.Any:

--- a/urwid/widget/attr_wrap.py
+++ b/urwid/widget/attr_wrap.py
@@ -11,11 +11,13 @@ if typing.TYPE_CHECKING:
     from .constants import Sizing
     from .widget import AbstractWidget
 
+WrappedWidget = typing.TypeVar("WrappedWidget", bound="AbstractWidget")
 
-class AttrWrap(AttrMap):
+
+class AttrWrap(AttrMap[WrappedWidget]):
     def __init__(
         self,
-        w: AbstractWidget,
+        w: WrappedWidget,
         attr: Hashable | Mapping[Hashable, Hashable],
         focus_attr: Hashable | Mapping[Hashable, Hashable] = None,
     ) -> None:
@@ -58,7 +60,7 @@ class AttrWrap(AttrMap):
         return d
 
     @property
-    def w(self) -> AbstractWidget:
+    def w(self) -> WrappedWidget:
         """backwards compatibility, widget used to be stored as w"""
         warnings.warn(
             "backwards compatibility, widget used to be stored as original_widget. API will be removed in version 5.0.",
@@ -68,7 +70,7 @@ class AttrWrap(AttrMap):
         return self.original_widget
 
     @w.setter
-    def w(self, new_widget: AbstractWidget) -> None:
+    def w(self, new_widget: WrappedWidget) -> None:
         warnings.warn(
             "backwards compatibility, widget used to be stored as original_widget. API will be removed in version 5.0.",
             DeprecationWarning,

--- a/urwid/widget/bar_graph.py
+++ b/urwid/widget/bar_graph.py
@@ -14,6 +14,8 @@ if typing.TYPE_CHECKING:
 
     from typing_extensions import Literal
 
+    from urwid.util import _TagMarkup
+
 
 class BarGraphMeta(WidgetMeta):
     """
@@ -471,7 +473,7 @@ class BarGraph(Widget, metaclass=BarGraphMeta):
                     a = self.attr[bar_type]
                     t = self.char[bar_type] * width
                 widget_list.append((a, t))
-            c = Text(widget_list).render((maxcol,))  # type: ignore[arg-type]
+            c = Text(widget_list).render((maxcol,))
             if c.rows() != 1:
                 raise BarGraphError("Invalid characters in BarGraph!")
             combinelist += [(c, None, False)] * y_count
@@ -641,7 +643,7 @@ class GraphVScale(Widget):
 
     def __init__(
         self,
-        labels: Sequence[tuple[float | int, str | Sequence]],
+        labels: Sequence[tuple[float | int, _TagMarkup]],
         top: float,
     ) -> None:
         """
@@ -658,7 +660,7 @@ class GraphVScale(Widget):
 
     def set_scale(
         self,
-        labels: Sequence[tuple[float | int, str | Sequence]],
+        labels: Sequence[tuple[float | int, _TagMarkup]],
         top: float,
     ) -> None:
         """
@@ -674,7 +676,7 @@ class GraphVScale(Widget):
         self.txt = []
         for y, markup in labels:
             self.pos.append(y)
-            self.txt.append(Text(markup))  # type: ignore[arg-type]
+            self.txt.append(Text(markup))
         self.top = top
 
     def selectable(self) -> Literal[False]:

--- a/urwid/widget/big_text.py
+++ b/urwid/widget/big_text.py
@@ -12,8 +12,7 @@ if typing.TYPE_CHECKING:
     from collections.abc import Hashable
 
     from urwid import Font
-
-    _TagMarkup = typing.Union[str, tuple["Hashable", str], list["_TagMarkup"]]
+    from urwid.util import _TagMarkup
 
 
 class BigText(Widget):
@@ -31,7 +30,7 @@ class BigText(Widget):
         self.set_text(markup)
 
     def set_text(self, markup: _TagMarkup) -> None:
-        self.text, self.attrib = decompose_tagmarkup(markup)  # type: ignore[assignment,arg-type]
+        self.text, self.attrib = decompose_tagmarkup(markup)  # type: ignore[assignment]
         self._invalidate()
 
     def get_text(self) -> tuple[str, list[tuple[Hashable, int]]]:

--- a/urwid/widget/columns.py
+++ b/urwid/widget/columns.py
@@ -328,7 +328,7 @@ class Columns(
 
             elif w[0] == WHSettings.WEIGHT:
                 _ignored, width, w = w
-                self.contents.append((w, (WHSettings.WEIGHT, typing.cast("int | float", width), i in box_columns)))
+                self.contents.append((w, (WHSettings.WEIGHT, width, i in box_columns)))
 
             else:
                 raise ColumnsError(f"initial widget list item invalid: {original!r}")

--- a/urwid/widget/edit.py
+++ b/urwid/widget/edit.py
@@ -20,8 +20,7 @@ if typing.TYPE_CHECKING:
     from typing_extensions import Literal
 
     from urwid.canvas import TextCanvas
-
-    _TagMarkup = typing.Union[str, tuple[Hashable, typing.Union[str]], list["_TagMarkup"]]
+    from urwid.util import _TagMarkup
 
 
 class EditError(TextError):
@@ -111,7 +110,7 @@ class Edit(WidgetWrap[Text]):
         self.multiline = multiline
         self.allow_tab = allow_tab
         self._edit_pos = 0
-        self._caption, self._attrib = decompose_tagmarkup(caption)  # type: ignore[arg-type]
+        self._caption, self._attrib = decompose_tagmarkup(caption)
         self._edit_text = ""
         self.highlight: tuple[int, int] | None = None
         self._mask: str | None = None
@@ -269,7 +268,7 @@ class Edit(WidgetWrap[Text]):
 
         return typing.cast("int", pref_col)
 
-    def set_caption(self, caption: str | tuple[Hashable, str] | list[str | tuple[Hashable, str]]) -> None:
+    def set_caption(self, caption: _TagMarkup) -> None:
         """
         Set the caption markup for this widget.
 
@@ -289,7 +288,7 @@ class Edit(WidgetWrap[Text]):
         Traceback (most recent call last):
         AttributeError: can't set attribute
         """
-        self._caption, self._attrib = decompose_tagmarkup(caption)  # type: ignore[arg-type]
+        self._caption, self._attrib = decompose_tagmarkup(caption)
         self._sync_wrapped()
         self._invalidate()
 

--- a/urwid/widget/grid_flow.py
+++ b/urwid/widget/grid_flow.py
@@ -408,7 +408,7 @@ class GridFlow(
                     p.contents.append((divider, typing.cast("tuple[Literal[WHSettings.WEIGHT], int]", p.options())))
                 c = Columns([], self.h_sep)
                 column_focused = False
-                pad = Padding(typing.cast("Columns", c), self.align)
+                pad = Padding(c, self.align)
                 self.first_position[pad] = i
                 p.contents.append((pad, typing.cast("tuple[Literal[WHSettings.WEIGHT], int]", p.options())))
 

--- a/urwid/widget/listbox.py
+++ b/urwid/widget/listbox.py
@@ -758,7 +758,7 @@ class ListBox(Widget, WidgetContainerMixin[_K]):
         if middle is None:
             return SolidCanvas(" ", maxcol, maxrow)
 
-        _ignore, focus_widget, focus_pos, focus_rows, cursor = typing.cast("VisibleInfoMiddle", middle)  # pylint: disable=unpacking-non-sequence
+        _ignore, focus_widget, focus_pos, focus_rows, cursor = middle  # pylint: disable=unpacking-non-sequence
         trim_top, fill_above = typing.cast("VisibleInfoTopBottom", top)  # pylint: disable=unpacking-non-sequence
         trim_bottom, fill_below = typing.cast("VisibleInfoTopBottom", bottom)  # pylint: disable=unpacking-non-sequence
 
@@ -865,7 +865,7 @@ class ListBox(Widget, WidgetContainerMixin[_K]):
         if middle is None:
             return None
 
-        offset_inset, _ignore1, _ignore2, _ignore3, cursor = typing.cast("VisibleInfoMiddle", middle)  # pylint: disable=unpacking-non-sequence
+        offset_inset, _ignore1, _ignore2, _ignore3, cursor = middle  # pylint: disable=unpacking-non-sequence
         if not cursor:
             return None
 
@@ -1513,7 +1513,7 @@ class ListBox(Widget, WidgetContainerMixin[_K]):
         if middle is None:
             return True
 
-        focus_row_offset, focus_widget, focus_pos, focus_rows, cursor = typing.cast("VisibleInfoMiddle", middle)  # pylint: disable=unpacking-non-sequence
+        focus_row_offset, focus_widget, focus_pos, focus_rows, cursor = middle  # pylint: disable=unpacking-non-sequence
         _trim_bottom, fill_below = typing.cast("VisibleInfoTopBottom", bottom)  # pylint: disable=unpacking-non-sequence
 
         row_offset = focus_row_offset + focus_rows

--- a/urwid/widget/monitored_list.py
+++ b/urwid/widget/monitored_list.py
@@ -37,10 +37,14 @@ _S = typing.TypeVar("_S")
 
 
 def _call_modified(
-    fn: Callable[Concatenate[MonitoredList, ArgSpec], Ret],
-) -> Callable[Concatenate[MonitoredList, ArgSpec], Ret]:
+    fn: Callable[Concatenate[MonitoredList[typing.Any], ArgSpec], Ret],
+) -> Callable[Concatenate[MonitoredList[typing.Any], ArgSpec], Ret]:
     @functools.wraps(fn)
-    def call_modified_wrapper(self: MonitoredList, *args: ArgSpec.args, **kwargs: ArgSpec.kwargs) -> Ret:
+    def call_modified_wrapper(
+        self: MonitoredList[typing.Any],
+        *args: ArgSpec.args,
+        **kwargs: ArgSpec.kwargs,
+    ) -> Ret:
         rval = fn(self, *args, **kwargs)
         self._modified()  # pylint: disable=protected-access
         return rval

--- a/urwid/widget/overlay.py
+++ b/urwid/widget/overlay.py
@@ -809,7 +809,7 @@ class Overlay(
                 self.align_type,
                 self.align_amount,
                 WHSettings.CLIP,
-                typing.cast("int", width),
+                width,
                 None,
                 self.left,
                 self.right,

--- a/urwid/widget/pile.py
+++ b/urwid/widget/pile.py
@@ -251,7 +251,7 @@ class Pile(
                     w = original[-1]
                     self.contents.append(
                         (
-                            typing.cast("AbstractFlowWidget | AbstractFixedWidget", w),
+                            w,
                             (WHSettings.PACK, None),
                         )
                     )
@@ -281,7 +281,7 @@ class Pile(
                 elif settings == WHSettings.WEIGHT:
                     self.contents.append(
                         (
-                            typing.cast("AbstractBoxWidget | AbstractFlowWidget", w),
+                            w,
                             (
                                 WHSettings.WEIGHT,
                                 typing.cast("int | float", height),

--- a/urwid/widget/scrollable.py
+++ b/urwid/widget/scrollable.py
@@ -165,7 +165,12 @@ class Scrollable(WidgetDecoration[WrappedScrollWidget]):
             ch = 0
             last_hidden = False
             first_visible = False
-            for pwi, (w, _o) in enumerate(typing.cast("WidgetContainerListContentsMixin", ow).contents):
+            for pwi, (w, _o) in enumerate(
+                typing.cast(
+                    "WidgetContainerListContentsMixin[tuple[AbstractWidget, typing.Any]]",
+                    ow,
+                ).contents
+            ):
                 wcanv = w.render((maxcol,))
 
                 if wh := wcanv.rows():
@@ -181,7 +186,10 @@ class Scrollable(WidgetDecoration[WrappedScrollWidget]):
                     if not w.selectable():
                         continue
 
-                    typing.cast("WidgetContainerListContentsMixin", ow).focus_position = pwi
+                    typing.cast(
+                        "WidgetContainerListContentsMixin[tuple[AbstractWidget, typing.Any]]",
+                        ow,
+                    ).focus_position = pwi
 
                     st = None
                     nf = ow.focus

--- a/urwid/widget/text.py
+++ b/urwid/widget/text.py
@@ -17,8 +17,7 @@ if typing.TYPE_CHECKING:
     from typing_extensions import Literal
 
     from urwid.canvas import TextCanvas
-
-    _TagMarkup = typing.Union[str, tuple[Hashable, typing.Union[str]], list["_TagMarkup"]]
+    from urwid.util import _TagMarkup
 
 
 class TextError(WidgetError):
@@ -123,7 +122,7 @@ class Text(Widget):
         Traceback (most recent call last):
         AttributeError: can't set attribute
         """
-        self._text, self._attrib = decompose_tagmarkup(markup)  # type: ignore[arg-type]  # discourage `bytes` input
+        self._text, self._attrib = decompose_tagmarkup(markup)
         self._invalidate()
 
     def get_text(self) -> tuple[str | bytes, list[tuple[Hashable, int]]]:

--- a/urwid/widget/treetools.py
+++ b/urwid/widget/treetools.py
@@ -43,25 +43,30 @@ from .wimp import SelectableIcon
 if typing.TYPE_CHECKING:
     from collections.abc import Hashable, Sequence
 
+    from typing_extensions import Self
+
+    from urwid.util import _TagMarkup
+
     from .listbox import VisibleInfo
 
 __all__ = ("ParentNode", "TreeListBox", "TreeNode", "TreeWalker", "TreeWidget", "TreeWidgetError")
 
 _T = typing.TypeVar("_T")
+_Node = typing.TypeVar("_Node", bound="TreeNode[typing.Any] | ParentNode[typing.Any]")
 
 
 class TreeWidgetError(RuntimeError):
     pass
 
 
-class TreeWidget(WidgetWrap[Padding[typing.Union[Text, Columns]]]):
+class TreeWidget(WidgetWrap[Padding[typing.Union[Text, Columns]]], typing.Generic[_Node]):
     """A widget representing something in a nested tree display."""
 
     indent_cols = 3
     unexpanded_icon = SelectableIcon("+", 0)
     expanded_icon = SelectableIcon("-", 0)
 
-    def __init__(self, node: TreeNode | ParentNode) -> None:
+    def __init__(self, node: _Node) -> None:
         self._node = node
         self._innerwidget: Text | None = None
         if not isinstance(node, ParentNode):
@@ -109,18 +114,18 @@ class TreeWidget(WidgetWrap[Padding[typing.Union[Text, Columns]]]):
     def get_inner_widget(self) -> Text:
         if self._innerwidget is None:
             self._innerwidget = self.load_inner_widget()
-        return typing.cast("Text", self._innerwidget)
+        return self._innerwidget
 
     def load_inner_widget(self) -> Text:
-        return Text(self.get_display_text())  # type: ignore[arg-type]
+        return Text(self.get_display_text())
 
-    def get_node(self) -> TreeNode:
+    def get_node(self) -> _Node:
         return self._node
 
-    def get_display_text(self) -> str | tuple[Hashable, str] | list[str | tuple[Hashable, str]]:
+    def get_display_text(self) -> _TagMarkup:
         return f"{self.get_node().get_key()}: {self.get_node().get_value()!s}"
 
-    def next_inorder(self) -> TreeWidget | None:
+    def next_inorder(self) -> TreeWidget[TreeNode[typing.Any]] | None:
         """Return the next TreeWidget depth first from this one."""
         # first check if there's a child widget
 
@@ -128,7 +133,7 @@ class TreeWidget(WidgetWrap[Padding[typing.Union[Text, Columns]]]):
             return first_child
 
         # now we need to hunt for the next sibling
-        this_node = self.get_node()
+        this_node: TreeNode[typing.Any] = self.get_node()
         next_node = this_node.next_sibling()
         depth = this_node.get_depth()
         while next_node is None and depth > 0:
@@ -144,7 +149,7 @@ class TreeWidget(WidgetWrap[Padding[typing.Union[Text, Columns]]]):
 
         return next_node.get_widget()
 
-    def prev_inorder(self) -> TreeWidget | None:
+    def prev_inorder(self) -> TreeWidget[TreeNode[typing.Any]] | None:
         """Return the previous TreeWidget depth first from this one."""
         this_node = self._node
 
@@ -204,24 +209,24 @@ class TreeWidget(WidgetWrap[Padding[typing.Union[Text, Columns]]]):
 
         return False
 
-    def first_child(self) -> TreeWidget | None:
+    def first_child(self) -> TreeWidget[TreeNode[typing.Any]] | None:
         """Return first child if expanded."""
         if self.is_leaf or not self.expanded:
             return None
 
-        if typing.cast("ParentNode", self._node).has_children():
-            first_node = typing.cast("ParentNode", self._node).get_first_child()
+        if typing.cast("ParentNode[typing.Any]", self._node).has_children():
+            first_node = typing.cast("ParentNode[typing.Any]", self._node).get_first_child()
             return first_node.get_widget()
 
         return None
 
-    def last_child(self) -> TreeWidget | None:
+    def last_child(self) -> TreeWidget[TreeNode[typing.Any]] | None:
         """Return last child if expanded."""
         if self.is_leaf or not self.expanded:
             return None
 
-        if typing.cast("ParentNode", self._node).has_children():
-            last_child = typing.cast("ParentNode", self._node).get_last_child().get_widget()
+        if typing.cast("ParentNode[typing.Any]", self._node).has_children():
+            last_child = typing.cast("ParentNode[typing.Any]", self._node).get_last_child().get_widget()
         else:
             return None
         # recursively search down for the last descendant
@@ -252,22 +257,22 @@ class TreeNode(typing.Generic[_T]):
         self._parent = parent
         self._value = value
         self._depth = depth
-        self._widget: TreeWidget | None = None
+        self._widget: TreeWidget[Self] | None = None
 
-    def get_widget(self, reload: bool = False) -> TreeWidget:
+    def get_widget(self, reload: bool = False) -> TreeWidget[Self]:
         """Return the widget for this node."""
         if self._widget is None or reload:
             self._widget = self.load_widget()
-        return typing.cast("TreeWidget", self._widget)
+        return self._widget
 
-    def load_widget(self) -> TreeWidget:
+    def load_widget(self) -> TreeWidget[Self]:
         return TreeWidget(self)
 
     def get_depth(self) -> int:
         if self._depth is self._parent is None:
             self._depth = 0
         elif self._depth is None:
-            self._depth = typing.cast("ParentNode", self._parent).get_depth() + 1
+            self._depth = typing.cast("ParentNode[typing.Any]", self._parent).get_depth() + 1
         return self._depth
 
     def get_index(self) -> int | None:
@@ -288,7 +293,7 @@ class TreeNode(typing.Generic[_T]):
     def get_parent(self) -> ParentNode[typing.Any]:
         if self._parent is None and self.get_depth() > 0:
             self._parent = self.load_parent()
-        return typing.cast("ParentNode", self._parent)
+        return typing.cast("ParentNode[typing.Any]", self._parent)
 
     def load_parent(self) -> ParentNode[typing.Any]:
         """Provide TreeNode with a parent for the current node.
@@ -304,23 +309,23 @@ class TreeNode(typing.Generic[_T]):
     def is_root(self) -> bool:
         return self.get_depth() == 0
 
-    def next_sibling(self) -> TreeNode | None:
+    def next_sibling(self) -> TreeNode[typing.Any] | None:
         if self.get_depth() > 0:
             return self.get_parent().next_child(self.get_key())
 
         return None
 
-    def prev_sibling(self) -> TreeNode | None:
+    def prev_sibling(self) -> TreeNode[typing.Any] | None:
         if self.get_depth() > 0:
             return self.get_parent().prev_child(self.get_key())
 
         return None
 
-    def get_root(self) -> ParentNode:
+    def get_root(self) -> ParentNode[typing.Any]:
         root = self
         while root.get_parent() is not None:
             root = root.get_parent()
-        return typing.cast("ParentNode", root)
+        return typing.cast("ParentNode[typing.Any]", root)
 
 
 class ParentNode(TreeNode[_T]):
@@ -342,13 +347,13 @@ class ParentNode(TreeNode[_T]):
         """Return a possibly ordered list of child keys"""
         if self._child_keys is None or reload:
             self._child_keys = self.load_child_keys()
-        return typing.cast("Sequence[Hashable]", self._child_keys)
+        return self._child_keys
 
     def load_child_keys(self) -> Sequence[Hashable]:
         """Provide ParentNode with an ordered list of child keys (virtual function)"""
         raise TreeWidgetError("virtual function.  Implement in subclass")
 
-    def get_child_widget(self, key: Hashable) -> TreeWidget:
+    def get_child_widget(self, key: Hashable) -> TreeWidget[TreeNode[typing.Any]]:
         """Return the widget for a given key.  Create if necessary."""
 
         return self.get_child_node(key).get_widget()
@@ -416,31 +421,37 @@ class ParentNode(TreeNode[_T]):
         return len(self.get_child_keys()) > 0
 
 
-class TreeWalker(ListWalker[TreeNode, TreeWidget]):
+class TreeWalker(ListWalker[TreeNode[typing.Any], TreeWidget[TreeNode[typing.Any]]]):
     """ListWalker-compatible class for displaying TreeWidgets
 
     positions are TreeNodes."""
 
-    def __init__(self, start_from: TreeNode) -> None:
+    def __init__(self, start_from: TreeNode[typing.Any]) -> None:
         """start_from: TreeNode with the initial focus."""
         self.focus = start_from
 
-    def get_focus(self) -> tuple[TreeWidget, TreeNode]:
+    def get_focus(self) -> tuple[TreeWidget[TreeNode[typing.Any]], TreeNode[typing.Any]]:
         widget = self.focus.get_widget()
         return widget, self.focus
 
-    def set_focus(self, focus: TreeNode) -> None:
+    def set_focus(self, focus: TreeNode[typing.Any]) -> None:
         self.focus = focus
         self._modified()
 
     # pylint: disable=arguments-renamed  # its bad, but we should not change API
-    def get_next(self, start_from: TreeNode) -> tuple[TreeWidget, TreeNode] | tuple[None, None]:
+    def get_next(
+        self,
+        start_from: TreeNode[typing.Any],
+    ) -> tuple[TreeWidget[TreeNode[typing.Any]], TreeNode[typing.Any]] | tuple[None, None]:
         if (target := start_from.get_widget().next_inorder()) is not None:
             return target, target.get_node()
 
         return None, None
 
-    def get_prev(self, start_from: TreeNode) -> tuple[TreeWidget, TreeNode] | tuple[None, None]:
+    def get_prev(
+        self,
+        start_from: TreeNode[typing.Any],
+    ) -> tuple[TreeWidget[TreeNode[typing.Any]], TreeNode[typing.Any]] | tuple[None, None]:
         if (target := start_from.get_widget().prev_inorder()) is not None:
             return target, target.get_node()
 
@@ -449,7 +460,7 @@ class TreeWalker(ListWalker[TreeNode, TreeWidget]):
     # pylint: enable=arguments-renamed
 
 
-class TreeListBox(ListBox):
+class TreeListBox(ListBox[TreeNode[typing.Any]]):
     """A ListBox with special handling for navigation and collapsing of TreeWidgets"""
 
     def keypress(
@@ -487,7 +498,7 @@ class TreeListBox(ListBox):
 
         _widget, pos = self.body.get_focus()
 
-        parentpos = typing.cast("TreeNode", pos).get_parent()
+        parentpos = typing.cast("TreeNode[typing.Any]", pos).get_parent()
 
         if parentpos is None:
             return
@@ -502,7 +513,7 @@ class TreeListBox(ListBox):
                 self.change_focus(size, pos, row_offset)
                 return
 
-        self.change_focus(size, typing.cast("TreeNode", pos).get_parent())
+        self.change_focus(size, typing.cast("TreeNode[typing.Any]", pos).get_parent())
 
     def _keypress_max_left(self, size: tuple[int, int]) -> None:
         self.focus_home(size)
@@ -514,7 +525,7 @@ class TreeListBox(ListBox):
         """Move focus to very top."""
 
         _widget, pos = self.body.get_focus()
-        rootnode = typing.cast("TreeNode", pos).get_root()
+        rootnode = typing.cast("TreeNode[typing.Any]", pos).get_root()
         self.change_focus(size, rootnode)
 
     def focus_end(self, size: tuple[int, int]) -> None:
@@ -523,7 +534,7 @@ class TreeListBox(ListBox):
         maxrow, _maxcol = size
         _widget, pos = self.body.get_focus()
 
-        if lastwidget := typing.cast("TreeNode", pos).get_root().get_widget().last_child():
+        if lastwidget := typing.cast("TreeNode[typing.Any]", pos).get_root().get_widget().last_child():
             lastnode = lastwidget.get_node()
 
             self.change_focus(size, lastnode, maxrow - 1)

--- a/urwid/widget/wimp.py
+++ b/urwid/widget/wimp.py
@@ -34,12 +34,13 @@ from .text import Text
 from .widget import WidgetError, WidgetWrap
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Callable, Hashable, MutableSequence
+    from collections.abc import Callable, MutableSequence
 
     from typing_extensions import Literal, Self
 
     from urwid.canvas import TextCanvas
     from urwid.text_layout import TextLayout
+    from urwid.util import _TagMarkup
 
     _T = typing.TypeVar("_T")
 
@@ -50,7 +51,7 @@ class SelectableIcon(Text):
 
     def __init__(
         self,
-        text: str | tuple[Hashable, str] | list[str | tuple[Hashable, str]],
+        text: _TagMarkup,
         cursor_position: int = 0,
         align: Literal["left", "center", "right"] | Align = Align.LEFT,
         wrap: Literal["space", "any", "clip", "ellipsis"] | WrapMode = WrapMode.SPACE,
@@ -72,7 +73,7 @@ class SelectableIcon(Text):
         displayed at a fixed location in the text when in focus.
         This widget has no special handling of keyboard or mouse input.
         """
-        super().__init__(text, align=align, wrap=wrap, layout=layout)  # type: ignore[arg-type]  # markup
+        super().__init__(text, align=align, wrap=wrap, layout=layout)
         self._cursor_position = cursor_position
 
     def render(  # type: ignore[override]
@@ -158,7 +159,7 @@ class CheckBox(WidgetWrap[Columns]):
     @typing.overload
     def __init__(
         self,
-        label: str | tuple[Hashable, str] | list[str | tuple[Hashable, str]],
+        label: _TagMarkup,
         state: bool = False,
         has_mixed: typing.Literal[False] = False,
         on_state_change: Callable[[Self, bool, _T], typing.Any] | None = None,
@@ -169,7 +170,7 @@ class CheckBox(WidgetWrap[Columns]):
     @typing.overload
     def __init__(
         self,
-        label: str | tuple[Hashable, str] | list[str | tuple[Hashable, str]],
+        label: _TagMarkup,
         state: typing.Literal["mixed"] | bool = False,
         has_mixed: typing.Literal[True] = True,
         on_state_change: Callable[[Self, bool | typing.Literal["mixed"], _T], typing.Any] | None = None,
@@ -180,7 +181,7 @@ class CheckBox(WidgetWrap[Columns]):
     @typing.overload
     def __init__(
         self,
-        label: str | tuple[Hashable, str] | list[str | tuple[Hashable, str]],
+        label: _TagMarkup,
         state: bool = False,
         has_mixed: typing.Literal[False] = False,
         on_state_change: Callable[[Self, bool], typing.Any] | None = None,
@@ -191,7 +192,7 @@ class CheckBox(WidgetWrap[Columns]):
     @typing.overload
     def __init__(
         self,
-        label: str | tuple[Hashable, str] | list[str | tuple[Hashable, str]],
+        label: _TagMarkup,
         state: typing.Literal["mixed"] | bool = False,
         has_mixed: typing.Literal[True] = True,
         on_state_change: Callable[[Self, bool | typing.Literal["mixed"]], typing.Any] | None = None,
@@ -201,7 +202,7 @@ class CheckBox(WidgetWrap[Columns]):
 
     def __init__(
         self,
-        label: str | tuple[Hashable, str] | list[str | tuple[Hashable, str]],
+        label: _TagMarkup,
         state: bool | Literal["mixed"] = False,
         has_mixed: typing.Literal[False, True] = False,  # MyPy issue: Literal[True, False] is not equal `bool`
         on_state_change: (
@@ -252,7 +253,7 @@ class CheckBox(WidgetWrap[Columns]):
         if state not in self.states:
             raise ValueError(f"{state!r} not in {tuple(self.states.keys())}")
 
-        self._label = Text(label)  # type: ignore[arg-type]  # markup specific
+        self._label = Text(label)
         self.has_mixed = has_mixed
 
         self._state = state
@@ -300,7 +301,7 @@ class CheckBox(WidgetWrap[Columns]):
     def _repr_attrs(self) -> dict[str, typing.Any]:
         return {**super()._repr_attrs(), "state": self.state}
 
-    def set_label(self, label: str | tuple[Hashable, str] | list[str | tuple[Hashable, str]]) -> None:
+    def set_label(self, label: _TagMarkup) -> None:
         """
         Change the check box label.
 
@@ -314,7 +315,7 @@ class CheckBox(WidgetWrap[Columns]):
         >>> cb
         <CheckBox selectable fixed/flow widget 'bar' state=False>
         """
-        self._label.set_text(label)  # type: ignore[arg-type]  # markup specific
+        self._label.set_text(label)
         # no need to call self._invalidate(). WidgetWrap takes care of
         # that when self.w changes
 
@@ -473,7 +474,7 @@ class RadioButton(CheckBox):
     def __init__(
         self,
         group: MutableSequence[RadioButton],
-        label: str | tuple[Hashable, str] | list[str | tuple[Hashable, str]],
+        label: _TagMarkup,
         state: bool | Literal["first True"] = ...,
         on_state_change: Callable[[Self, bool, _T], typing.Any] | None = None,
         user_data: _T = ...,
@@ -483,7 +484,7 @@ class RadioButton(CheckBox):
     def __init__(
         self,
         group: MutableSequence[RadioButton],
-        label: str | tuple[Hashable, str] | list[str | tuple[Hashable, str]],
+        label: _TagMarkup,
         state: bool | Literal["first True"] = ...,
         on_state_change: Callable[[Self, bool], typing.Any] | None = None,
         user_data: None = None,
@@ -492,7 +493,7 @@ class RadioButton(CheckBox):
     def __init__(
         self,
         group: MutableSequence[RadioButton],
-        label: str | tuple[Hashable, str] | list[str | tuple[Hashable, str]],
+        label: _TagMarkup,
         state: bool | Literal["first True"] = "first True",
         on_state_change: Callable[[Self, bool, _T], typing.Any] | Callable[[Self, bool], typing.Any] | None = None,
         user_data: _T | None = None,
@@ -620,7 +621,7 @@ class Button(WidgetWrap[Columns]):
     @typing.overload
     def __init__(
         self,
-        label: str | tuple[Hashable, str] | list[str | tuple[Hashable, str]],
+        label: _TagMarkup,
         on_press: Callable[[Self, _T], typing.Any] | None = None,
         user_data: _T = ...,
         *,
@@ -632,7 +633,7 @@ class Button(WidgetWrap[Columns]):
     @typing.overload
     def __init__(
         self,
-        label: str | tuple[Hashable, str] | list[str | tuple[Hashable, str]],
+        label: _TagMarkup,
         on_press: Callable[[Self], typing.Any] | None = None,
         user_data: None = None,
         *,
@@ -643,7 +644,7 @@ class Button(WidgetWrap[Columns]):
 
     def __init__(
         self,
-        label: str | tuple[Hashable, str] | list[str | tuple[Hashable, str]],
+        label: _TagMarkup,
         on_press: Callable[[Self, _T], typing.Any] | Callable[[Self], typing.Any] | None = None,
         user_data: _T | None = None,
         *,
@@ -726,7 +727,7 @@ class Button(WidgetWrap[Columns]):
         # include button.label in repr(button)
         return [*super()._repr_words(), repr(self.label)]
 
-    def set_label(self, label: str | tuple[Hashable, str] | list[str | tuple[Hashable, str]]) -> None:
+    def set_label(self, label: _TagMarkup) -> None:
         """
         Change the button label.
 
@@ -737,7 +738,7 @@ class Button(WidgetWrap[Columns]):
         >>> b
         <Button selectable fixed/flow widget 'Yup yup'>
         """
-        self._label.set_text(label)  # type: ignore[arg-type]  # markup specific
+        self._label.set_text(label)
 
     def get_label(self) -> str | bytes:
         """


### PR DESCRIPTION
Make TreeWidget generic as it dependent on exact TreeNode (created by it) and return link to it

Rework tag markup to get rid of downstream errors

* redundant-cast
* type-arg

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
