### PR TITLE
Text layout: do not crash when a wide character is clipped on both sides

### DIFF
--- a/tests/test_text_layout.py
+++ b/tests/test_text_layout.py
@@ -157,6 +157,52 @@ class SubsegTest(unittest.TestCase):
         self.st((6, 2, 8), t, 0, 5, [(4, 2, 6), (1, 6)])
         self.st((6, 2, 8), t, 1, 5, [(1, 3), (2, 4, 6), (1, 6)])
 
+    def test4_range_inside_a_wide_character(self):
+        """A window that lands inside a wide character is padding and nothing else."""
+        t = b"12\xa1\xa156\xa1\xa190"
+        self.st((10, 0, 10), t, 2, 3, [(1, 2)])
+        self.st((10, 0, 10), t, 3, 4, [(1, 3)])
+        self.st((10, 0, 10), t, 7, 8, [(1, 7)])
+        self.st((6, 2, 8), t, 1, 2, [(1, 3)])
+
+
+class NarrowWideCharacterRenderTest(unittest.TestCase):
+    """Rendering wide characters into an area too narrow to hold them."""
+
+    CJK = "你好世界"
+
+    def render(self, widget, size, focus: bool = False) -> list[str]:
+        return [line.decode("utf-8") for line in widget.render(size, focus).text]
+
+    def test_clipped_on_both_edges(self):
+        with set_temporary_encoding("utf-8"):
+            self.assertEqual([" "], self.render(urwid.Text(self.CJK, wrap="clip"), (1,)))
+            self.assertEqual(["你 "], self.render(urwid.Text(self.CJK, wrap="clip"), (3,)))
+            self.assertEqual(["  "], self.render(urwid.Text(self.CJK, align="center", wrap="clip"), (2,)))
+            self.assertEqual([" "], self.render(urwid.Text(self.CJK, align="right", wrap="clip"), (1,)))
+
+    def test_inside_a_line_box(self):
+        with set_temporary_encoding("utf-8"):
+            self.assertEqual(
+                ["┌─┐", "│ │", "└─┘"],
+                self.render(urwid.LineBox(urwid.Text(self.CJK, wrap="clip")), (3,)),
+            )
+
+    def test_shifted_left_by_padding(self):
+        with set_temporary_encoding("utf-8"):
+            self.assertEqual(
+                [" "],
+                self.render(urwid.Padding(urwid.Text(self.CJK, wrap="clip"), left=-1), (1,)),
+            )
+
+    def test_every_narrow_width_renders(self):
+        with set_temporary_encoding("utf-8"):
+            for align in (urwid.Align.LEFT, urwid.Align.CENTER, urwid.Align.RIGHT):
+                for width in range(1, 10):
+                    with self.subTest(align=align, width=width):
+                        canvas = urwid.Text(self.CJK, align=align, wrap=urwid.WrapMode.CLIP).render((width,))
+                        self.assertEqual(width, canvas.cols())
+
 
 class CalcTranslateTest(unittest.TestCase):
     def setUp(self) -> None:

--- a/urwid/text_layout.py
+++ b/urwid/text_layout.py
@@ -453,7 +453,11 @@ class LayoutSegment:
                 lines: list[tuple[int, int, int] | tuple[int, int]] = []
                 if pad_left:
                     lines.append((1, spos - 1))
-                lines.append((end - start - pad_left - pad_right, spos, epos))
+                # A window that both starts and ends inside wide characters has
+                # nothing left between the two padding cells, and a segment of
+                # zero screen columns is not a shape LayoutSegment accepts.
+                if (seg_cols := end - start - pad_left - pad_right) > 0:
+                    lines.append((seg_cols, spos, epos))
                 if pad_right:
                     lines.append((1, epos))
                 return lines  # type: ignore[return-value]  # we're narrowing return type


### PR DESCRIPTION
##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:

Text containing double-width characters raises `ValueError` instead of drawing when the area is narrower than the character.

```pycon
>>> import urwid
>>> urwid.set_encoding("utf-8")
>>> urwid.Text("你好世界", wrap="clip").render((1,))
ValueError: (0, 0, 0)
>>> urwid.LineBox(urwid.Text("你好世界", wrap="clip")).render((3,))
ValueError: (0, 0, 0)
>>> urwid.Text("你好世界", align="center", wrap="clip").render((2,))
ValueError: (0, 2, 2)
```

The same text in ASCII draws fine at those widths (`urwid.Text("abcd", wrap="clip").render((1,))` gives `a`), and it is not limited to `wrap="clip"`. An `Edit` with the default wrap mode raises too:

```pycon
>>> urwid.Edit("a: ", "你好世界").render((2,), True)
ValueError: (0, 7, 7)
```

The `LineBox` cases are the ones that turn up in practice, since the border takes two columns, so a pane narrowed to three or four columns brings the application down.

`LayoutSegment.subseg` appends `(end - start - pad_left - pad_right, spos, epos)` without checking it. When the requested window both starts and ends inside one wide character, `calc_trim_text` returns `pad_left == 1`, `pad_right == 1` and `spos == epos`, so that width comes out as zero. `LayoutSegment.__init__` refuses a segment of zero screen columns (`if self.sc <= 0: raise ValueError(seg)` at line 396), and `apply_text_layout` walks straight into it.

The two halves of the clipped character are already emitted as their own one-column segments on either side, so the empty one between them carries nothing. Not appending it is the whole change.

What I checked:

At every width from 1 to 9 in all three alignments the render stops raising and the canvas comes out at the width that was asked for. At every width where master already worked the bytes are unchanged, which I compared side by side for `Text` and `Edit` from width 2 up to 12.

`pytest tests/ --ignore=tests/test_vterm.py` gives the same failure list before and after the change: 16 failures, all Windows-only `fcntl` and `os.O_NONBLOCK`, with 300 passing before and 305 after. `ruff check` reports the same codes on both touched files before and after, and `ruff format --check` says both are formatted.

One thing this does not fix: with the crash gone, `Edit` at an even width still drops a character (`urwid.Edit("a: ", "你好世界").render((2,), True)` shows `你好世` and not `界`). That is not new here, master does the same at widths 4 and 6 where it does not raise, so it looks like a separate problem in how `Edit` wraps around the cursor and I left it alone.
