### PR TITLE
Count the real ellipsis width in trimmed layout segments

### DIFF
--- a/tests/test_text_layout.py
+++ b/tests/test_text_layout.py
@@ -475,6 +475,27 @@ class TestEllipsis(unittest.TestCase):
             canvas = widget.render((1,))
             self.assertEqual("T", str(canvas))
 
+    def test_ellipsis_multichar_alignment(self):
+        """A multi-character ellipsis has to be counted at its real width.
+
+        The trimmed text plus the ellipsis fills all the available columns, so
+        `align` has nothing left to distribute and every alignment renders alike.
+        """
+        for encoding, expected in (("utf-8", "Test…"), ("ascii", "Te...")):
+            for align in (urwid.Align.LEFT, urwid.Align.CENTER, urwid.Align.RIGHT):
+                with self.subTest(encoding=encoding, align=align), set_temporary_encoding(encoding):
+                    widget = urwid.Text("Test label", align=align, wrap=urwid.WrapMode.ELLIPSIS)
+                    self.assertEqual(expected, str(widget.render((5,))))
+
+    def test_ellipsis_line_declares_available_columns(self):
+        """A trimmed line and its ellipsis together declare exactly `width` columns."""
+        layout = urwid.StandardTextLayout()
+        for encoding in ("utf-8", "ascii"):
+            for width in range(3, 10):
+                with self.subTest(encoding=encoding, width=width), set_temporary_encoding(encoding):
+                    segments = layout.layout("Test label", width, urwid.Align.LEFT, urwid.WrapMode.ELLIPSIS)
+                    self.assertEqual(width, sum(segment[0] for segment in segments[0]))
+
 
 class NumericLayout(urwid.TextLayout):
     """

--- a/urwid/text_layout.py
+++ b/urwid/text_layout.py
@@ -216,7 +216,7 @@ class StandardTextLayout(TextLayout):
                     raise ValueError(f"Invalid padding for start column==0: {pad_left!r}")
                 if start_off != idx:
                     raise ValueError(f"Invalid start offset for  start column==0 and position={idx!r}: {start_off!r}")
-                screen_columns = width - 1 - pad_right
+                screen_columns = width - ellipsis_width - pad_right
 
             else:
                 trimmed = False


### PR DESCRIPTION
##### Checklist
- [ ] I've ensured that similar functionality has not already been implemented
- [ ] I've ensured that similar functionality has not earlier been proposed and declined
- [ ] I've branched off the `master` branch
- [ ] I've merged fresh upstream into my branch recently
- [ ] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

*Boxes left unticked deliberately — here is what was actually done instead of a tick.* Branched off `master` at `1ec89b2` and rebased onto it just before pushing. Searched open and closed issues and PRs for this code site: the closest prior art is #812 / #813, referenced below; nothing open or declined covers it. Not a new feature, so no docs. I did **not** run the full `tox` matrix — I ran `pytest tests/` on 3.14, `ruff check` and `ruff format --diff` on both changed files, and `mypy urwid/text_layout.py`; results below.

##### Description:

`_calculate_trimmed_segments` declares the trimmed text as `width - 1 - pad_right` columns (`text_layout.py:219`). That is only right when the ellipsis is the one-column `…`. When `get_ellipsis_string()` falls back to ASCII `"..."` the line declares `width + 2` columns, `align_layout` computes a negative pad from it, and centre/right aligned text loses its leading characters.

```python
>>> import urwid
>>> urwid.set_encoding("ascii")
>>> [urwid.Text("abcdefghij", align=a, wrap="ellipsis").render((8,)).text
...  for a in ("left", "center", "right")]
[[b'abcde...'], [b'bcde .. '], [b'cde ... ']]   # before
[[b'abcde...'], [b'abcde...'], [b'abcde...']]   # after
```

The trimmed line plus the ellipsis already fills all 8 columns, so alignment has nothing to distribute and all three should be identical — which is what the UTF-8 path does today. The layout structure shows it directly: `ascii` produced `[(7, 0, 5), (3, 5, b'...'), (0, 5)]`, declaring 10 columns for a width of 8, while `utf-8` produced `[(7, 0, 7), (1, 7, b'…'), (0, 7)]`, declaring 8.

**This is the leftover half of #813.** That PR fixed the same hardcoded `1` four lines further down — `line += [(1, end_off, ellipsis_char)]` became `ellipsis_width` — and left this one. `calc_trim_text` is already called with `width - ellipsis_width`, so that is the value the segment should claim.

**How this was found:** not from a bug report — a systematic pass over column arithmetic in terminal libraries, looking for constants that duplicate a value computed nearby. The blind spot is structural rather than accidental: `TestEllipsis.test_ellipsis_encoding_support` is the only ellipsis test and it uses the default `align="left"`, which `align_layout` short-circuits at `text_layout.py:168`, so a wrong `screen_columns` cannot reach the output there. The new tests cover the other two alignments and assert the layout invariant directly.

**Verified:** `pytest tests/` — 441 passed / 38 skipped / 373 subtests before, 443 / 38 / 393 after. Reverting only `urwid/text_layout.py` and keeping the new tests: 9 failed in `test_text_layout.py` (`'Te...' != ' ... '`). A symptom-only fix — clamping the negative pad in `align_layout` — fails 12, because the layout still declares more columns than it has. `ruff format --diff` clean on both files; `ruff check` reports 3 findings in `tests/test_text_layout.py` (`E741`, two `RUF012`) that are **pre-existing** — identical on the unmodified file. `mypy urwid/text_layout.py` reports nothing in that module (only optional-dependency import errors in `event_loop/`).

**Where my test does not discriminate, stated plainly:** replacing line 219 with `screen_columns = calc_width(text, idx, end_off)` also passes everything — 443/38/393, identical. I chose the subtraction because it states the arithmetic the surrounding code already committed to when it called `calc_trim_text(..., width - ellipsis_width)`, and it avoids a second pass over the text on this path. If you would rather recompute, say so and I will switch.

**Not tested:** only ASCII and UTF-8. Other encodings that cannot represent `…` take the same `"..."` fallback, but I did not enumerate them.

*AI assistance: this change was written with Claude Code (model Claude Opus 5). I reviewed the diff and ran everything reported above.*
