### PR TITLE
Stop CanvasCache._deps growing without bound

### DIFF
--- a/tests/test_canvas.py
+++ b/tests/test_canvas.py
@@ -42,6 +42,26 @@ class CanvasCacheTest(unittest.TestCase):
         self.cct(a, (15, 1), False, None)
         self.cct(b, (20, 2), True, bloo)
 
+    def test_deps_does_not_grow_unbounded_on_repeated_store(self):
+        # A widget that is re-rendered many times (e.g. one screen refresh
+        # per store() call) used to add itself to CanvasCache._deps[w] every
+        # single time, so the list kept growing for as long as the program
+        # ran, even though it only ever depends on `w` once.
+        dependency = urwid.Text("")
+        dependent = urwid.Text("")
+
+        dependency_canv = urwid.TextCanvas()
+        dependency_canv.finalize(dependency, (10, 1), False)
+        urwid.CanvasCache.store(urwid.Widget, dependency_canv)
+
+        for _ in range(50):
+            canv = urwid.TextCanvas()
+            canv.finalize(dependent, (10, 1), False)
+            canv.depends_on = [dependency]
+            urwid.CanvasCache.store(urwid.Widget, canv)
+
+        self.assertEqual({dependent}, urwid.CanvasCache._deps[dependency])
+
 
 class CanvasTest(unittest.TestCase):
     def test_basic_info(self):

--- a/urwid/canvas.py
+++ b/urwid/canvas.py
@@ -73,7 +73,7 @@ class CanvasCache:
 
     _widgets[widget] = {(wcls, size, focus): weakref.ref(canvas), ...}
     _refs[weakref.ref(canvas)] = (widget, wcls, size, focus)
-    _deps[widget} = [dependent_widget, ...]
+    _deps[widget} = {dependent_widget, ...}
     """
 
     _widgets: typing.ClassVar[
@@ -91,7 +91,7 @@ class CanvasCache:
             tuple[AbstractWidget, type[AbstractWidget], tuple[int, int] | tuple[int] | tuple[()], bool],
         ]
     ] = {}
-    _deps: typing.ClassVar[dict[AbstractWidget, list[AbstractWidget]]] = {}
+    _deps: typing.ClassVar[dict[AbstractWidget, set[AbstractWidget]]] = {}
     hits = 0
     fetches = 0
     cleanups = 0
@@ -134,7 +134,7 @@ class CanvasCache:
                 if w not in cls._widgets:
                     return
             for w in depends_on:
-                cls._deps.setdefault(w, []).append(widget)
+                cls._deps.setdefault(w, set()).add(widget)
 
         ref = weakref.ref(canvas, cls.cleanup)
         cls._refs[ref] = (widget, wcls, size, focus)
@@ -181,7 +181,7 @@ class CanvasCache:
 
         if widget not in cls._deps:
             return
-        dependants = cls._deps.get(widget, [])
+        dependants = cls._deps.get(widget, set())
         with suppress(KeyError):
             del cls._deps[widget]
         for w in dependants:


### PR DESCRIPTION
Closes #451

`CanvasCache.store()` appends the dependent widget to `_deps[w]` on every render, not just the first time that dependency relationship shows up. Anything on screen gets rendered repeatedly during normal use (each redraw goes through `store()` again), so the same entry keeps getting added to that list. Nothing ever removes a duplicate, `invalidate()` only clears the whole entry for a widget once it's actually invalidated, so for a long-running program that redraws frequently this grows without any limit. That matches what the original reporter measured: `CanvasCache._deps[button_filler]` filling up with an ever-growing number of references to the same `Pile` object as clicks accumulated.

Switched the list to a set so each dependent widget only ever appears once, no matter how many times it's rendered. `invalidate()` still walks every entry in `_deps[widget]` and clears the whole mapping the same way it did before, this only changes how the duplicate case is handled, not the invalidation logic itself.

Added `test_deps_does_not_grow_unbounded_on_repeated_store` alongside the existing `CanvasCacheTest`, which stores 50 canvases that all depend on the same widget and checks that `_deps` ends up with a single reference rather than 50. Reverted just the `canvas.py` change locally and confirmed the new test fails with the list containing all 50 duplicate entries, restored the fix and it passes with exactly one.

Ran the full test suite (380 passed, 28 pre-existing skips) plus `ruff check` and `mypy` on the touched source file, both clean.