### PR TITLE
Typing: initial examples annotation

### DIFF
--- a/examples/bigtext.py
+++ b/examples/bigtext.py
@@ -33,13 +33,14 @@ if typing.TYPE_CHECKING:
     from collections.abc import Callable
 
 
-_Wrapped = typing.TypeVar("_Wrapped")
-
-
-class SwitchingPadding(urwid.Padding[_Wrapped]):
-    def padding_values(self, size, focus: bool) -> tuple[int, int]:
+class SwitchingPadding(urwid.Padding[urwid.BigText]):
+    def padding_values(
+        self,
+        size: tuple[int],  # type: ignore[override]
+        focus: bool,
+    ) -> tuple[int, int]:
         maxcol = size[0]
-        width, _height = self.original_widget.pack(size, focus=focus)
+        width, _height = self.original_widget.pack((), focus=focus)  # urwid.BigText is FIXED size widget
         if maxcol > width:
             self.align = urwid.LEFT
         else:
@@ -89,12 +90,12 @@ class BigTextDisplay:
         w = urwid.AttrMap(w, "edit")
         return w
 
-    def set_font_event(self, w, state: bool) -> None:
+    def set_font_event(self, w: urwid.RadioButton, state: bool) -> None:
         if state:
             self.bigtext.set_font(w.font)
             self.chars_avail.set_text(w.font.characters())
 
-    def edit_change_event(self, widget, text: str) -> None:
+    def edit_change_event(self, widget: urwid.Edit, text: str) -> None:
         self.bigtext.set_text(text)
 
     def setup_view(
@@ -106,7 +107,7 @@ class BigTextDisplay:
         fonts = urwid.get_all_fonts()
         # setup mode radio buttons
         self.font_buttons = []
-        group = []
+        group: list[urwid.RadioButton] = []
         utf8 = urwid.get_encoding_mode() == "utf8"
         for name, fontcls in fonts:
             font = fontcls()
@@ -120,7 +121,7 @@ class BigTextDisplay:
             self.font_buttons.append(rb)
 
         # Create BigText
-        self.bigtext = urwid.BigText("", None)
+        self.bigtext = urwid.BigText("", None)  # type: ignore[arg-type]  # font assigned before render
         bt = urwid.BoxAdapter(
             urwid.Filler(
                 urwid.AttrMap(
@@ -146,14 +147,18 @@ class BigTextDisplay:
 
         # ListBox
         chars = urwid.Pile([cah, ca])
-        fonts = urwid.Pile([urwid.Text("Fonts:"), *self.font_buttons], focus_item=1)
-        col = urwid.Columns([(16, chars), fonts], 3, focus_column=1)
-        bt = urwid.Pile([bt, edit], focus_item=1)
-        lines = [bt, urwid.Divider(), col]
+        fonts_pile = urwid.Pile([urwid.Text("Fonts:"), *self.font_buttons], focus_item=1)
+        col = urwid.Columns([(16, chars), fonts_pile], 3, focus_column=1)
+        bt_pile = urwid.Pile([bt, edit], focus_item=1)
+        lines: list[urwid.widget.AbstractFlowWidget] = [bt_pile, urwid.Divider(), col]
         listbox = urwid.ListBox(urwid.SimpleListWalker(lines))
 
         # Frame
-        w = urwid.Frame(
+        w: urwid.Frame[
+            urwid.AttrMap[urwid.ListBox[int]],
+            urwid.AttrMap[urwid.Text],
+            None,
+        ] = urwid.Frame(
             body=urwid.AttrMap(listbox, "body"),
             header=urwid.AttrMap(urwid.Text("Urwid BigText example program - F8 exits."), "header"),
         )
@@ -169,7 +174,7 @@ class BigTextDisplay:
         )
         return w, exit_w
 
-    def main(self):
+    def main(self) -> None:
         self.view, self.exit_view = self.setup_view()
         self.loop = urwid.MainLoop(self.view, self.palette, unhandled_input=self.unhandled_input)
         self.loop.run()
@@ -188,7 +193,7 @@ class BigTextDisplay:
         return None
 
 
-def main():
+def main() -> None:
     BigTextDisplay().main()
 
 

--- a/examples/palette_test.py
+++ b/examples/palette_test.py
@@ -32,6 +32,8 @@ import typing
 import urwid
 
 if typing.TYPE_CHECKING:
+    from collections.abc import Callable
+
     from typing_extensions import Literal
 
 CHART_TRUE = """
@@ -257,7 +259,10 @@ SHORT_ATTR = 4  # length of short high-colour descriptions which may
 # be packed one after the next
 
 
-def parse_chart(chart: str, convert):
+def parse_chart(
+    chart: str,
+    convert: Callable[[str], tuple[urwid.AttrSpec, str] | None],
+) -> list[str | tuple[urwid.AttrSpec, str]]:
     """
     Convert string chart into text markup with the correct attributes.
 
@@ -294,7 +299,11 @@ def parse_chart(chart: str, convert):
     return out
 
 
-def foreground_chart(chart: str, background, colors: Literal[1, 16, 88, 256, 16777216]):
+def foreground_chart(
+    chart: str,
+    background: str,
+    colors: Literal[1, 16, 88, 256, 16777216],
+) -> list[str | tuple[urwid.AttrSpec, str]]:
     """
     Create text markup for a foreground colour chart
 
@@ -303,7 +312,7 @@ def foreground_chart(chart: str, background, colors: Literal[1, 16, 88, 256, 167
     colors -- number of colors (88 or 256)
     """
 
-    def convert_foreground(entry):
+    def convert_foreground(entry: str) -> tuple[urwid.AttrSpec, str] | None:
         try:
             attr = urwid.AttrSpec(entry, background, colors)
         except urwid.AttrSpecError:
@@ -313,7 +322,11 @@ def foreground_chart(chart: str, background, colors: Literal[1, 16, 88, 256, 167
     return parse_chart(chart, convert_foreground)
 
 
-def background_chart(chart: str, foreground, colors: Literal[1, 16, 88, 256, 16777216]):
+def background_chart(
+    chart: str,
+    foreground: str,
+    colors: Literal[1, 16, 88, 256, 16777216],
+) -> list[str | tuple[urwid.AttrSpec, str]]:
     """
     Create text markup for a background colour chart
 
@@ -321,11 +334,10 @@ def background_chart(chart: str, foreground, colors: Literal[1, 16, 88, 256, 167
     foreground -- colour to use for foreground of chart
     colors -- number of colors (88 or 256)
 
-    This will remap 8 <= colour < 16 to high-colour versions
-    in the hopes of greater compatibility
+    This will remap 8 <= colour < 16 to high-colour versions in the hopes of greater compatibility
     """
 
-    def convert_background(entry):
+    def convert_background(entry: str) -> tuple[urwid.AttrSpec, str] | None:
         try:
             attr = urwid.AttrSpec(foreground, entry, colors)
         except urwid.AttrSpecError:
@@ -350,17 +362,17 @@ def main() -> None:
     screen = urwid.display.raw.Screen()
     screen.register_palette(palette)
 
-    lb = urwid.SimpleListWalker([])
-    chart_offset = None  # offset of chart in lb list
+    lb: urwid.SimpleListWalker[urwid.widget.AbstractFlowWidget] = urwid.SimpleListWalker([])
+    chart_offset = 0  # offset of chart in lb list
 
-    mode_radio_buttons = []
-    chart_radio_buttons = []
+    mode_radio_buttons: list[urwid.RadioButton] = []
+    chart_radio_buttons: list[urwid.RadioButton] = []
 
-    def fcs(widget) -> urwid.AttrMap:
+    def fcs(widget: urwid.AbstractWidget) -> urwid.AttrMap:
         # wrap widgets that can take focus
         return urwid.AttrMap(widget, None, "focus")
 
-    def set_mode(colors: int, is_foreground_chart: bool) -> None:
+    def set_mode(colors: Literal[1, 16, 88, 256, 16777216], is_foreground_chart: bool) -> None:
         # set terminal mode and redraw chart
         screen.set_terminal_properties(colors)
         screen.reset_default_terminal_palette()
@@ -373,11 +385,11 @@ def main() -> None:
             txt = chart_fn(chart, "default", colors)
             lb[chart_offset] = urwid.Text(txt, wrap=urwid.CLIP)
 
-    def on_mode_change(colors: int, rb: urwid.RadioButton, state: bool) -> None:
+    def on_mode_change(colors: Literal[1, 16, 88, 256, 16777216], rb: urwid.RadioButton, state: bool) -> None:
         # if this radio button is checked
         if state:
             is_foreground_chart = chart_radio_buttons[0].state
-            set_mode(colors, is_foreground_chart)
+            set_mode(colors, typing.cast("bool", is_foreground_chart))
 
     def mode_rb(text: str, colors: int, state: bool = False) -> urwid.AttrMap:
         # mode radio buttons
@@ -389,7 +401,7 @@ def main() -> None:
         # handle foreground check box state change
         set_mode(screen.colors, state)
 
-    def click_exit(button) -> typing.NoReturn:
+    def click_exit(button: urwid.Button) -> typing.NoReturn:
         raise urwid.ExitMainLoop()
 
     lb.extend(

--- a/examples/tour.py
+++ b/examples/tour.py
@@ -28,9 +28,9 @@ from __future__ import annotations
 import urwid
 
 
-def main():
+def main() -> None:
     text_header = "Welcome to the urwid tour!  UP / DOWN / PAGE UP / PAGE DOWN scroll.  F8 exits."
-    text_intro = [
+    text_intro: list[str | tuple[str, str]] = [
         ("important", "Text"),
         (
             " widgets are the most common in "
@@ -75,12 +75,12 @@ def main():
         "with the alignment set to relative 20% and with its width "
         "fixed at 40."
     )
-    text_divider = [
+    text_divider: list[str | tuple[str, str]] = [
         "The ",
         ("important", "Divider"),
         " widget repeats the same character across the whole line.  It can also add blank lines above and below.",
     ]
-    text_edit = [
+    text_edit: list[str | tuple[str, str]] = [
         "The ",
         ("important", "Edit"),
         (
@@ -105,9 +105,12 @@ def main():
     text_edit_left = "left aligned (default)"
     text_edit_center = "center aligned"
     text_edit_right = "right aligned"
-    text_intedit = ("editcp", [("important", "IntEdit"), " allows only numbers: "])
+    text_intedit: tuple[str, list[str | tuple[str, str]]] = (
+        "editcp",
+        [("important", "IntEdit"), " allows only numbers: "],
+    )
     text_edit_padding = ("editcp", "Edit widget within a Padding widget ")
-    text_columns1 = [
+    text_columns1: list[str | tuple[str, str]] = [
         ("important", "Columns"),
         (
             " are used to share horizontal screen space.  "
@@ -116,7 +119,7 @@ def main():
             "contents of each column is a single widget."
         ),
     ]
-    text_columns2 = [
+    text_columns2: list[str | tuple[str, str]] = [
         "When you need to put more than one widget into a column you can use a ",
         ("important", "Pile"),
         " to combine two or more widgets.",
@@ -139,7 +142,7 @@ def main():
     text_edit_col_text2 = "more"
     text_edit_col_cap3 = ("editcp", "another ")
     text_edit_col_text3 = "still more"
-    text_gridflow = [
+    text_gridflow: list[str | tuple[str, str]] = [
         "A ",
         ("important", "GridFlow"),
         (
@@ -159,7 +162,7 @@ def main():
     text_button_list = ["Yes", "No", "Perhaps", "Certainly", "Partially", "Tuesdays Only", "Help"]
     text_cb_list = ["Wax", "Wash", "Buff", "Clear Coat", "Dry", "Racing Stripe"]
     text_rb_list = ["Morning", "Afternoon", "Evening", "Weekend"]
-    text_listbox = [
+    text_listbox: list[str | tuple[str, str]] = [
         "All these widgets have been displayed with the help of a ",
         ("important", "ListBox"),
         " widget.  ListBox widgets handle scrolling and changing focus.  A ",
@@ -170,10 +173,10 @@ def main():
     def button_press(button: urwid.Button) -> None:
         frame.footer = urwid.AttrMap(urwid.Text(["Pressed: ", button.get_label()]), "header")
 
-    radio_button_group = []
+    radio_button_group: list[urwid.RadioButton] = []
 
     blank = urwid.Divider()
-    listbox_content = [
+    listbox_content: list[urwid.widget.AbstractFlowWidget] = [
         blank,
         urwid.Padding(urwid.Text(text_intro), left=2, right=2, min_width=20),
         blank,
@@ -357,9 +360,16 @@ def main():
         listbox,
         trough_char=urwid.ScrollBar.Symbols.LITE_SHADE,
     )
-    frame = urwid.Frame(urwid.AttrMap(scrollable, "body"), header=header)
+    frame: urwid.Frame[
+        urwid.AttrMap[urwid.ScrollBar[urwid.ListBox[int]]],
+        urwid.AttrMap[urwid.Text] | None,
+        urwid.AttrMap[urwid.Text] | None,
+    ] = urwid.Frame(
+        urwid.AttrMap(scrollable, "body"),
+        header=header,
+    )
 
-    palette = [
+    palette: list[tuple[str, str, str] | tuple[str, str, str, str]] = [
         ("body", "black", "light gray", "standout"),
         ("reverse", "light gray", "black"),
         ("header", "white", "dark red", "bold"),
@@ -385,7 +395,7 @@ def main():
     urwid.MainLoop(frame, palette, screen, unhandled_input=unhandled).run()
 
 
-def setup():
+def setup() -> None:
     urwid.display.web.set_preferences("Urwid Tour")
     # try to handle short web requests quickly
     if urwid.display.web.handle_short_request():

--- a/urwid/widget/constants.py
+++ b/urwid/widget/constants.py
@@ -56,7 +56,7 @@ class WHSettings(str, enum.Enum):
     FLOW = "flow"  # Used as pack for flow widgets
 
 
-RELATIVE_100 = (WHSettings.RELATIVE, 100)
+RELATIVE_100: tuple[Literal[WHSettings.RELATIVE], int] = (WHSettings.RELATIVE, 100)
 
 
 @typing.overload

--- a/urwid/widget/filler.py
+++ b/urwid/widget/filler.py
@@ -93,12 +93,12 @@ class Filler(WidgetDecoration[WrappedWidget]):
                 if not isinstance(valign, tuple) or valign[0] != "fixed bottom":
                     raise FillerError("fixed top height may only be used with fixed bottom valign")
                 top = height[1]
-                height = RELATIVE_100  # type: ignore[assignment]
+                height = RELATIVE_100
             elif height[0] == "fixed bottom":
                 if not isinstance(valign, tuple) or valign[0] != "fixed top":
                     raise FillerError("fixed bottom height may only be used with fixed top valign")
                 bottom = height[1]
-                height = RELATIVE_100  # type: ignore[assignment]
+                height = RELATIVE_100
 
         if isinstance(valign, tuple):
             if valign[0] == "fixed top":

--- a/urwid/widget/overlay.py
+++ b/urwid/widget/overlay.py
@@ -504,10 +504,10 @@ class Overlay(
         if isinstance(width, tuple):
             if width[0] == "fixed left":
                 left = width[1]
-                width = RELATIVE_100  # type: ignore[assignment]
+                width = RELATIVE_100
             elif width[0] == "fixed right":
                 right = width[1]
-                width = RELATIVE_100  # type: ignore[assignment]
+                width = RELATIVE_100
 
         normalized_valign: VAlign | tuple[Literal["relative", WHSettings.RELATIVE], int]
         if isinstance(valign, tuple):
@@ -530,10 +530,10 @@ class Overlay(
         if isinstance(height, tuple):
             if height[0] == "fixed bottom":
                 bottom = height[1]
-                height = RELATIVE_100  # type: ignore[assignment]
+                height = RELATIVE_100
             elif height[0] == "fixed top":
                 top = height[1]
-                height = RELATIVE_100  # type: ignore[assignment]
+                height = RELATIVE_100
 
         if width is None:  # more obsolete values accepted
             width = WHSettings.PACK

--- a/urwid/widget/padding.py
+++ b/urwid/widget/padding.py
@@ -50,7 +50,8 @@ class Padding(WidgetDecoration[WrappedWidget], typing.Generic[WrappedWidget]):
             int
             | Literal["pack", "clip", WHSettings.PACK, WHSettings.CLIP]
             | tuple[Literal["relative", WHSettings.RELATIVE, "fixed left", "fixed right"], int]
-        ) = RELATIVE_100,  # type: ignore[assignment]
+            | None
+        ) = RELATIVE_100,
         min_width: int | None = None,
         left: int = 0,
         right: int = 0,
@@ -141,7 +142,7 @@ class Padding(WidgetDecoration[WrappedWidget], typing.Generic[WrappedWidget]):
                 left = width[1]
             else:
                 right = width[1]
-            width = RELATIVE_100  # type: ignore[assignment]
+            width = RELATIVE_100
 
         # convert old clipping mode width=None to width='clip'
         if width is None:


### PR DESCRIPTION
* bigtext.py
* palette_test.py
* tour.py

* Fix `Padding` annotation for width: allowed legacy `None` = `WHSettings.CLIP`
* Fix `RELATIVE_100` recognition

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
