### PR TITLE
Maintenance: migrate devcontainer to use `uv`

### DIFF
--- a/.devcontainer/dev.dockerfile
+++ b/.devcontainer/dev.dockerfile
@@ -1,15 +1,19 @@
-FROM ubuntu:24.04
+FROM ubuntu:26.04
 RUN apt-get update -y \
     && apt-get upgrade -y \
     && apt-get install -y \
       python3-dev \
-      python3-pip \
-      python3-virtualenv \
       python3-gi \
       python3-gi-cairo \
       gobject-introspection \
       libgirepository-2.0-dev \
       libcairo2-dev \
+      curl \
+      sudo \
     && apt-get clean
-RUN mkdir -p ~/.virtualenvs \
-    && virtualenv --download ~/.virtualenvs/urwid
+
+# Install uv globally to /usr/local/bin
+RUN curl -LsSf https://astral.sh/uv/install.sh | UV_INSTALL_DIR=/usr/local/bin sh
+
+# Set uv to use temporary venv location outside workspace
+ENV UV_PROJECT_ENVIRONMENT=/home/ubuntu/.venv-urwid

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,21 +11,16 @@
         "com.intellij:app:Vcs-Log-App-Settings.show_changes_from_parents": true
       }
     },
-    // Configure properties specific to VS Code.
     "vscode": {
-      // Set *default* container specific settings.json values on container create.
       "settings": {
-        "python.venvPath": "~/.virtualenvs",
         "python.terminal.activateEnvInCurrentTerminal": true,
-        "python.defaultInterpreterPath": "~/.virtualenvs/urwid/bin/python",
+        "python.defaultInterpreterPath": "/home/ubuntu/.venv-urwid/bin/python",
         "python.testing.unittestEnabled": true
       },
       "extensions": [
         "ms-python.python",
         "ms-python.debugpy",
         "ms-python.vscode-pylance",
-        "ms-python.isort",
-        "ms-python.black-formatter",
         "charliermarsh.ruff",
         "ms-azuretools.vscode-docker",
         "GitHub.vscode-github-actions"
@@ -33,8 +28,11 @@
     }
   },
   "name": "urwid-dev",
-  "containerUser": "root",
+  "containerUser": "ubuntu",
   "init": true,
-  "postCreateCommand": "~/.virtualenvs/urwid/bin/pip3 install isort black ruff pylint refurb mypy",
-  "postStartCommand": "~/.virtualenvs/urwid/bin/pip3 install -r test_requirements.txt PyGObject && ~/.virtualenvs/urwid/bin/pip3 install -U -e ."
+  "postCreateCommand": "uv venv /home/ubuntu/.venv-urwid && uv sync --all-groups",
+  "postStartCommand": "uv sync --all-groups --all-extras",
+  "mounts": [
+    "source=${localEnv:HOME}/.ssh,target=/home/ubuntu/.ssh,type=bind,readonly"
+  ]
 }


### PR DESCRIPTION
##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
