### PR TITLE
Restore terminal palette if was modified

### DIFF
--- a/tests/display/test_raw_display.py
+++ b/tests/display/test_raw_display.py
@@ -131,6 +131,37 @@ class TestRawDisplay(unittest.TestCase):
         self.assertTrue(watched, "no descriptors are watched after restart -- regression of urwid/urwid#285")
         s.stop()
 
+    def test_modify_terminal_palette_restored_on_stop(self):
+        """Palette entries modified with modify_terminal_palette() must be reset when the
+        screen stops, so urwid doesn't leave the user's terminal with a custom palette after
+        the process exits (urwid/urwid#458).
+        """
+        s = urwid.display.raw.Screen()
+        written: list[str] = []
+        s.write = written.append
+        s.flush = lambda: None
+        s._started = True
+
+        s.modify_terminal_palette([(1, 255, 0, 0), (2, 0, 255, 0)])
+        self.assertEqual({1, 2}, s._modified_palette_entries)
+
+        s._stop_restore_palette()
+
+        self.assertIn("\x1b]104;1;2\x1b\\", "".join(written))
+        self.assertEqual(set(), s._modified_palette_entries)
+
+    def test_stop_restore_palette_noop_when_untouched(self):
+        """No reset escape should be sent if the palette was never modified."""
+        s = urwid.display.raw.Screen()
+        written: list[str] = []
+        s.write = written.append
+        s.flush = lambda: None
+        s._started = True
+
+        s._stop_restore_palette()
+
+        self.assertEqual([], written)
+
 
 class TestTerminalProperties(unittest.TestCase):
     def test_term_families(self) -> None:

--- a/urwid/display/_posix_raw_display.py
+++ b/urwid/display/_posix_raw_display.py
@@ -274,6 +274,7 @@ class Screen(_raw_display_base.Screen):
         self.signal_restore()
 
         self._stop_mouse_restore_buffer()
+        self._stop_restore_palette()
 
         fd = self._input_fileno()
         if fd is not None and os.isatty(fd):

--- a/urwid/display/_raw_display_base.py
+++ b/urwid/display/_raw_display_base.py
@@ -281,6 +281,7 @@ class Screen(BaseScreen, RealTerminal):
         self._pal_escape: dict[str | None, str] = {}
         self._pal_attrspec: dict[str | None, AttrSpec] = {}
         self._alternate_buffer: bool = False
+        self._modified_palette_entries: set[int] = set()
         signals.connect_signal(self, UPDATE_PALETTE_ENTRY, self._on_update_palette_entry)
         self.term = os.environ.get("TERM", "")
         properties = detect_terminal_properties(self.term, os.environ)
@@ -428,6 +429,21 @@ class Screen(BaseScreen, RealTerminal):
             move_cursor = escape.set_cursor_position(0, self.maxrow)
         self.write(self._attrspec_to_escape(AttrSpec("", "")) + escape.SI + move_cursor + escape.SHOW_CURSOR)
         self.flush()
+
+    def _stop_restore_palette(self) -> None:
+        """Reset (OSC 104) any palette entries modify_terminal_palette() changed this session."""
+        if not self._modified_palette_entries:
+            return
+        if self.term == "fbterm":
+            # fbterm's palette-modification escape (used in modify_terminal_palette) has no
+            # known reset counterpart, so there is nothing safe to send here.
+            self._modified_palette_entries.clear()
+            return
+
+        indexes = ";".join(str(index) for index in sorted(self._modified_palette_entries))
+        self.write(f"\x1b]104;{indexes}\x1b\\")
+        self.flush()
+        self._modified_palette_entries.clear()
 
     @abc.abstractmethod
     def _stop(self) -> None:
@@ -1148,6 +1164,7 @@ class Screen(BaseScreen, RealTerminal):
             modify = [f"{index:d};rgb:{red:02x}/{green:02x}/{blue:02x}" for index, red, green, blue in entries]
             self.write(f"\x1b]4;{';'.join(modify)}\x1b\\")
         self.flush()
+        self._modified_palette_entries.update(index for index, _red, _green, _blue in entries)
 
     # shortcut for creating an AttrSpec with this screen object's
     # number of colors

--- a/urwid/display/_win32_raw_display.py
+++ b/urwid/display/_win32_raw_display.py
@@ -135,6 +135,7 @@ class Screen(_raw_display_base.Screen):
         signals.emit_signal(self, INPUT_DESCRIPTORS_CHANGED)
 
         self._stop_mouse_restore_buffer()
+        self._stop_restore_palette()
 
         if self._dwOriginalOutMode is not None and self._dwOriginalInMode is not None:
             handle_out = _win32.GetStdHandle(_win32.STD_OUTPUT_HANDLE)


### PR DESCRIPTION
Fix: #458

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
