### PR TITLE
Fix `SIGTSTP` handler for POSIX RAW display and explain behaviour

### DIFF
--- a/urwid/display/_posix_raw_display.py
+++ b/urwid/display/_posix_raw_display.py
@@ -71,6 +71,22 @@ class Screen(_raw_display_base.Screen):
         focus_reporting -- enable focus reporting in the host terminal.
             If the host terminal supports it, the application will receive `focus in`
             and `focus out` keystrokes when the application gains and loses focus.
+
+        .. note::
+            on terminal-generated signals: putting the terminal into cbreak mode (see `start()`)
+            does not clear the tty's ``ISIG`` flag,
+            so the line discipline still turns Ctrl+C and Ctrl+Z into ``SIGINT`` and ``SIGTSTP``
+            and delivers them to this process (urwid/urwid#1268).
+            ``SIGINT`` is left for the application or its event loop to handle as it sees fit.
+            ``SIGTSTP`` is handled by this class:
+            `signal_init()` installs a handler that restores the terminal before actually suspending the process,
+            and the paired `SIGCONT` handler puts the terminal back into cbreak/alternate-buffer mode
+            and forces a redraw on resume, so a stray Ctrl+Z does not leave a stale,
+            unresponsive frame painted on screen.
+            Applications that install their own ``SIGTSTP``/``SIGCONT`` handlers on top of this one
+            should chain to the previous handler (as this class does) rather than replacing it outright,
+            and multithreaded applications must call `signal_init()` and `signal_restore()` from the main thread,
+            since only the main thread can receive process signals.
         """
         super().__init__(input, output)
         self.gpm_mev: Popen[str] | None = None
@@ -102,11 +118,31 @@ class Screen(_raw_display_base.Screen):
             self._prev_sigwinch_handler(signum, frame)
 
     def _sigtstp_handler(self, signum: int, frame: FrameType | None = None) -> None:
-        self.stop()  # Restores the previous signal handlers
-        self._prev_sigcont_handler = self.signal_handler_setter(signal.SIGCONT, self._sigcont_handler)
-        # Handled by the previous handler.
-        # If non-default, it may set its own SIGCONT handler which should hopefully call our own.
-        os.kill(os.getpid(), signal.SIGTSTP)
+        """Tear the screen down, then re-raise ``SIGTSTP`` with its default disposition so the process actually stops.
+
+        ``SIGCONT`` is blocked for the duration of this handler.
+        Without that guard, a ``fg`` issued by an enclosing shell (for example a wrapper script)
+        while this handler is still restoring the terminal can interrupt it
+        and run :meth:`_sigcont_handler` before the process has actually stopped:
+        CPython checks for pending signals
+        -- and will invoke a newly-arrived handler -- at the next bytecode boundary,
+        even while another handler is already executing.
+        That leaves the redraw logic believing it has resumed while the trailing `os.kill()` call below
+        still suspends the process a moment later,
+        so the first ``fg`` appears to do nothing and a second ``^Z``/``fg`` cycle
+        is needed to actually resume (see urwid/urwid#889).
+        Blocking ``SIGCONT`` here defers its delivery until we unblock it immediately after the process has genuinely
+        stopped and resumed, which removes the race.
+        """
+        previous_mask = signal.pthread_sigmask(signal.SIG_BLOCK, {signal.SIGCONT})
+        try:
+            self.stop()  # Restores the previous signal handlers
+            self._prev_sigcont_handler = self.signal_handler_setter(signal.SIGCONT, self._sigcont_handler)
+            # Handled by the previous handler.
+            # If non-default, it may set its own SIGCONT handler which should hopefully call our own.
+            os.kill(os.getpid(), signal.SIGTSTP)
+        finally:
+            signal.pthread_sigmask(signal.SIG_SETMASK, previous_mask)
 
     def _sigcont_handler(self, signum: int, frame: FrameType | None = None) -> None:
         """


### PR DESCRIPTION
Not everything belong to urwid itself - some cases are dependent on caller or actual app implementation using urwid

Fix #889
Fix #1268

##### Checklist
- [ X] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
