### PR TITLE
Display attributes: add faint text support

### DIFF
--- a/docs/manual/displayattributes.rst
+++ b/docs/manual/displayattributes.rst
@@ -174,6 +174,11 @@ Foreground and Background Settings
      - NO
      - NO
      - some supported
+   * - :ref:`faint <bold-underline-standout>`
+     - YES
+     - NO
+     - NO
+     - some support
    * - :ref:`"bright" background colors <bright-background>`
      - YES
      - urxvt
@@ -257,6 +262,7 @@ Bold, Underline, Standout
 * ``'blink'``
 * ``'italics'``
 * ``'strikethrough'``
+* ``'faint'``
 
 These settings may be tagged on to foreground colors using commas, eg: ``'light
 gray,underline,bold,strikethrough'``

--- a/tests/test_raw_display.py
+++ b/tests/test_raw_display.py
@@ -13,6 +13,18 @@ class TestRawDisplay(unittest.TestCase):
         a2e = s._attrspec_to_escape
         self.assertEqual("\x1b[0;33;42m", a2e(s.AttrSpec("brown", "dark green")))
         self.assertEqual("\x1b[0;38;5;229;4;48;5;164m", a2e(s.AttrSpec("#fea,underline", "#d0d")))
+        self.assertEqual("\x1b[0;33;2;42m", a2e(s.AttrSpec("brown,faint", "dark green")))
+
+    def test_attrspec_faint(self):
+        a = urwid.AttrSpec("dark red,faint", "")
+        self.assertTrue(a.faint)
+        self.assertEqual("dark red,faint", a.foreground)
+        # faint can be combined with other settings and is kept on round-trip
+        self.assertEqual(
+            "AttrSpec('yellow,bold,faint', 'dark blue')",
+            repr(urwid.AttrSpec("yellow,faint,bold", "dark blue")),
+        )
+        self.assertFalse(urwid.AttrSpec("dark red", "").faint)
 
     def test_last_row_without_preceding_segment(self):
         """A last row holding a single grapheme has no character to slide back."""

--- a/urwid/display/_raw_display_base.py
+++ b/urwid/display/_raw_display_base.py
@@ -854,6 +854,7 @@ class Screen(BaseScreen, RealTerminal):
             fg = "39"
         st = (
             "1;" * a.bold
+            + "2;" * a.faint
             + "3;" * a.italics
             + "4;" * a.underline
             + "5;" * a.blink

--- a/urwid/display/common.py
+++ b/urwid/display/common.py
@@ -146,6 +146,7 @@ _BOLD =            0x400000000000000
 _BLINK =           0x800000000000000
 _ITALICS =        0x1000000000000000
 _STRIKETHROUGH =  0x2000000000000000
+_FAINT =          0x4000000000000000
 # fmt: on
 
 _FG_MASK = (
@@ -158,6 +159,7 @@ _FG_MASK = (
     | _BOLD
     | _ITALICS
     | _STRIKETHROUGH
+    | _FAINT
 )
 _BG_MASK = _BG_COLOR_MASK | _BG_BASIC_COLOR | _BG_HIGH_COLOR
 
@@ -205,6 +207,7 @@ _ATTRIBUTES = {
     "blink": _BLINK,
     "standout": _STANDOUT,
     "strikethrough": _STRIKETHROUGH,
+    "faint": _FAINT,
 }
 
 
@@ -558,7 +561,7 @@ class AttrSpec:
 
               Setting:
               'bold', 'italics', 'underline', 'blink', 'standout',
-              'strikethrough'
+              'strikethrough', 'faint'
 
               Some terminals use 'bold' for bright colors.  Most terminals
               ignore the 'blink' setting.  If the color is not given then
@@ -690,6 +693,10 @@ class AttrSpec:
         return self.__value & _STRIKETHROUGH != 0
 
     @property
+    def faint(self) -> bool:
+        return self.__value & _FAINT != 0
+
+    @property
     def colors(self) -> Literal[1, 16, 88, 256, 16777216]:
         """
         Return the maximum colors required for this object.
@@ -739,6 +746,7 @@ class AttrSpec:
             + ",blink" * self.blink
             + ",underline" * self.underline
             + ",strikethrough" * self.strikethrough
+            + ",faint" * self.faint
         )
 
     def __set_foreground(self, foreground: str) -> None:

--- a/urwid/display/curses.py
+++ b/urwid/display/curses.py
@@ -550,6 +550,8 @@ class Screen(BaseScreen, RealTerminal):
             attr |= curses.A_UNDERLINE
         if a.blink:
             attr |= curses.A_BLINK
+        if a.faint:
+            attr |= curses.A_DIM
 
         self.s.attrset(attr)
 


### PR DESCRIPTION
##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

##### Description:
Closes #1057.

Adds a `faint` foreground setting so text can be rendered dim, following the same pattern as the existing `italics`/`strikethrough` attributes. On the raw display this emits SGR 2, and on curses it maps to `curses.A_DIM`. It parses and round-trips through `AttrSpec` like the other settings (e.g. `AttrSpec("dark red,faint", "")`), so nothing changes unless you ask for it.

Added a couple of tests for the escape output and the round-trip, and listed the new setting in the display attributes docs.
