### PR TITLE
Fix sizing related issues

### DIFF
--- a/tests/test_canvas.py
+++ b/tests/test_canvas.py
@@ -71,6 +71,30 @@ class CanvasTest(unittest.TestCase):
             repr(rendered),
         )
 
+    def test_set_pop_up_argument_validation(self):
+        """Out of contract pop-up parameters are refused instead of mis-placing the pop-up."""
+        widget = urwid.SolidFill("*")
+
+        for description, kwargs, message in (
+            ("negative left", {"left": -1, "top": 0}, "Pop-up position must not be negative"),
+            ("negative top", {"left": 0, "top": -1}, "Pop-up position must not be negative"),
+            ("zero width", {"overlay_width": 0}, "Pop-up size must be positive"),
+            ("zero height", {"overlay_height": 0}, "Pop-up size must be positive"),
+            ("negative width", {"overlay_width": -3}, "Pop-up size must be positive"),
+            ("negative height", {"overlay_height": -3}, "Pop-up size must be positive"),
+        ):
+            with self.subTest(description):
+                params = {"left": 0, "top": 0, "overlay_width": 4, "overlay_height": 2, **kwargs}
+                canvas = urwid.CompositeCanvas(urwid.SolidCanvas(" ", 10, 5))
+                with self.assertRaises(urwid.CanvasError) as ctx:
+                    canvas.set_pop_up(widget, **params)
+                self.assertIn(message, str(ctx.exception))
+
+        with self.subTest("in contract parameters are accepted"):
+            canvas = urwid.CompositeCanvas(urwid.SolidCanvas(" ", 10, 5))
+            canvas.set_pop_up(widget, 0, 0, 4, 2)
+            self.assertEqual((0, 0, (widget, 4, 2)), canvas.get_pop_up())
+
     def ct(self, text, attr, exp_content):
         with self.subTest(text=text, attr=attr, exp_content=exp_content):
             c = urwid.TextCanvas([t.encode("iso8859-1") for t in text], attr)

--- a/tests/test_filler.py
+++ b/tests/test_filler.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import unittest
+import warnings
 
 import urwid
 
@@ -173,6 +174,33 @@ class FillerTest(unittest.TestCase):
                 f"Cannot pack (maxcol,) size, this is not a flow widget: {widget!r}",
                 str(ctx.exception),
             )
+
+    def test_sizing_pack_height_requires_flow_body(self):
+        """A PACK height is only meaningful for a FLOW body: warn instead of failing obscurely later.
+
+        With a BOX-only body and the default PACK height the filler declares BOX and FLOW support,
+        yet every render raises ``AttributeError`` from the missing ``rows`` method,
+        so the mismatch has to be announced while the sizing is calculated.
+        """
+        widget = urwid.Filler(urwid.SolidFill("#"))
+
+        with self.assertWarns(urwid.widget.FillerWarning) as ctx:
+            sizing = widget.sizing()
+
+        self.assertEqual(
+            f"WHSettings.PACK height expects a FLOW widget to be used, but received {widget.original_widget!r}",
+            str(ctx.warning),
+        )
+        # The declared sizing is deliberately left untouched: containers branch on it while laying out.
+        self.assertEqual(frozenset((urwid.BOX, urwid.FLOW)), sizing)
+
+    def test_sizing_pack_height_flow_body_does_not_warn(self):
+        """A FLOW body with a PACK height is the supported combination and must stay silent."""
+        widget = urwid.Filler(urwid.Text("Some text"))
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            self.assertEqual(frozenset((urwid.BOX, urwid.FLOW)), widget.sizing())
 
     def test_render_focused_not_fit(self):
         """Test that a focused widget will be shown and top trimmed if not enough height."""

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -308,6 +308,84 @@ class OverlayTest(unittest.TestCase):
             ovl.render((20, 10)).decoded_text,
         )
 
+    def test_pack_width_not_fitting_is_clipped(self):
+        """An oversized PACK width is clipped into the available columns instead of raising.
+
+        Regression test: negative padding used to be passed to the canvas overlay as a position,
+        producing a canvas wider than the size requested.
+        """
+        top_w = urwid.Text("Some long text")
+        self.assertEqual((14, 1), top_w.pack(()))
+
+        ovl = urwid.Overlay(
+            top_w,
+            urwid.SolidFill("#"),
+            urwid.CENTER,
+            urwid.PACK,
+            urwid.MIDDLE,
+            urwid.PACK,
+        )
+        self.assertEqual((-2, -2, 1, 1), ovl.calculate_padding_filler((10, 3), False))
+
+        canvas = ovl.render((10, 3))
+        self.assertEqual(10, canvas.cols())
+        self.assertEqual(3, canvas.rows())
+        self.assertEqual(("##########", "me long te", "##########"), canvas.decoded_text)
+
+        with self.subTest("clipped on both axes"):
+            top_w = urwid.LineBox(urwid.Text("Some long text"))
+            self.assertEqual((16, 3), top_w.pack(()))
+
+            ovl = urwid.Overlay(
+                top_w,
+                urwid.SolidFill("#"),
+                urwid.CENTER,
+                urwid.PACK,
+                urwid.MIDDLE,
+                urwid.PACK,
+            )
+            self.assertEqual((-3, -3, 0, -1), ovl.calculate_padding_filler((10, 2), False))
+
+            canvas = ovl.render((10, 2))
+            self.assertEqual(10, canvas.cols())
+            self.assertEqual(2, canvas.rows())
+            self.assertEqual(("──────────", "me long te"), canvas.decoded_text)
+
+    def test_pack_height_measured_at_top_widget_width(self):
+        """A PACK height is measured at the width top_w is given, not at the full width.
+
+        Regression test for https://github.com/urwid/urwid/issues/471: the row count was measured
+        at the full width of the overlay, so a wrapping flow widget was placed too low
+        and mouse events below the wrapped text were dropped.
+        """
+        check_box = urwid.CheckBox("x")
+        top_w = urwid.Pile([urwid.Text("one two three"), check_box])
+        self.assertEqual(4, top_w.rows((5,)))
+        self.assertEqual(2, top_w.rows((20,)))
+
+        ovl = urwid.Overlay(top_w, urwid.SolidFill("#"), urwid.CENTER, 5, urwid.MIDDLE, urwid.PACK)
+        self.assertEqual((7, 8, 3, 3), ovl.calculate_padding_filler((20, 10), False))
+
+        self.assertEqual(
+            (
+                "####################",
+                "####################",
+                "####################",
+                "#######one  ########",
+                "#######two  ########",
+                "#######three########",
+                "#######[ ] x########",
+                "####################",
+                "####################",
+                "####################",
+            ),
+            ovl.render((20, 10)).decoded_text,
+        )
+
+        # the check box is rendered on the last row of top_w, so a click there must reach it
+        self.assertTrue(ovl.mouse_event((20, 10), "mouse press", 1, 8, 6, True))
+        self.assertTrue(check_box.state)
+
     def test_old_params(self):
         o1 = urwid.Overlay(
             urwid.SolidFill("X"),

--- a/urwid/canvas.py
+++ b/urwid/canvas.py
@@ -348,9 +348,20 @@ class Canvas:
         :type overlay_width: int
         :param overlay_height: height of overlay in screen rows > 0
         :type overlay_height: int
+        :raises CanvasError: the canvas is already finalised, the position is negative
+            or the overlay size is not positive
         """
         if self.widget_info and self.cacheable:
             raise self._finalized_error
+
+        if left < 0 or top < 0:
+            raise CanvasError(f"Pop-up position must not be negative, got left={left!r} and top={top!r}")
+
+        if overlay_width <= 0 or overlay_height <= 0:
+            raise CanvasError(
+                f"Pop-up size must be positive, "
+                f"got overlay_width={overlay_width!r} and overlay_height={overlay_height!r}"
+            )
 
         self.coords["pop up"] = (left, top, (w, overlay_width, overlay_height))
 

--- a/urwid/widget/__init__.py
+++ b/urwid/widget/__init__.py
@@ -27,7 +27,7 @@ from .constants import (
 from .container import WidgetContainerListContentsMixin, WidgetContainerMixin
 from .divider import Divider
 from .edit import Edit, EditError, IntEdit
-from .filler import Filler, FillerError, calculate_top_bottom_filler
+from .filler import Filler, FillerError, FillerWarning, calculate_top_bottom_filler
 from .frame import Frame, FrameError
 from .grid_flow import GridFlow, GridFlowError, GridFlowWarning
 from .line_box import LineBox
@@ -105,6 +105,7 @@ __all__ = (
     "EditError",
     "Filler",
     "FillerError",
+    "FillerWarning",
     "Frame",
     "FrameError",
     "GraphVScale",

--- a/urwid/widget/filler.py
+++ b/urwid/widget/filler.py
@@ -17,7 +17,7 @@ from .constants import (
     simplify_height,
     simplify_valign,
 )
-from .widget_decoration import WidgetDecoration, WidgetError
+from .widget_decoration import WidgetDecoration, WidgetError, WidgetWarning
 
 if typing.TYPE_CHECKING:
     from typing_extensions import Literal
@@ -29,6 +29,10 @@ WrappedWidget = typing.TypeVar("WrappedWidget", bound="AbstractWidget")
 
 class FillerError(WidgetError):
     pass
+
+
+class FillerWarning(WidgetWarning):
+    """Filler related warnings."""
 
 
 class Filler(WidgetDecoration[WrappedWidget]):
@@ -154,10 +158,24 @@ class Filler(WidgetDecoration[WrappedWidget]):
 
         Sizing BOX is always supported.
         Sizing FLOW is supported if: FLOW widget (a height type is PACK) or BOX widget with height GIVEN
+
+        Rules:
+        * height == PACK: the height is taken from the wrapped widget, which therefore should support FLOW
         """
         sizing: set[Sizing] = {Sizing.BOX}
         if self.height_type in {WHSettings.PACK, WHSettings.GIVEN}:
             sizing.add(Sizing.FLOW)
+
+        if self.height_type == WHSettings.PACK:
+            body = self.original_widget
+            # A body without the "sizing" method is a legacy widget: it is handled by the render path as before.
+            if hasattr(body, "sizing") and Sizing.FLOW not in body.sizing():
+                warnings.warn(
+                    f"WHSettings.PACK height expects a FLOW widget to be used, but received {body!r}",
+                    FillerWarning,
+                    stacklevel=3,
+                )
+
         return frozenset(sizing)
 
     def rows(self, size: tuple[int], focus: bool = False) -> int:

--- a/urwid/widget/overlay.py
+++ b/urwid/widget/overlay.py
@@ -867,8 +867,9 @@ class Overlay(
             if maxrow - top - bottom < height:
                 bottom = maxrow - top - height
         elif self.height_type == WHSettings.PACK:
-            # top_w is a flow widget
-            height = typing.cast("AbstractFlowWidget", self.top_w).rows((maxcol,), focus=focus)
+            # top_w is a flow widget: it will be rendered at the width left over by the horizontal padding,
+            # so the row count has to be measured at that width and not at the full width of the overlay.
+            height = typing.cast("AbstractFlowWidget", self.top_w).rows((maxcol - left - right,), focus=focus)
             top, bottom = calculate_top_bottom_filler(
                 maxrow,
                 self.valign_type,
@@ -928,7 +929,9 @@ class Overlay(
         if top < 0 or bottom < 0:
             top_c.pad_trim_top_bottom(min(0, top), min(0, bottom))
 
-        return CanvasOverlay(top_c, bottom_c, left, top)
+        # Negative padding clips top_w instead of shifting it: the trimming above already removed the hidden part,
+        # so what is left starts at the edge of the area available for the overlay.
+        return CanvasOverlay(top_c, bottom_c, max(left, 0), max(top, 0))
 
     def mouse_event(
         self,

--- a/urwid/widget/popup.py
+++ b/urwid/widget/popup.py
@@ -59,6 +59,11 @@ class PopUpLauncher(
         Subclass must override this method and return a widget
         to be used for the pop-up.  This method is called once each time
         the pop-up is opened.
+
+        :class:`PopUpTarget` renders the pop-up with the box size declared by
+        :meth:`get_pop_up_parameters`, so the widget returned here must accept an
+        (*overlay_width*, *overlay_height*) size.  Wrap a flow or fixed widget in a
+        :class:`Filler <urwid.Filler>` (or in another box container) before returning it.
         """
         raise NotImplementedError("Subclass must override this method")
 
@@ -155,7 +160,7 @@ class PopUpTarget(WidgetDecoration[WrappedWidget]):
         if not hasattr(self._current_widget, "get_pref_col"):
             raise TypeError(f"widget {type(self._current_widget)} has no get_pref_col method")
 
-        return self._current_widget.get_pref_col(size)
+        return typing.cast("int", self._current_widget.get_pref_col(size))
 
     def keypress(
         self,
@@ -171,7 +176,7 @@ class PopUpTarget(WidgetDecoration[WrappedWidget]):
         if not hasattr(self._current_widget, "move_cursor_to_coords"):
             raise TypeError(f"widget {type(self._current_widget)} has no move_cursor_to_coords method")
 
-        return self._current_widget.move_cursor_to_coords(size, x, y)
+        return typing.cast("bool", self._current_widget.move_cursor_to_coords(size, x, y))
 
     def mouse_event(
         self,


### PR DESCRIPTION
## Fixes
- **`Overlay`: oversized `width=PACK` no longer raises `WidgetError`.** `render()` passed the negative `left`/`right` padding to `CanvasOverlay` as a *position*, shifting the already-trimmed top canvas off the left edge and producing a canvas wider than the requested size. The padding itself is left untouched (negative values are the correct coordinate model for clipped content, and `mouse_event`/`get_cursor_coords` rely on it); only the overlay position is clamped.
- **`Overlay`: `PACK` height is measured at the width the top widget actually gets** (`maxcol - left - right`) instead of the overlay's full width. Fixes wrong vertical centring and dead mouse clicks below wrapped text. Since `render`, `keypress`, `mouse_event` and `get_cursor_coords` all route through `calculate_padding_filler`, all four become consistent, and it now agrees with `Overlay.rows()`. Fixes #471.
- **`Canvas.set_pop_up`: enforces its documented preconditions.** `left`/`top` `>= 0` and `overlay_width`/`overlay_height` `> 0` were documented but unchecked, so bad values either silently mis-placed the pop-up or surfaced later as a bare `ValueError: 0`. Now raises `CanvasError` with a clear message.
- **`Filler.sizing()`: warns when a `PACK` height is paired with a non-FLOW body.** Such a `Filler` declared `{BOX, FLOW}` but failed at *every* size with an opaque `AttributeError: '…' object has no attribute 'rows'`. Follows the existing `Padding.sizing()` pattern (warn via the new `FillerWarning`, returned set unchanged). Relates to #247.
- **`PopUpLauncher.create_pop_up`: documents that the pop-up must accept a box size**, since `PopUpTarget` always overlays with `GIVEN`/`GIVEN`. Previously a flow pop-up failed with an unexplained `ValueError: too many values to unpack`.

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
