### PR TITLE
Feat: detect terminal properties not only for basic xterm

### DIFF
--- a/tests/test_raw_display.py
+++ b/tests/test_raw_display.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import unittest
 
 import urwid
+from urwid import escape
+from urwid.display._raw_display_base import detect_terminal_properties
 from urwid.util import set_temporary_encoding
 
 
@@ -33,6 +35,27 @@ class TestRawDisplay(unittest.TestCase):
 
         self.assertEqual((row, 0, None), s._last_row(row))
 
+    def test_attrspec_truecolor_to_escape(self):
+        s = urwid.display.raw.Screen()
+        s.set_terminal_properties(colors=16777216)
+        a2e = s._attrspec_to_escape
+
+        self.assertEqual(
+            "\x1b[0;38;2;118;185;0;48;2;0;0;0m",
+            a2e(s.AttrSpec("#76b900", "#000000")),
+        )
+
+    def test_named_palette_attr_to_escape(self):
+        # Bright foreground colors render either as bold or as a 90-series color depending on the
+        # terminal, so bright_is_bold is pinned instead of inherited from the ambient TERM.
+        for bright_is_bold, expected in ((True, "\x1b[0;1;32;1;44m"), (False, "\x1b[0;92;1;44m")):
+            with self.subTest(bright_is_bold=bright_is_bold):
+                s = urwid.display.raw.Screen()
+                s.set_terminal_properties(colors=256, bright_is_bold=bright_is_bold)
+                s.register_palette_entry("focus", "light green,bold", "dark blue")
+
+                self.assertEqual(expected, s._attr_to_escape("focus"))
+
     def test_draw_screen_two_columns_wide_characters(self):
         """Drawing double width text on a two column screen used to raise IndexError."""
         s = urwid.display.raw.Screen()
@@ -47,3 +70,122 @@ class TestRawDisplay(unittest.TestCase):
 
         self.assertEqual(3, canvas.rows())
         self.assertIn("語", "".join(written))
+
+    def test_draw_screen_shows_cursor_when_set(self):
+        s = urwid.display.raw.Screen()
+        written: list[str] = []
+        s.write = written.append
+        s.flush = lambda: None
+        s._started = True
+
+        canvas = urwid.Edit("x").render((10,), focus=True)
+        s.draw_screen((10, canvas.rows()), canvas)
+
+        output = "".join(written)
+        self.assertEqual((1, 0), canvas.cursor)
+        self.assertIn(escape.SHOW_CURSOR, output)
+        self.assertIn(escape.HIDE_CURSOR, output)
+
+
+class TestTerminalProperties(unittest.TestCase):
+    def test_term_families(self) -> None:
+        cases = (
+            ("", 16, True, True, False, True),
+            ("xterm", 16, True, False, False, True),
+            ("xterm-256color", 256, True, False, False, True),
+            ("xterm-direct", 16777216, True, False, False, True),
+            ("linux", 16, True, True, True, True),
+            ("linux-16color", 16, True, True, True, True),
+            ("gnome-256color", 256, True, False, False, True),
+            ("konsole", 16, True, False, False, True),
+            ("konsole-direct", 16777216, True, False, False, True),
+            ("rxvt-unicode-256color", 256, True, False, False, True),
+            ("vte-256color", 256, True, False, False, True),
+            ("screen", 16, True, True, False, False),
+            ("screen-256color", 256, True, True, False, False),
+            ("screen-256color-bce", 256, True, True, False, True),
+            ("screen.xterm-256color", 256, True, False, False, False),
+            ("tmux-256color", 256, True, False, False, True),
+            ("alacritty", 16777216, True, False, False, True),
+            ("xterm-kitty", 16777216, True, False, False, True),
+            ("dumb", 1, False, True, False, False),
+            ("xterm-88color", 88, True, False, False, True),
+        )
+        for term, colors, underline, bright_bold, blink, bce in cases:
+            with self.subTest(term=term):
+                props = detect_terminal_properties(term, {}, windows_version=(0, 0, 0))
+                self.assertEqual(colors, props.colors)
+                self.assertEqual(underline, props.has_underline)
+                self.assertEqual(bright_bold, props.fg_bright_is_bold)
+                self.assertEqual(blink, props.bg_bright_is_blink)
+                self.assertEqual(bce, props.back_color_erase)
+
+    def test_color_environment_variables(self) -> None:
+        xterm = "xterm-256color"
+
+        def colors(term: str, environ: dict[str, str]) -> int:
+            return detect_terminal_properties(term, environ, windows_version=(0, 0, 0)).colors
+
+        self.assertEqual(1, colors(xterm, {"NO_COLOR": "1"}))
+        self.assertEqual(1, colors(xterm, {"CLICOLOR": "0"}))
+        self.assertEqual(16, colors(xterm, {"FORCE_COLOR": "1"}))
+        self.assertEqual(256, colors("xterm", {"FORCE_COLOR": "2"}))
+        self.assertEqual(16777216, colors("linux", {"FORCE_COLOR": "3"}))
+        self.assertEqual(256, colors("xterm", {"CLICOLOR_FORCE": "2"}))
+        self.assertEqual(16777216, colors(xterm, {"COLORTERM": "truecolor"}))
+        self.assertEqual(16777216, colors("xterm", {"COLORTERM": "24bit"}))
+        self.assertEqual(256, colors("xterm", {"COLORTERM": "gnome-terminal"}))
+        # NO_COLOR wins over COLORTERM / FORCE_COLOR
+        self.assertEqual(1, colors(xterm, {"NO_COLOR": "1", "COLORTERM": "truecolor"}))
+        self.assertEqual(1, colors(xterm, {"NO_COLOR": "1", "FORCE_COLOR": "3"}))
+        # Empty NO_COLOR is unset per the spec
+        self.assertEqual(256, colors(xterm, {"NO_COLOR": ""}))
+
+    def test_windows_console_vt(self) -> None:
+        win7 = (6, 1, 7601)
+        win10_rtm = (10, 0, 10240)
+        win10_1511 = (10, 0, 10586)
+        win10_1703 = (10, 0, 15063)
+        win11 = (10, 0, 22621)
+
+        props = detect_terminal_properties("", {}, windows_version=win7)
+        self.assertEqual(16, props.colors)
+        self.assertTrue(props.fg_bright_is_bold)
+
+        props = detect_terminal_properties("", {}, windows_version=win10_rtm)
+        self.assertEqual(16, props.colors)
+        self.assertTrue(props.fg_bright_is_bold)
+
+        props = detect_terminal_properties("", {}, windows_version=win10_1511)
+        self.assertEqual(256, props.colors)
+        self.assertFalse(props.fg_bright_is_bold)
+        self.assertTrue(props.has_underline)
+        self.assertTrue(props.back_color_erase)
+        self.assertFalse(props.bg_bright_is_blink)
+
+        for version in (win10_1703, win11):
+            with self.subTest(windows_version=version):
+                props = detect_terminal_properties("", {}, windows_version=version)
+                self.assertEqual(16777216, props.colors)
+                self.assertFalse(props.fg_bright_is_bold)
+                self.assertTrue(props.has_underline)
+                self.assertTrue(props.back_color_erase)
+                self.assertFalse(props.bg_bright_is_blink)
+
+        self.assertEqual(1, detect_terminal_properties("", {"NO_COLOR": "1"}, windows_version=win11).colors)
+        self.assertEqual(1, detect_terminal_properties("dumb", {}, windows_version=win11).colors)
+
+    def test_windows_terminal_hosts(self) -> None:
+        # Windows Terminal / ConEmu / VS Code report xterm-256color but speak 24-bit SGR.
+        for environ in (
+            {"WT_SESSION": "deadbeef-0000-0000-0000-000000000000"},
+            {"WT_PROFILE_ID": "{guid}"},
+            {"ConEmuANSI": "ON"},
+            {"ConEmuPID": "1234"},
+            {"TERM_PROGRAM": "vscode"},
+        ):
+            with self.subTest(environ=environ):
+                props = detect_terminal_properties("xterm-256color", environ, windows_version=(6, 1, 7601))
+                self.assertEqual(16777216, props.colors)
+                self.assertFalse(props.fg_bright_is_bold)
+                self.assertTrue(props.has_underline)

--- a/urwid/display/_raw_display_base.py
+++ b/urwid/display/_raw_display_base.py
@@ -41,7 +41,7 @@ from . import escape
 from .common import UNPRINTABLE_TRANS_TABLE, UPDATE_PALETTE_ENTRY, AttrSpec, BaseScreen, RealTerminal
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Callable, Iterable, Sequence
+    from collections.abc import Callable, Iterable, Mapping, Sequence
     from types import FrameType
 
     from typing_extensions import Literal
@@ -54,6 +54,209 @@ if typing.TYPE_CHECKING:
 
 IS_WINDOWS = sys.platform == "win32"
 IS_WSL = (sys.platform == "linux") and ("wsl" in platform.platform().lower())
+
+_ColorCount = typing.Literal[1, 16, 88, 256, 16777216]
+
+# Terminals that implement SGR 90-97 / 100-107 bright colors without needing bold/blink.
+_INDEPENDENT_BRIGHT_FAMILIES = frozenset(
+    {
+        "alacritty",
+        "cygwin",
+        "eterm",
+        "foot",
+        "ghostty",
+        "gnome",
+        "iterm",
+        "iterm2",
+        "kitty",
+        "konsole",
+        "mintty",
+        "mlterm",
+        "putty",
+        "rxvt",
+        "st",
+        "terminator",
+        "tmux",
+        "vte",
+        "wezterm",
+        "xfce",
+        "xterm",
+    }
+)
+_TRUECOLOR_FAMILIES = frozenset(
+    {
+        "alacritty",
+        "contour",
+        "foot",
+        "ghostty",
+        "iterm",
+        "iterm2",
+        "kitty",
+        "wezterm",
+    }
+)
+_NO_UNDERLINE_FAMILIES = frozenset({"dumb", "unknown", "vt52"})
+# Windows 10 TH2 (1511) gained 256-color VT; 1703-era build 14931 gained 24-bit color.
+_WINDOWS_256COLOR_BUILD = 10586
+_WINDOWS_TRUECOLOR_BUILD = 14931
+_TRUECOLOR_TERM_PROGRAMS = frozenset({"hyper", "tabby", "vscode", "vscode-insiders"})
+
+
+class TerminalProperties(typing.NamedTuple):
+    """Capabilities inferred from TERM and standard color environment variables."""
+
+    colors: _ColorCount
+    has_underline: bool
+    fg_bright_is_bold: bool
+    bg_bright_is_blink: bool
+    back_color_erase: bool
+
+
+def _term_families(term: str) -> frozenset[str]:
+    """Name tokens from a TERM value.
+
+    ``screen.xterm-256color`` yields ``screen``, ``xterm`` and ``256color``.
+    ``rxvt-unicode-256color`` yields ``rxvt``, ``unicode`` and ``256color``.
+    ``xterm-kitty`` yields ``xterm`` and ``kitty``.
+    """
+    families: set[str] = set()
+    for part in term.lower().split("."):
+        if part:
+            families.update(token for token in part.split("-") if token)
+    return frozenset(families)
+
+
+def _primary_family(term: str) -> str:
+    if not term:
+        return ""
+    return term.lower().split(".", 1)[0].split("-", 1)[0]
+
+
+def _env_nonempty(environ: Mapping[str, str], name: str) -> str | None:
+    value = environ.get(name)
+    if value:
+        return value
+    return None
+
+
+def _parse_force_color(value: str) -> _ColorCount:
+    """Map FORCE_COLOR / CLICOLOR_FORCE to a color count (chalk / supports-color convention)."""
+    normalized = value.strip().lower()
+    if normalized in {"0", "false", "no"}:
+        return 1
+    if normalized in {"", "1", "true", "yes"}:
+        return 16
+    if normalized == "2":
+        return 256
+    if normalized == "3":
+        return 16777216
+    return 16
+
+
+def _windows_version() -> tuple[int, int, int] | None:
+    if sys.platform != "win32":
+        return None
+    version = sys.getwindowsversion()  # pylint: disable=no-member
+    return (version.major, version.minor, version.build)
+
+
+def _windows_console_colors(version: tuple[int, int, int] | None) -> _ColorCount | None:
+    """Color depth of the Windows console VT host, if any."""
+    if version is None or version < (10, 0, 0):
+        return None
+    if version >= (10, 0, _WINDOWS_TRUECOLOR_BUILD):
+        return 16777216
+    if version >= (10, 0, _WINDOWS_256COLOR_BUILD):
+        return 256
+    return 16
+
+
+def _truecolor_host(environ: Mapping[str, str]) -> bool:
+    """Hosts that speak 24-bit SGR even when TERM still says xterm-256color."""
+    if (colorterm := _env_nonempty(environ, "COLORTERM")) and colorterm.lower() in {"truecolor", "24bit"}:
+        return True
+    if _env_nonempty(environ, "WT_SESSION") or _env_nonempty(environ, "WT_PROFILE_ID"):
+        return True
+    if environ.get("ConEmuANSI", "").lower() in {"on", "1"} or _env_nonempty(environ, "ConEmuPID"):
+        return True
+    return environ.get("TERM_PROGRAM", "").lower() in _TRUECOLOR_TERM_PROGRAMS
+
+
+def _colors_from_term(term: str, families: frozenset[str]) -> _ColorCount:
+    term_l = term.lower()
+    if not term_l:
+        return 16
+    if families & _NO_UNDERLINE_FAMILIES or term_l in _NO_UNDERLINE_FAMILIES:
+        return 1
+    if "direct" in term_l or families & _TRUECOLOR_FAMILIES:
+        return 16777216
+    if "256color" in term_l:
+        return 256
+    if "88color" in term_l:
+        return 88
+    return 16
+
+
+def detect_terminal_properties(
+    term: str | None = None,
+    environ: Mapping[str, str] | None = None,
+    *,
+    windows_version: tuple[int, int, int] | None = None,
+) -> TerminalProperties:
+    """Detect raw-display capabilities from TERM and standard color environment variables.
+
+    Environment handling follows the NO_COLOR spec and common COLORTERM / FORCE_COLOR / CLICOLOR_FORCE /
+    CLICOLOR conventions.
+    TERM names are matched by family so ``gnome-256color``, ``konsole-direct``
+    and ``rxvt-unicode-256color`` are recognized.
+
+    On Windows 10 and later the console VT host is used when TERM is empty or generic:
+    256 colors from build 10586, 24-bit color from build 14931. Windows Terminal
+    (``WT_SESSION``), ConEmu and VS Code's terminal are treated as 24-bit hosts even
+    when TERM still reports ``xterm-256color``.
+    """
+    env = os.environ if environ is None else environ
+    term_value = env.get("TERM", "") if term is None else term
+    families = _term_families(term_value)
+    term_l = term_value.lower()
+    term_colors = _colors_from_term(term_value, families)
+    if windows_version is None:
+        windows_version = _windows_version()
+    win_colors = _windows_console_colors(windows_version)
+    vt_truecolor = _truecolor_host(env) or win_colors == 16777216
+    vt_host = vt_truecolor or win_colors in {256, 16777216}
+
+    if _env_nonempty(env, "NO_COLOR"):
+        colors: _ColorCount = 1
+    elif force := _env_nonempty(env, "FORCE_COLOR") or _env_nonempty(env, "CLICOLOR_FORCE"):
+        colors = _parse_force_color(force)
+    elif env.get("CLICOLOR") == "0" or term_colors == 1:
+        colors = 1
+    elif vt_truecolor:
+        colors = 16777216
+    elif _env_nonempty(env, "COLORTERM") and term_colors < 256:
+        colors = 256
+    elif win_colors is not None and term_colors < win_colors:
+        colors = win_colors
+    else:
+        colors = term_colors
+
+    has_underline = not bool(families & _NO_UNDERLINE_FAMILIES)
+    linux_console = _primary_family(term_value) == "linux"
+    fg_bright_is_bold = not bool(families & _INDEPENDENT_BRIGHT_FAMILIES)
+    if vt_host and not linux_console:
+        fg_bright_is_bold = False
+        has_underline = True
+    bg_bright_is_blink = linux_console
+    back_color_erase = "bce" in term_l or not families & {"screen", "dumb", "unknown"}
+
+    return TerminalProperties(
+        colors=colors,
+        has_underline=has_underline,
+        fg_bright_is_bold=fg_bright_is_bold,
+        bg_bright_is_blink=bg_bright_is_blink,
+        back_color_erase=back_color_erase,
+    )
 
 
 @typing.runtime_checkable
@@ -90,8 +293,13 @@ class Screen(BaseScreen, RealTerminal):
         self._pal_attrspec: dict[str | None, AttrSpec] = {}
         self._alternate_buffer: bool = False
         signals.connect_signal(self, UPDATE_PALETTE_ENTRY, self._on_update_palette_entry)
-        self.colors: Literal[1, 16, 88, 256, 16777216] = 16  # FIXME: detect this
-        self.has_underline = True  # FIXME: detect this
+        self.term = os.environ.get("TERM", "")
+        properties = detect_terminal_properties(self.term, os.environ)
+        self.colors = properties.colors
+        self.has_underline = properties.has_underline
+        self.fg_bright_is_bold = properties.fg_bright_is_bold
+        self.bg_bright_is_blink = properties.bg_bright_is_blink
+        self.back_color_erase = properties.back_color_erase
         self.prev_input_resize = 0
         self.set_input_timeouts()
         self.screen_buf: list[list[tuple[AttrSpec | str | None, Literal["0", "U"] | None, bytes]]] | None = None
@@ -103,10 +311,6 @@ class Screen(BaseScreen, RealTerminal):
         self._setup_G1_done = False
         self._rows_used: int | None = None
         self._cy = 0
-        self.term = os.environ.get("TERM", "")
-        self.fg_bright_is_bold = not self.term.startswith("xterm")
-        self.bg_bright_is_blink = self.term == "linux"
-        self.back_color_erase = not self.term.startswith("screen")
         self.register_palette_entry(None, "default", "default")
         self._next_timeout: float | None = None
         self.signal_handler_setter = signal.signal


### PR DESCRIPTION
RAW display only

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
