### PR TITLE
Documentation: fix docstrings to follow PEP257

### DIFF
--- a/urwid/canvas.py
+++ b/urwid/canvas.py
@@ -101,8 +101,8 @@ class CanvasCache:
         """
         Store a weakref to canvas in the cache.
 
-        wcls -- widget class that contains render() function
-        canvas -- rendered canvas with widget_info (widget, size, focus)
+        :param wcls: widget class that contains render() function
+        :param canvas: rendered canvas with widget_info (widget, size, focus)
         """
         if not canvas.cacheable:
             return
@@ -151,9 +151,10 @@ class CanvasCache:
         """
         Return the cached canvas or None.
 
-        widget -- widget object requested
-        wcls -- widget class that contains render() function
-        size, focus -- render() parameters
+        :param widget: widget object requested
+        :param wcls: widget class that contains render() function
+        :param size: size parameter passed to the widget's render method
+        :param focus: focus parameter passed to the widget's render method
         """
         cls.fetches += 1  # collect stats
 
@@ -250,9 +251,9 @@ class Canvas:
         'render call returns the canvas thanks to some metaclass
         magic.
 
-        widget -- widget that rendered this canvas
-        size -- size parameter passed to widget's render method
-        focus -- focus parameter passed to widget's render method
+        :param widget: widget that rendered this canvas
+        :param size: size parameter passed to widget's render method
+        :param focus: focus parameter passed to widget's render method
         """
         if self.widget_info:
             raise self._finalized_error
@@ -292,10 +293,12 @@ class Canvas:
         raise NotImplementedError()
 
     def content_delta(self, other: Canvas) -> list[int] | Iterator[_ContentLine]:
-        """Delta between two canvases
+        """Delta between two canvases.
 
-        Returns list of row deltas if other is None, otherwise returns iterator of row deltas.
-        Not used by code base and will be removed in the future releases.
+        :returns: a list of row deltas if other is None, otherwise an iterator of row deltas.
+
+        .. deprecated:: 4.0.3
+            Not used by the code base; there is no replacement. It will be removed in a future release.
         """
         warnings.warn(
             "content_delta is not used by code base and will be removed in the future releases",
@@ -410,12 +413,12 @@ class TextCanvas(Canvas):
         check_width: bool = True,
     ) -> None:
         """
-        text -- list of strings, one for each line
-        attr -- list of run length encoded attributes for text
-        cs -- list of run length encoded character set for text
-        cursor -- (x,y) of cursor or None
-        maxcol -- screen columns taken by this canvas
-        check_width -- check and fix width of all lines in text
+        :param text: list of strings, one for each line
+        :param attr: list of run length encoded attributes for text
+        :param cs: list of run length encoded character set for text
+        :param cursor: (x,y) of cursor or None
+        :param maxcol: screen columns taken by this canvas
+        :param check_width: check and fix width of all lines in text
         """
         super().__init__()
         if text is None:
@@ -561,6 +564,9 @@ class TextCanvas(Canvas):
 
         If other is the same object as self this will return no differences,
         otherwise this is the same as calling content().
+
+        .. deprecated:: 4.0.3
+            Not used by the code base; there is no replacement. It will be removed in a future release.
         """
         warnings.warn(
             "content_delta is not used by code base and will be removed in the future releases",
@@ -603,6 +609,12 @@ class BlankCanvas(Canvas):
         raise NotImplementedError("BlankCanvas doesn't know its own size!")
 
     def content_delta(self, other: Canvas) -> typing.NoReturn:
+        """
+        Raise :exc:`NotImplementedError`: a BlankCanvas does not know its own size.
+
+        .. deprecated:: 4.0.3
+            Not used by the code base; there is no replacement. It will be removed in a future release.
+        """
         warnings.warn(
             "content_delta is not used by code base and will be removed in the future releases",
             DeprecationWarning,
@@ -658,6 +670,9 @@ class SolidCanvas(Canvas):
     def content_delta(self, other: Canvas) -> list[int] | Iterator[_ContentLine]:
         """
         Return the differences between other and this canvas.
+
+        .. deprecated:: 4.0.3
+            Not used by the code base; there is no replacement. It will be removed in a future release.
         """
         warnings.warn(
             "content_delta is not used by code base and will be removed in the future releases",
@@ -676,7 +691,7 @@ class CompositeCanvas(Canvas):
 
     def __init__(self, canv: Canvas | None = None) -> None:
         """
-        canv -- a Canvas object to wrap this CompositeCanvas around.
+        :param canv: a Canvas object to wrap this CompositeCanvas around.
 
         if canv is a CompositeCanvas, make a copy of its contents
         """
@@ -763,6 +778,9 @@ class CompositeCanvas(Canvas):
     def content_delta(self, other: Canvas) -> Iterator[_ContentLine]:
         """
         Return the differences between other and this canvas.
+
+        .. deprecated:: 4.0.3
+            Not used by the code base; there is no replacement. It will be removed in a future release.
         """
         warnings.warn(
             "content_delta is not used by code base and will be removed in the future releases",
@@ -794,8 +812,8 @@ class CompositeCanvas(Canvas):
     def trim(self, top: int, count: int | None = None) -> None:
         """Trim lines from the top and/or bottom of canvas.
 
-        top -- number of lines to remove from top
-        count -- number of lines to keep, or None for all the rest
+        :param top: number of lines to remove from top
+        :param count: number of lines to keep, or None for all the rest
         """
         if top < 0:
             raise ValueError(f"invalid trim amount {top:d}!")
@@ -817,7 +835,7 @@ class CompositeCanvas(Canvas):
     def trim_end(self, end: int) -> None:
         """Trim lines from the bottom of the canvas.
 
-        end -- number of lines to remove from the end
+        :param end: number of lines to remove from the end
         """
         if end <= 0:
             raise ValueError(f"invalid trim amount {end:d}!")
@@ -936,7 +954,7 @@ class CompositeCanvas(Canvas):
         """
         Apply an attribute-mapping dictionary to the canvas.
 
-        mapping -- dictionary of original-attribute:new-attribute items
+        :param mapping: dictionary of original-attribute:new-attribute items
         """
         if self.widget_info:
             raise self._finalized_error
@@ -1011,6 +1029,9 @@ def shards_delta(
 ) -> Iterator[tuple[int, Iterable[_CView | tuple[int, int, int, int, dict[Hashable, Hashable] | None, None]]]]:
     """
     Yield shards1 with cviews that are the same as shards2 having canv = None.
+
+    .. deprecated:: 4.0.3
+        Not used by the code base; there is no replacement. It will be removed in a future release.
     """
     warnings.warn(
         "shards_delta is deprecated and will be removed in a future version",
@@ -1042,9 +1063,12 @@ def shard_cviews_delta(
     cviews: Iterable[_CView],
     other_cviews: Iterable[_CView],
 ) -> Iterator[_CView | tuple[int, int, int, int, dict[Hashable, Hashable] | None, None]]:
-    """Return iterator of cviews with differences between shards
+    """Return iterator of cviews with differences between shards.
 
     If Canvas and shard tail are equal between shards, return None instead of canvas.
+
+    .. deprecated:: 4.0.3
+        Not used by the code base; there is no replacement. It will be removed in a future release.
     """
     warnings.warn(
         "shard_cviews_delta is deprecated and will be removed in a future version",

--- a/urwid/display/_posix_raw_display.py
+++ b/urwid/display/_posix_raw_display.py
@@ -65,12 +65,10 @@ class Screen(_raw_display_base.Screen):
         """Initialize a screen that directly prints escape codes to an output
         terminal.
 
-        bracketed_paste_mode -- enable bracketed paste mode in the host terminal.
-            If the host terminal supports it, the application will receive `begin paste`
-            and `end paste` keystrokes when the user pastes text.
-        focus_reporting -- enable focus reporting in the host terminal.
-            If the host terminal supports it, the application will receive `focus in`
-            and `focus out` keystrokes when the application gains and loses focus.
+        :param bracketed_paste_mode: enable bracketed paste mode in the host terminal. If the host terminal supports it,
+            the application will receive `begin paste` and `end paste` keystrokes when the user pastes text.
+        :param focus_reporting: enable focus reporting in the host terminal. If the host terminal supports it, the
+            application will receive `focus in` and `focus out` keystrokes when the application gains and loses focus.
 
         .. note::
             on terminal-generated signals: putting the terminal into cbreak mode (see `start()`)
@@ -110,7 +108,7 @@ class Screen(_raw_display_base.Screen):
 
     def _sigwinch_handler(self, signum: int = 28, frame: FrameType | None = None) -> None:
         """
-        frame -- will always be None when the GLib event loop is being used.
+        :param frame: will always be None when the GLib event loop is being used.
         """
         super()._sigwinch_handler(signum, frame)
 
@@ -146,7 +144,7 @@ class Screen(_raw_display_base.Screen):
 
     def _sigcont_handler(self, signum: int, frame: FrameType | None = None) -> None:
         """
-        frame -- will always be None when the GLib event loop is being used.
+        :param frame: will always be None when the GLib event loop is being used.
         """
         self.signal_restore()
 
@@ -222,7 +220,7 @@ class Screen(_raw_display_base.Screen):
         """
         Initialize the screen and input mode.
 
-        alternate_buffer -- use an alternate screen buffer
+        :param alternate_buffer: use an alternate screen buffer
         """
         if args or kwargs:
             raise TypeError(f"start() got unexpected arguments: {args=!r}, {kwargs=!r}")

--- a/urwid/display/_raw_display_base.py
+++ b/urwid/display/_raw_display_base.py
@@ -322,7 +322,7 @@ class Screen(BaseScreen, RealTerminal):
 
     def _sigwinch_handler(self, signum: int = 28, frame: FrameType | None = None) -> None:
         """
-        frame -- will always be None when the GLib event loop is being used.
+        :param frame: will always be None when the GLib event loop is being used.
         """
         logger = self.logger.getChild("signal_handlers")
 
@@ -366,15 +366,12 @@ class Screen(BaseScreen, RealTerminal):
         Set the get_input timeout values.  All values are in floating
         point numbers of seconds.
 
-        max_wait -- amount of time in seconds to wait for input when
-            there is no input pending, wait forever if None
-        complete_wait -- amount of time in seconds to wait when
-            get_input detects an incomplete escape sequence at the
-            end of the available input
-        resize_wait -- amount of time in seconds to wait for more input
-            after receiving two screen resize requests in a row to
-            stop Urwid from consuming 100% cpu during a gradual
-            window resize operation
+        :param max_wait: amount of time in seconds to wait for input when there is no input pending, wait forever if
+            None
+        :param complete_wait: amount of time in seconds to wait when get_input detects an incomplete escape sequence at
+            the end of the available input
+        :param resize_wait: amount of time in seconds to wait for more input after receiving two screen resize requests
+            in a row to stop Urwid from consuming 100% cpu during a gradual window resize operation
         """
         self.max_wait = max_wait
         if max_wait is not None:
@@ -415,7 +412,7 @@ class Screen(BaseScreen, RealTerminal):
         """
         Initialize the screen and input mode.
 
-        alternate_buffer -- use alternate screen buffer
+        :param alternate_buffer: use alternate screen buffer
         """
 
     def _stop_mouse_restore_buffer(self) -> None:
@@ -476,7 +473,7 @@ class Screen(BaseScreen, RealTerminal):
     def get_input(self, raw_keys: bool = False) -> _DecodedInput | tuple[_DecodedInput, list[int]]:
         """Return pending input as a list.
 
-        raw_keys -- return raw keycodes as well as translated versions
+        :param raw_keys: return raw keycodes as well as translated versions
 
         This function will immediately return all the input since the
         last time it was called.  If there is no input pending it will
@@ -1095,15 +1092,11 @@ class Screen(BaseScreen, RealTerminal):
         has_underline: bool | None = None,
     ) -> None:
         """
-        colors -- number of colors terminal supports (1, 16, 88, 256, or 2**24)
-            or None to leave unchanged
-        bright_is_bold -- set to True if this terminal uses the bold
-            setting to create bright colors (numbers 8-15), set to False
-            if this Terminal can create bright colors without bold or
-            None to leave unchanged
-        has_underline -- set to True if this terminal can use the
-            underline setting, False if it cannot or None to leave
-            unchanged
+        :param colors: number of colors terminal supports (1, 16, 88, 256, or 2**24) or None to leave unchanged
+        :param bright_is_bold: set to True if this terminal uses the bold setting to create bright colors (numbers
+            8-15), set to False if this Terminal can create bright colors without bold or None to leave unchanged
+        :param has_underline: set to True if this terminal can use the underline setting, False if it cannot or None to
+            leave unchanged
         """
         if colors is None:
             colors = self.colors

--- a/urwid/display/_win32_raw_display.py
+++ b/urwid/display/_win32_raw_display.py
@@ -80,7 +80,7 @@ class Screen(_raw_display_base.Screen):
         """
         Initialize the screen and input mode.
 
-        alternate_buffer -- use alternate screen buffer
+        :param alternate_buffer: use alternate screen buffer
         """
         if args or kwargs:
             raise TypeError(f"start() got unexpected arguments: {args=!r}, {kwargs=!r}")

--- a/urwid/display/common.py
+++ b/urwid/display/common.py
@@ -216,8 +216,8 @@ def _value_lookup_table(values: Sequence[int], size: int) -> list[int]:
     Generate a lookup table for finding the closest item in values.
     Lookup returns (index into values)+1
 
-    values -- list of values in ascending order, all < size
-    size -- size of lookup table and maximum value
+    :param values: list of values in ascending order, all < size
+    :param size: size of lookup table and maximum value
 
     >>> _value_lookup_table([0, 7, 9], 10)
     [0, 0, 0, 0, 1, 1, 1, 1, 2, 2]
@@ -545,7 +545,7 @@ class AttrSpec:
         colors: Literal[1, 16, 88, 256, 16777216] = 256,
     ) -> None:
         """
-        fg -- a string containing a comma-separated foreground color and settings
+        :param fg: a string containing a comma-separated foreground color and settings
 
               Color values:
               'default' (use the terminal's default foreground),
@@ -570,7 +570,7 @@ class AttrSpec:
               Most terminals ignore the 'blink' setting.
               If the color is not given then 'default' will be assumed.
 
-        bg -- a string containing the background color
+        :param bg: a string containing the background color
 
               Color values:
               'default' (use the terminal's default background),
@@ -582,7 +582,7 @@ class AttrSpec:
 
               An empty string will be treated the same as 'default'.
 
-        colors -- the maximum colors available for the specification
+        :param colors: the maximum colors available for the specification
 
                    Valid values include: 1, 16, 88, 256, and 2**24.  High-color
                    values are only usable with 88, 256, or 2**24 colors.  With
@@ -1037,7 +1037,8 @@ class BaseScreen(abc.ABC, metaclass=signals.MetaSignals):
 
         Extra arguments are passed to `start`.
 
-        Deprecated in favor of calling `start` as a context manager.
+        .. deprecated:: 1.3.0
+            Call `start` as a context manager instead. This API will be removed in version 5.0.
         """
         warnings.warn(
             "run_wrapper is deprecated in favor of calling `start` as a context manager."
@@ -1076,8 +1077,8 @@ class BaseScreen(abc.ABC, metaclass=signals.MetaSignals):
     ) -> None:
         """Register a set of palette entries.
 
-        palette -- a list of (name, like_other_name) or
-        (name, foreground, background, mono, foreground_high, background_high) tuples
+        :param palette: a list of (name, like_other_name) or
+            (name, foreground, background, mono, foreground_high, background_high) tuples
 
             The (name, like_other_name) format will copy the settings
             from the palette entry like_other_name, which must appear
@@ -1111,10 +1112,10 @@ class BaseScreen(abc.ABC, metaclass=signals.MetaSignals):
     ) -> None:
         """Register a single palette entry.
 
-        name -- new entry/attribute name
+        :param name: new entry/attribute name
 
-        foreground -- a string containing a comma-separated foreground
-        color and settings
+        :param foreground: a string containing a comma-separated foreground
+            color and settings
 
             Color values:
             'default' (use the terminal's default foreground),
@@ -1130,22 +1131,22 @@ class BaseScreen(abc.ABC, metaclass=signals.MetaSignals):
             ignore the 'blink' setting.  If the color is not given then
             'default' will be assumed.
 
-        background -- a string containing the background color
+        :param background: a string containing the background color
 
             Background color values:
             'default' (use the terminal's default background),
             'black', 'dark red', 'dark green', 'brown', 'dark blue',
             'dark magenta', 'dark cyan', 'light gray'
 
-        mono -- a comma-separated string containing monochrome terminal
-        settings (see "Settings" above.)
+        :param mono: a comma-separated string containing monochrome terminal
+            settings (see "Settings" above.)
 
             None = no terminal settings (same as 'default')
 
-        foreground_high -- a string containing a comma-separated
-        foreground color and settings, standard foreground
-        colors (see "Color values" above) or high-colors may
-        be used
+        :param foreground_high: a string containing a comma-separated
+            foreground color and settings, standard foreground
+            colors (see "Color values" above) or high-colors may
+            be used
 
             High-color example values:
             '#009' (0% red, 0% green, 60% red, like HTML colors)
@@ -1157,10 +1158,10 @@ class BaseScreen(abc.ABC, metaclass=signals.MetaSignals):
 
             None = use foreground parameter value
 
-        background_high -- a string containing the background color,
-        standard background colors (see "Background colors" above)
-        or high-colors (see "High-color example values" above)
-        may be used
+        :param background_high: a string containing the background color,
+            standard background colors (see "Background colors" above)
+            or high-colors (see "High-color example values" above)
+            may be used
 
             None = use background parameter value
         """

--- a/urwid/display/curses.py
+++ b/urwid/display/curses.py
@@ -281,15 +281,12 @@ class Screen(BaseScreen, RealTerminal):
         0.1 and any value less than 0.05 will be treated as 0.  The
         maximum timeout value for this module is 25.5 seconds.
 
-        max_wait -- amount of time in seconds to wait for input when
-            there is no input pending, wait forever if None
-        complete_wait -- amount of time in seconds to wait when
-            get_input detects an incomplete escape sequence at the
-            end of the available input
-        resize_wait -- amount of time in seconds to wait for more input
-            after receiving two screen resize requests in a row to
-            stop urwid from consuming 100% cpu during a gradual
-            window resize operation
+        :param max_wait: amount of time in seconds to wait for input when there is no input pending, wait forever if
+            None
+        :param complete_wait: amount of time in seconds to wait when get_input detects an incomplete escape sequence at
+            the end of the available input
+        :param resize_wait: amount of time in seconds to wait for more input after receiving two screen resize requests
+            in a row to stop urwid from consuming 100% cpu during a gradual window resize operation
         """
 
         def convert_to_tenths(s: float | None) -> int | None:
@@ -310,7 +307,7 @@ class Screen(BaseScreen, RealTerminal):
     def get_input(self, raw_keys: bool = False) -> _DecodedInput | tuple[_DecodedInput, list[int]]:
         """Return pending input as a list.
 
-        raw_keys -- return raw keycodes as well as translated versions
+        :param raw_keys: return raw keycodes as well as translated versions
 
         This function will immediately return all the input since the
         last time it was called.  If there is no input pending it will

--- a/urwid/display/escape.py
+++ b/urwid/display/escape.py
@@ -499,12 +499,10 @@ def process_keyqueue(
     more_available: bool,
 ) -> tuple[list[str | _MouseInput | _CursorPosition], list[int]]:
     """
-    codes -- list of key codes
-    more_available -- if True then raise MoreInputRequired when in the
-        middle of a character sequence (escape/utf8/wide) and caller
-        will attempt to send more key codes on the next call.
-
-    returns (list of input, list of remaining key codes).
+    :param codes: list of key codes
+    :param more_available: if True then raise MoreInputRequired when in the middle of a character sequence
+        (escape/utf8/wide) and caller will attempt to send more key codes on the next call.
+    :returns: a ``(list of input, list of remaining key codes)`` tuple.
     """
     code = codes[0]
     if 32 <= code <= 126:

--- a/urwid/display/html_fragment.py
+++ b/urwid/display/html_fragment.py
@@ -200,10 +200,8 @@ def screenshot_init(
     Call this function before executing an application that uses
     curses_display.Screen to have that code use HtmlGenerator instead.
 
-    sizes -- list of ( columns, rows ) tuples to be returned by each call
-             to HtmlGenerator.get_cols_rows()
-    keys -- list of lists of keys to be returned by each call to
-            HtmlGenerator.get_input()
+    :param sizes: list of ( columns, rows ) tuples to be returned by each call to HtmlGenerator.get_cols_rows()
+    :param keys: list of lists of keys to be returned by each call to HtmlGenerator.get_input()
 
     Lists of keys may include "window resize" to force the application to
     call get_cols_rows and read a new screen size.

--- a/urwid/display/lcd.py
+++ b/urwid/display/lcd.py
@@ -113,8 +113,8 @@ class CFLCDScreen(LCDScreen, abc.ABC):
 
     def __init__(self, device_path: str, baud: int) -> None:
         """
-        device_path -- eg. '/dev/ttyUSB0'
-        baud -- baud rate
+        :param device_path: eg. '/dev/ttyUSB0'
+        :param baud: baud rate
         """
         super().__init__()
         self.device_path = device_path
@@ -235,8 +235,8 @@ class KeyRepeatSimulator:
 
     def __init__(self, repeat_delay: float, repeat_next: float) -> None:
         """
-        repeat_delay -- seconds to wait before starting to repeat keys
-        repeat_next -- time between each repeated key
+        :param repeat_delay: seconds to wait before starting to repeat keys
+        :param repeat_next: time between each repeated key
         """
         self.repeat_delay = repeat_delay
         self.repeat_next = repeat_next
@@ -332,11 +332,11 @@ class CF635Screen(CFLCDScreen):
         key_map: Iterable[str] = ("up", "down", "left", "right", "enter", "esc"),
     ):
         """
-        device_path -- eg. '/dev/ttyUSB0'
-        baud -- baud rate
-        repeat_delay -- seconds to wait before starting to repeat keys
-        repeat_next -- time between each repeated key
-        key_map -- the keys to send for this device's buttons
+        :param device_path: eg. '/dev/ttyUSB0'
+        :param baud: baud rate
+        :param repeat_delay: seconds to wait before starting to repeat keys
+        :param repeat_next: time between each repeated key
+        :param key_map: the keys to send for this device's buttons
         """
         super().__init__(device_path, baud)
 
@@ -470,9 +470,9 @@ class CF635Screen(CFLCDScreen):
 
         Characters available as chr(0) through chr(7), and repeated as chr(8) through chr(15).
 
-        index -- 0 to 7 index of character to program
+        :param index: 0 to 7 index of character to program
 
-        data -- list of 8, 6-bit integer values top to bottom with MSB on the left side of the character.
+        :param data: list of 8, 6-bit integer values top to bottom with MSB on the left side of the character.
         """
         if not 0 <= index <= 7:
             raise ValueError(index)
@@ -482,8 +482,7 @@ class CF635Screen(CFLCDScreen):
 
     def set_cursor_style(self, style: Literal[1, 2, 3, 4]) -> None:
         """
-        style -- CURSOR_BLINKING_BLOCK, CURSOR_UNDERSCORE,
-            CURSOR_BLINKING_BLOCK_UNDERSCORE or
+        :param style: CURSOR_BLINKING_BLOCK, CURSOR_UNDERSCORE, CURSOR_BLINKING_BLOCK_UNDERSCORE or
             CURSOR_INVERTING_BLINKING_BLOCK
         """
         if not 1 <= style <= 4:
@@ -495,7 +494,7 @@ class CF635Screen(CFLCDScreen):
         """
         Set backlight brightness
 
-        value -- 0 to 100
+        :param value: 0 to 100
         """
         if not 0 <= value <= 100:
             raise ValueError(value)
@@ -503,7 +502,7 @@ class CF635Screen(CFLCDScreen):
 
     def set_lcd_contrast(self, value: int) -> None:
         """
-        value -- 0 to 255
+        :param value: 0 to 255
         """
         if not 0 <= value <= 255:
             raise ValueError(value)
@@ -511,9 +510,9 @@ class CF635Screen(CFLCDScreen):
 
     def set_led_pin(self, led: Literal[0, 1, 2, 3], rg: Literal[0, 1], value: int) -> None:
         """
-        led -- 0 to 3
-        rg -- 0 for red, 1 for green
-        value -- 0 to 100
+        :param led: 0 to 3
+        :param rg: 0 for red, 1 for green
+        :param value: 0 to 100
         """
         if not 0 <= led <= 3:
             raise ValueError(led)

--- a/urwid/display/web.py
+++ b/urwid/display/web.py
@@ -149,8 +149,7 @@ class Screen(BaseScreen):
     ) -> None:
         """Register a list of palette entries.
 
-        palette -- list of (name, foreground, background) or
-                   (name, same_as_other_name) palette entries.
+        :param palette: list of (name, foreground, background) or (name, same_as_other_name) palette entries.
 
         calls self.register_palette_entry for each item in l
         """
@@ -177,10 +176,10 @@ class Screen(BaseScreen):
     ) -> None:
         """Register a single palette entry.
 
-        name -- new entry/attribute name
-        foreground -- foreground colour
-        background -- background colour
-        mono -- monochrome terminal attribute
+        :param name: new entry/attribute name
+        :param foreground: foreground colour
+        :param background: background colour
+        :param mono: monochrome terminal attribute
 
         See curses_display.register_palette_entry for more info.
         """
@@ -643,14 +642,11 @@ def set_preferences(
     """
     Set web_display preferences.
 
-    app_name -- application name to appear in html interface
-    pipe_dir -- directory for input pipes, daemon update sockets
-                and daemon error logs
-    allow_polling -- allow creation of daemon processes for
-                     browsers without multipart support
-    max_clients -- maximum concurrent client connections. This
-               pool is shared by all urwid applications
-               using the same pipe_dir
+    :param app_name: application name to appear in html interface
+    :param pipe_dir: directory for input pipes, daemon update sockets and daemon error logs
+    :param allow_polling: allow creation of daemon processes for browsers without multipart support
+    :param max_clients: maximum concurrent client connections. This pool is shared by all urwid applications using the
+        same pipe_dir
     """
     _prefs.app_name = app_name
     _prefs.pipe_dir = pipe_dir

--- a/urwid/event_loop/abstract_loop.py
+++ b/urwid/event_loop/abstract_loop.py
@@ -99,8 +99,8 @@ class EventLoop(abc.ABC):
 
         Returns a handle that may be passed to remove_alarm()
 
-        seconds -- floating point time to wait before calling callback
-        callback -- function to call from event loop
+        :param seconds: floating point time to wait before calling callback
+        :param callback: function to call from event loop
         """
 
     @abc.abstractmethod
@@ -162,8 +162,8 @@ class EventLoop(abc.ABC):
 
         Returns a handle that may be passed to remove_watch_file()
 
-        fd -- file descriptor to watch for input
-        callback -- function to call when input is available
+        :param fd: file descriptor to watch for input
+        :param callback: function to call when input is available
         """
 
     def set_signal_handler(
@@ -178,8 +178,8 @@ class EventLoop(abc.ABC):
         is simply a proxy function that calls :func:`signal.signal()`
         and returns the resulting value.
 
-        signum -- signal number
-        handler -- function (taking signum as its single argument),
-        or `signal.SIG_IGN`, or `signal.SIG_DFL`
+        :param signum: signal number
+        :param handler: function (taking signum as its single argument),
+            or `signal.SIG_IGN`, or `signal.SIG_DFL`
         """
         return signal.signal(signum, handler)

--- a/urwid/event_loop/asyncio_loop.py
+++ b/urwid/event_loop/asyncio_loop.py
@@ -165,8 +165,8 @@ class AsyncioEventLoop(EventLoop):
 
         Returns a handle that may be passed to remove_alarm()
 
-        seconds -- time in seconds to wait before calling callback
-        callback -- function to call from event loop
+        :param seconds: time in seconds to wait before calling callback
+        :param callback: function to call from event loop
         """
         return self._loop.call_later(seconds, self._also_call_idle(callback))
 
@@ -187,8 +187,8 @@ class AsyncioEventLoop(EventLoop):
 
         Returns a handle that may be passed to remove_watch_file()
 
-        fd -- file descriptor to watch for input
-        callback -- function to call when input is available
+        :param fd: file descriptor to watch for input
+        :param callback: function to call when input is available
         """
         self._loop.add_reader(fd, self._also_call_idle(callback))
         return fd

--- a/urwid/event_loop/glib_loop.py
+++ b/urwid/event_loop/glib_loop.py
@@ -103,8 +103,8 @@ class GLibEventLoop(EventLoop):
 
         Returns a handle that may be passed to remove_alarm()
 
-        seconds -- floating point time to wait before calling callback
-        callback -- function to call from event loop
+        :param seconds: floating point time to wait before calling callback
+        :param callback: function to call from event loop
         """
 
         @self.handle_exit
@@ -136,9 +136,9 @@ class GLibEventLoop(EventLoop):
             Returns None in all cases (unlike :func:`signal.signal()`).
         ..
 
-        signum -- signal number
-        handler -- function (taking signum as its single argument),
-        or `signal.SIG_IGN`, or `signal.SIG_DFL`
+        :param signum: signal number
+        :param handler: function (taking signum as its single argument),
+            or `signal.SIG_IGN`, or `signal.SIG_DFL`
         """
         glib_signals = [
             signal.SIGHUP,
@@ -194,8 +194,8 @@ class GLibEventLoop(EventLoop):
 
         Returns a handle that may be passed to remove_watch_file()
 
-        fd -- file descriptor to watch for input
-        callback -- function to call when input is available
+        :param fd: file descriptor to watch for input
+        :param callback: function to call when input is available
         """
 
         @self.handle_exit

--- a/urwid/event_loop/select_loop.py
+++ b/urwid/event_loop/select_loop.py
@@ -94,8 +94,8 @@ class SelectEventLoop(EventLoop):
 
         Returns a handle that may be passed to remove_alarm()
 
-        seconds -- floating point time to wait before calling callback
-        callback -- function to call from event loop
+        :param seconds: floating point time to wait before calling callback
+        :param callback: function to call from event loop
         """
         tm = time.time() + seconds
         handle = (tm, next(self._tie_break), callback)
@@ -124,8 +124,8 @@ class SelectEventLoop(EventLoop):
 
         Returns a handle that may be passed to remove_watch_file()
 
-        fd -- file descriptor to watch for input
-        callback -- function to call when input is available
+        :param fd: file descriptor to watch for input
+        :param callback: function to call when input is available
         """
         self._watch_files[fd] = callback
         return fd

--- a/urwid/event_loop/trio_loop.py
+++ b/urwid/event_loop/trio_loop.py
@@ -114,16 +114,14 @@ class TrioEventLoop(EventLoop):
     def remove_alarm(self, handle: trio.CancelScope) -> bool:
         """Removes an alarm.
 
-        Parameters:
-            handle: the handle of the alarm to remove
+        :param handle: the handle of the alarm to remove
         """
         return self._cancel_scope(handle)
 
     def remove_enter_idle(self, handle: int) -> bool:
         """Removes an idle callback.
 
-        Parameters:
-            handle: the handle of the idle callback to remove
+        :param handle: the handle of the idle callback to remove
         """
         try:
             del self._idle_callbacks[handle]
@@ -134,20 +132,16 @@ class TrioEventLoop(EventLoop):
     def remove_watch_file(self, handle: trio.CancelScope) -> bool:
         """Removes a file descriptor being watched for input.
 
-        Parameters:
-            handle: the handle of the file descriptor callback to remove
-
-        Returns:
-            True if the file descriptor was watched, False otherwise
+        :param handle: the handle of the file descriptor callback to remove
+        :returns: True if the file descriptor was watched, False otherwise
         """
         return self._cancel_scope(handle)
 
     def _cancel_scope(self, scope: trio.CancelScope) -> bool:
         """Cancels the given Trio cancellation scope.
 
-        Returns:
-            True if the scope was cancelled, False if it was cancelled already
-            before invoking this function
+        :param scope: the Trio cancellation scope to cancel
+        :returns: True if the scope was cancelled, False if it was cancelled already before invoking this function
         """
         existed = not scope.cancel_called
         scope.cancel()
@@ -202,12 +196,9 @@ class TrioEventLoop(EventLoop):
         """Calls `callback()` when the given file descriptor has some data
         to read. No parameters are passed to the callback.
 
-        Parameters:
-            fd: file descriptor to watch for input
-            callback: function to call when some input is available
-
-        Returns:
-            a handle that may be passed to `remove_watch_file()`
+        :param fd: file descriptor to watch for input
+        :param callback: function to call when some input is available
+        :returns: a handle that may be passed to `remove_watch_file()`
         """
         return self._start_task(self._watch_task, fd, callback)
 
@@ -220,10 +211,9 @@ class TrioEventLoop(EventLoop):
         """Asynchronous task that sleeps for a given number of seconds and then
         calls the given callback.
 
-        Parameters:
-            scope: the cancellation scope that can be used to cancel the task
-            seconds: the number of seconds to wait
-            callback: the callback to call
+        :param scope: the cancellation scope that can be used to cancel the task
+        :param seconds: the number of seconds to wait
+        :param callback: the callback to call
         """
         with scope:
             await self._sleep(seconds)
@@ -276,11 +266,9 @@ class TrioEventLoop(EventLoop):
         the task and the arguments so we can start the task when the nursery
         is open.
 
-        Parameters:
-            task: a Trio task to run
-
-        Returns:
-            a cancellation scope for the Trio task
+        :param task: a Trio task to run
+        :param args: extra positional arguments passed to the task after its cancellation scope
+        :returns: a cancellation scope for the Trio task
         """
         scope = trio.CancelScope()
         if self._nursery:
@@ -298,10 +286,9 @@ class TrioEventLoop(EventLoop):
         """Asynchronous task that watches the given file descriptor and calls
         the given callback whenever the file descriptor becomes readable.
 
-        Parameters:
-            scope: the cancellation scope that can be used to cancel the task
-            fd: the file descriptor to watch
-            callback: the callback to call
+        :param scope: the cancellation scope that can be used to cancel the task
+        :param fd: the file descriptor to watch
+        :param callback: the callback to call
         """
         with scope:
             # We check for the scope being cancelled before calling

--- a/urwid/event_loop/twisted_loop.py
+++ b/urwid/event_loop/twisted_loop.py
@@ -143,8 +143,8 @@ class TwistedEventLoop(EventLoop):
 
         Returns a handle that may be passed to remove_alarm()
 
-        seconds -- floating point time to wait before calling callback
-        callback -- function to call from event loop
+        :param seconds: floating point time to wait before calling callback
+        :param callback: function to call from event loop
         """
         handle = self.reactor.callLater(seconds, self.handle_exit(callback))
         return handle
@@ -170,8 +170,8 @@ class TwistedEventLoop(EventLoop):
 
         Returns a handle that may be passed to remove_watch_file()
 
-        fd -- file descriptor to watch for input
-        callback -- function to call when input is available
+        :param fd: file descriptor to watch for input
+        :param callback: function to call when input is available
         """
         ind = _TwistedInputDescriptor(self.reactor, fd, self.handle_exit(callback))
         self._watch_files[fd] = ind

--- a/urwid/font.py
+++ b/urwid/font.py
@@ -95,6 +95,16 @@ def separate_glyphs(gdata: str, height: int) -> tuple[dict[str, tuple[int, list[
 
 
 def add_font(name: str, cls: FontRegistry) -> None:
+    """
+    Register a font class under the given name.
+
+    :param name: name to register the font class under
+    :param cls: the font class to register
+
+    .. deprecated:: 2.2.0
+        Set the ``name`` attribute on the font class, pass the ``font_name`` metaclass keyword argument,
+        or call ``Font.register(<name>)`` instead. This API will be removed in version 5.0.
+    """
     warnings.warn(
         "`add_font` is deprecated, please set 'name' attribute to the font class,"
         " use metaclass keyword argument 'font_name'"

--- a/urwid/numedit.py
+++ b/urwid/numedit.py
@@ -57,6 +57,18 @@ class NumEdit(Edit):
         trim_leading_zeros: bool = True,
         allow_negative: bool = False,
     ):
+        """
+        :param allowed: characters accepted by this widget
+        :param caption: caption markup
+        :param default: default edit value
+        :param trimLeadingZeros: legacy spelling of ``trim_leading_zeros``
+        :param trim_leading_zeros: strip leading zeros from the edit value
+        :param allow_negative: accept a leading minus sign
+
+        .. deprecated:: 2.2.3
+            The ``trimLeadingZeros`` argument is deprecated, use the ``trim_leading_zeros``
+            keyword argument instead.
+        """
         super().__init__(caption, default)
         self._allowed = allowed
         self._trim_leading_zeros = trim_leading_zeros
@@ -140,8 +152,8 @@ class IntegerEdit(NumEdit):
         allow_negative: bool = False,
     ) -> None:
         """
-        caption -- caption markup
-        default -- default edit value
+        :param caption: caption markup
+        :param default: default edit value
 
         >>> IntegerEdit("", 42)
         <IntegerEdit selectable flow widget '42' edit_pos=2>
@@ -267,10 +279,14 @@ class FloatEdit(NumEdit):
         allow_negative: bool = False,
     ) -> None:
         """
-        caption -- caption markup
-        default -- default edit value
-        preserve_significance -- return value has the same signif. as default
-        decimal_separator -- use '.' as separator by default, optionally a ','
+        :param caption: caption markup
+        :param default: default edit value
+        :param preserve_significance: return value has the same signif. as default
+        :param decimal_separator: use '.' as separator by default, optionally a ','
+
+        .. deprecated:: 2.2.3
+            The ``preserveSignificance`` and ``decimalSeparator`` arguments are deprecated,
+            use the ``preserve_significance`` and ``decimal_separator`` keyword arguments instead.
 
         >>> FloatEdit("", "1.065434")
         <FloatEdit selectable flow widget '1.065434' edit_pos=8>

--- a/urwid/str_util.py
+++ b/urwid/str_util.py
@@ -366,14 +366,12 @@ def move_next_char(text: str | bytes, start_offs: int, end_offs: int) -> int:
 def within_double_byte(text: bytes, line_start: int, pos: int) -> Literal[0, 1, 2]:
     """Return whether pos is within a double-byte encoded character.
 
-    text -- byte string in question
-    line_start -- offset of beginning of line (< pos)
-    pos -- offset in question
-
-    Return values:
-    0 -- not within dbe char, or double_byte_encoding == False
-    1 -- pos is on the 1st half of a dbe char
-    2 -- pos is on the 2nd half of a dbe char
+    :param text: byte string in question
+    :param line_start: offset of beginning of line (< pos)
+    :param pos: offset in question
+    :returns: ``0`` if not within a double-byte character, or the byte encoding is not double-byte,
+        ``1`` if pos is on the first half of a double-byte character,
+        ``2`` if pos is on the second half of a double-byte character.
     """
     if not isinstance(text, bytes):
         raise TypeError(text)

--- a/urwid/text_layout.py
+++ b/urwid/text_layout.py
@@ -487,8 +487,9 @@ def shift_line(
 ) -> _LayoutLine:
     """
     Return a shifted line from a layout structure to the left or right.
-    segs -- line of a layout structure
-    amount -- screen columns to shift right (+ve) or left (-ve)
+
+    :param segs: line of a layout structure
+    :param amount: screen columns to shift right (+ve) or left (-ve)
     """
     if not isinstance(amount, int):
         raise TypeError(amount)
@@ -513,9 +514,10 @@ def trim_line(
 ) -> _LayoutLine:
     """
     Return a trimmed line of a text layout structure.
-    text -- text to which this layout structure applies
-    start -- starting screen column
-    end -- ending screen column
+
+    :param text: text to which this layout structure applies
+    :param start: starting screen column
+    :param end: ending screen column
     """
     result = []
     x = 0
@@ -668,10 +670,10 @@ def calc_coords(
     """
     Calculate the coordinates closest to position pos in text with layout.
 
-    text -- raw string or unicode string
-    layout -- layout structure applied to text
-    pos -- integer position into text
-    clamp -- ignored right now
+    :param text: raw string or unicode string
+    :param layout: layout structure applied to text
+    :param pos: integer position into text
+    :param clamp: ignored right now
     """
     closest: tuple[int, tuple[int, int]] | None = None
     y = 0

--- a/urwid/util.py
+++ b/urwid/util.py
@@ -261,16 +261,15 @@ def calc_trim_text(
 ) -> tuple[int, int, int, int]:
     """
     Calculate the result of trimming text.
-    start_offs -- offset into text to treat as screen column 0
-    end_offs -- offset into text to treat as the end of the line
-    start_col -- screen column to trim at the left
-    end_col -- screen column to trim at the right
 
-    Returns (start, end, pad_left, pad_right), where:
-    start -- resulting start offset
-    end -- resulting end offset
-    pad_left -- 0 for no pad or 1 for one space to be added
-    pad_right -- 0 for no pad or 1 for one space to be added
+    :param start_offs: offset into text to treat as screen column 0
+    :param end_offs: offset into text to treat as the end of the line
+    :param start_col: screen column to trim at the left
+    :param end_col: screen column to trim at the right
+
+    :returns: a ``(start, end, pad_left, pad_right)`` tuple, where ``start`` is the resulting start offset,
+        ``end`` the resulting end offset, and ``pad_left``/``pad_right`` are ``0`` for no pad
+        or ``1`` for one space to be added.
     """
     spos = start_offs
     pad_left = pad_right = 0
@@ -496,8 +495,8 @@ def _tagmarkup_recurse(
 ) -> tuple[list[str | bytes], list[tuple[Hashable, int]]]:
     """Return (text list, attribute list) for tagmarkup passed.
 
-    tm -- tagmarkup
-    attr -- current attribute or None"""
+    :param tm: tagmarkup
+    :param attr: current attribute or None"""
 
     if isinstance(tm, list):
         # for lists recurse to process each subelement
@@ -540,10 +539,13 @@ def is_mouse_press(ev: str) -> bool:
 
 
 class MetaSuper(type):
-    """Deprecated metaclass.
+    """Metaclass kept only so that existing class definitions keep importing.
 
-    Present only for code compatibility, all logic has been removed.
-    Please move to the last position in the class bases to allow future changes.
+    All logic has been removed; it is a plain :class:`type` subclass.
+
+    .. deprecated:: 3.0.0
+        Drop it from the class bases. While it is still listed, move it to the last position,
+        so that future changes to the other bases are not blocked by it.
     """
 
     __slots__ = ()

--- a/urwid/vterm.py
+++ b/urwid/vterm.py
@@ -636,7 +636,7 @@ class TermCanvas(Canvas):
         Process startbyte and return the number of bytes following it to get a
         valid UTF-8 multibyte sequence.
 
-        bytenum -- an integer ordinal
+        :param bytenum: an integer ordinal
         """
         length = 0
 
@@ -651,7 +651,7 @@ class TermCanvas(Canvas):
         Parse main charset and add the processed byte(s) to the terminal state
         machine.
 
-        byte -- an integer ordinal
+        :param byte: an integer ordinal
         """
         if self.modes.main_charset == CHARSET_UTF8 or util.get_encoding() == "utf8":
             if byte >= 0xC0:
@@ -687,7 +687,7 @@ class TermCanvas(Canvas):
         """
         Process a single character (single- and multi-byte).
 
-        char -- a byte string
+        :param char: a byte string
         """
         x, y = self.term_cursor
 
@@ -1305,6 +1305,12 @@ class TermCanvas(Canvas):
         self,
         other: Canvas,
     ) -> list[int] | Iterator[list[tuple[AttrSpec | None, Literal["0", "U"] | None, bytes]]]:
+        """
+        Return the differences between other and this canvas.
+
+        .. deprecated:: 4.0.3
+            Not used by the code base; there is no replacement. It will be removed in a future release.
+        """
         warnings.warn(
             "content_delta is not used by code base and will be removed in the future releases",
             DeprecationWarning,

--- a/urwid/widget/attr_wrap.py
+++ b/urwid/widget/attr_wrap.py
@@ -15,6 +15,14 @@ WrappedWidget = typing.TypeVar("WrappedWidget", bound="AbstractWidget")
 
 
 class AttrWrap(AttrMap[WrappedWidget]):
+    """
+    A special case of the :class:`AttrMap` widget that passes all function calls
+    and variable references on to the wrapped widget.
+
+    .. deprecated:: 0.9.9
+        Maintained for backwards compatibility only, new code should use :class:`AttrMap` instead.
+    """
+
     def __init__(
         self,
         w: WrappedWidget,
@@ -22,14 +30,12 @@ class AttrWrap(AttrMap[WrappedWidget]):
         focus_attr: Hashable | Mapping[Hashable, Hashable] = None,
     ) -> None:
         """
-        w -- widget to wrap (stored as self.original_widget)
-        attr -- attribute to apply to w
-        focus_attr -- attribute to apply when in focus, if None use attr
+        :param w: widget to wrap (stored as self.original_widget)
+        :param attr: attribute to apply to w
+        :param focus_attr: attribute to apply when in focus, if None use attr
 
-        This widget is a special case of the new AttrMap widget, and it
-        will pass all function calls and variable references to the wrapped
-        widget.  This class is maintained for backwards compatibility only,
-        new code should use AttrMap instead.
+        .. deprecated:: 0.9.9
+            Maintained for backwards compatibility only, new code should use :class:`AttrMap` instead.
 
         >>> from urwid import Divider, Edit, Text
         >>> AttrWrap(Divider("!"), "bright")
@@ -61,7 +67,13 @@ class AttrWrap(AttrMap[WrappedWidget]):
 
     @property
     def w(self) -> WrappedWidget:
-        """backwards compatibility, widget used to be stored as w"""
+        """
+        The wrapped widget.
+
+        .. deprecated:: 0.9.9
+            The widget used to be stored as ``w``. Use :attr:`original_widget` instead.
+            This API will be removed in version 5.0.
+        """
         warnings.warn(
             "backwards compatibility, widget used to be stored as original_widget. API will be removed in version 5.0.",
             DeprecationWarning,
@@ -71,6 +83,13 @@ class AttrWrap(AttrMap[WrappedWidget]):
 
     @w.setter
     def w(self, new_widget: WrappedWidget) -> None:
+        """
+        Replace the wrapped widget.
+
+        .. deprecated:: 0.9.9
+            The widget used to be stored as ``w``. Use :attr:`original_widget` instead.
+            This API will be removed in version 5.0.
+        """
         warnings.warn(
             "backwards compatibility, widget used to be stored as original_widget. API will be removed in version 5.0.",
             DeprecationWarning,

--- a/urwid/widget/bar_graph.py
+++ b/urwid/widget/bar_graph.py
@@ -21,7 +21,9 @@ class BarGraphMeta(WidgetMeta):
     """
     Detect subclass get_data() method and dynamic change to get_data() method and disable caching in these cases.
 
-    This is for backwards compatibility only, new programs should use set_data() instead of overriding get_data().
+    .. deprecated:: 4.0.10
+        Overriding ``get_data()`` in a :class:`BarGraph` subclass is supported for backwards compatibility only.
+        Call :meth:`BarGraph.set_data` instead, so that the rendered canvas can be cached.
     """
 
     def __init__(
@@ -170,9 +172,9 @@ class BarGraph(Widget, metaclass=BarGraphMeta):
         """
         Store bar data, bargraph top and horizontal line positions.
 
-        bardata -- a list of bar values.
-        top -- maximum value for segments within bardata
-        hlines -- None or a bar value marking horizontal line positions
+        :param bardata: a list of bar values.
+        :param top: maximum value for segments within bardata
+        :param hlines: None or a bar value marking horizontal line positions
 
         bar values are [ segment1, segment2, ... ] lists where top is
         the maximal value corresponding to the top of the bar graph and
@@ -214,7 +216,7 @@ class BarGraph(Widget, metaclass=BarGraphMeta):
         """
         Set a preferred bar width for calculate_bar_widths to use.
 
-        width -- width of bar or None for automatic width adjustment
+        :param width: width of bar or None for automatic width adjustment
         """
         if width is not None and width <= 0:
             raise ValueError(width)
@@ -495,10 +497,10 @@ def calculate_bargraph_display(
     Calculate a rendering of the bar graph described by data, bar_widths
     and height.
 
-    bardata -- bar information with same structure as BarGraph.data
-    top -- maximal value for bardata segments
-    bar_widths -- list of integer column widths for each bar
-    maxrow -- rows for display of bargraph
+    :param bardata: bar information with same structure as BarGraph.data
+    :param top: maximal value for bardata segments
+    :param bar_widths: list of integer column widths for each bar
+    :param maxrow: rows for display of bargraph
 
     Returns a structure as follows:
       [ ( y_count, [ ( bar_type, width), ... ] ), ... ]
@@ -650,13 +652,12 @@ class GraphVScale(Widget):
         top: float,
     ) -> None:
         """
-        GraphVScale( [(label1 position, label1 markup),...], top )
-        label position -- 0 < position < top for the y position
-        label markup -- text markup for this label
-        top -- top y position
+        Build a vertical scale for the BarGraph widget, which can correspond to the BarGraph's horizontal lines.
 
-        This widget is a vertical scale for the BarGraph widget that
-        can correspond to the BarGraph's horizontal lines
+        :param labels: a sequence of ``(label position, label markup)`` pairs, where the position satisfies
+            ``0 < position < top`` and gives the y position of the label, and the markup is the text markup
+            for that label
+        :param top: top y position
         """
         super().__init__()
         self.set_scale(labels, top)
@@ -667,10 +668,12 @@ class GraphVScale(Widget):
         top: float,
     ) -> None:
         """
-        set_scale( [(label1 position, label1 markup),...], top )
-        label position -- 0 < position < top for the y position
-        label markup -- text markup for this label
-        top -- top y position
+        Replace the labels and the top y position of the scale.
+
+        :param labels: a sequence of ``(label position, label markup)`` pairs, where the position satisfies
+            ``0 < position < top`` and gives the y position of the label, and the markup is the text markup
+            for that label
+        :param top: top y position
         """
 
         labels = sorted(labels[:], reverse=True)  # shallow copy

--- a/urwid/widget/big_text.py
+++ b/urwid/widget/big_text.py
@@ -20,8 +20,8 @@ class BigText(Widget):
 
     def __init__(self, markup: _TagMarkup, font: Font) -> None:
         """
-        markup -- same as Text widget markup
-        font -- instance of a Font class
+        :param markup: same as Text widget markup
+        :param font: instance of a Font class
         """
         super().__init__()
         self.text: str = ""

--- a/urwid/widget/box_adapter.py
+++ b/urwid/widget/box_adapter.py
@@ -48,9 +48,15 @@ class BoxAdapter(WidgetDecoration[WrappedWidget]):
     def _repr_attrs(self) -> dict[str, typing.Any]:
         return {**super()._repr_attrs(), "height": self.height}
 
-    # originally stored as box_widget, keep for compatibility
     @property
     def box_widget(self) -> WrappedWidget:
+        """
+        The wrapped box widget.
+
+        .. deprecated:: 0.9.9
+            The widget used to be stored as ``box_widget``. Use :attr:`original_widget` instead.
+            This API will be removed in version 5.0.
+        """
         warnings.warn(
             "original stored as original_widget, keep for compatibility. API will be removed in version 5.0.",
             DeprecationWarning,
@@ -60,6 +66,13 @@ class BoxAdapter(WidgetDecoration[WrappedWidget]):
 
     @box_widget.setter
     def box_widget(self, widget: WrappedWidget) -> None:
+        """
+        Replace the wrapped box widget.
+
+        .. deprecated:: 0.9.9
+            The widget used to be stored as ``box_widget``. Use :attr:`original_widget` instead.
+            This API will be removed in version 5.0.
+        """
         warnings.warn(
             "original stored as original_widget, keep for compatibility. API will be removed in version 5.0.",
             DeprecationWarning,

--- a/urwid/widget/columns.py
+++ b/urwid/widget/columns.py
@@ -438,10 +438,11 @@ class Columns(
     @property
     def widget_list(self) -> MonitoredList[AbstractWidget]:
         """
-        A list of the widgets in this Columns
+        A list of the widgets in this Columns.
 
-        .. note:: only for backwards compatibility. You should use the new
-            standard container property :attr:`contents`.
+        .. deprecated:: 1.1.0
+            Use the standard container property :attr:`contents` instead.
+            This API will be removed in version 5.0.
         """
         warnings.warn(
             "only for backwards compatibility. You should use the new standard container `contents`."
@@ -459,6 +460,13 @@ class Columns(
 
     @widget_list.setter
     def widget_list(self, widgets: MonitoredList[AbstractWidget]) -> None:
+        """
+        Replace the widgets in this Columns, keeping the old options where possible.
+
+        .. deprecated:: 1.1.0
+            Use the standard container property :attr:`contents` instead.
+            This API will be removed in version 5.0.
+        """
         warnings.warn(
             "only for backwards compatibility. You should use the new standard container `contents`."
             "API will be removed in version 5.0.",
@@ -486,9 +494,11 @@ class Columns(
         | tuple[Literal[WHSettings.WEIGHT], int | float],
     ]:
         """
-        A list of the old partial options values for widgets in this Pile,
-        for backwards compatibility only.  You should use the new standard
-        container property .contents to modify Pile contents.
+        A list of the old partial options values for the widgets in this Columns.
+
+        .. deprecated:: 1.1.0
+            Use the standard container property :attr:`contents` instead.
+            This API will be removed in version 5.0.
         """
         warnings.warn(
             "for backwards compatibility only."
@@ -524,6 +534,13 @@ class Columns(
             | tuple[Literal[WHSettings.WEIGHT], int | float],
         ],
     ) -> None:
+        """
+        Replace the width settings of the widgets in this Columns.
+
+        .. deprecated:: 1.1.0
+            Use the standard container property :attr:`contents` instead.
+            This API will be removed in version 5.0.
+        """
         warnings.warn(
             "for backwards compatibility only."
             "You should use the new standard container property .contents to modify Pile contents."
@@ -552,11 +569,12 @@ class Columns(
     @property
     def box_columns(self) -> MonitoredList[int]:
         """
-        A list of the indexes of the columns that are to be treated as
-        box widgets when the Columns is treated as a flow widget.
+        A list of the indexes of the columns that are to be treated as box widgets
+        when the Columns is treated as a flow widget.
 
-        .. note:: only for backwards compatibility. You should use the new
-            standard container property :attr:`contents`.
+        .. deprecated:: 1.1.0
+            Use the standard container property :attr:`contents` instead.
+            This API will be removed in version 5.0.
         """
         warnings.warn(
             "only for backwards compatibility.You should use the new standard container property `contents`."
@@ -574,6 +592,13 @@ class Columns(
 
     @box_columns.setter
     def box_columns(self, box_columns: MonitoredList[int]) -> None:
+        """
+        Mark the columns at the given indexes as box widgets.
+
+        .. deprecated:: 1.1.0
+            Use the standard container property :attr:`contents` instead.
+            This API will be removed in version 5.0.
+        """
         warnings.warn(
             "only for backwards compatibility.You should use the new standard container property `contents`."
             "API will be removed in version 5.0.",
@@ -671,8 +696,9 @@ class Columns(
         :param num: index of focus-to-be entry
         :type num: int
 
-        .. note:: only for backwards compatibility. You may also use the new
-            standard container property :attr:`focus_position` to set the focus.
+        .. deprecated:: 1.1.0
+            Use the standard container property :attr:`focus_position` instead.
+            This API will be removed in version 5.0.
         """
         warnings.warn(
             "only for backwards compatibility.You may also use the new standard container property `focus_position`."
@@ -686,8 +712,9 @@ class Columns(
         """
         Return the focus column index.
 
-        .. note:: only for backwards compatibility. You may also use the new
-            standard container property :attr:`focus_position` to get the focus.
+        .. deprecated:: 1.1.0
+            Use the standard container property :attr:`focus_position` instead.
+            This API will be removed in version 5.0.
         """
         warnings.warn(
             "only for backwards compatibility.You may also use the new standard container property `focus_position`."
@@ -699,12 +726,14 @@ class Columns(
 
     def set_focus(self, item: AbstractWidget | int) -> None:
         """
-        Set the item in focus
+        Set the item in focus.
 
-        .. note:: only for backwards compatibility. You may also use the new
-            standard container property :attr:`focus_position` to get the focus.
+        :param item: widget or integer index
 
-        :param item: widget or integer index"""
+        .. deprecated:: 1.1.0
+            Use the standard container property :attr:`focus_position` instead.
+            This API will be removed in version 5.0.
+        """
         warnings.warn(
             "only for backwards compatibility."
             "You may also use the new standard container property `focus_position` to get the focus."
@@ -723,23 +752,18 @@ class Columns(
 
     @property
     def focus(self) -> AbstractWidget | None:
-        """
-        the child widget in focus or None when Columns is empty
-
-        Return the widget in focus, for backwards compatibility.  You may
-        also use the new standard container property .focus to get the
-        child widget in focus.
-        """
+        """the child widget in focus or None when Columns is empty"""
         if not self.contents:
             return None
         return self.contents[self.focus_position][0]
 
     def get_focus(self) -> AbstractWidget | None:
         """
-        Return the widget in focus, for backwards compatibility.
+        Return the widget in focus.
 
-        .. note:: only for backwards compatibility. You may also use the new
-            standard container property :attr:`focus` to get the focus.
+        .. deprecated:: 1.1.0
+            Use the standard container property :attr:`focus` instead.
+            This API will be removed in version 5.0.
         """
         warnings.warn(
             "only for backwards compatibility."
@@ -768,7 +792,7 @@ class Columns(
         """
         Set the widget in focus.
 
-        position -- index of child widget to be made focus
+        :param position: index of child widget to be made focus
         """
         try:
             if position < 0 or position >= len(self.contents):
@@ -782,11 +806,11 @@ class Columns(
     @property
     def focus_col(self) -> int:
         """
-        A property for reading and setting the index of the column in
-        focus.
+        A property for reading and setting the index of the column in focus.
 
-        .. note:: only for backwards compatibility. You may also use the new
-            standard container property :attr:`focus_position` to get the focus.
+        .. deprecated:: 1.1.0
+            Use the standard container property :attr:`focus_position` instead.
+            This API will be removed in version 5.0.
         """
         warnings.warn(
             "only for backwards compatibility."
@@ -799,6 +823,13 @@ class Columns(
 
     @focus_col.setter
     def focus_col(self, new_position: int) -> None:
+        """
+        Set the index of the column in focus.
+
+        .. deprecated:: 1.1.0
+            Use the standard container property :attr:`focus_position` instead.
+            This API will be removed in version 5.0.
+        """
         warnings.warn(
             "only for backwards compatibility."
             "You may also use the new standard container property `focus_position` to get the focus."

--- a/urwid/widget/container.py
+++ b/urwid/widget/container.py
@@ -38,11 +38,15 @@ else:
 _ContentsItem = typing.TypeVar("_ContentsItem", bound=tuple[AbstractWidget, typing.Any])
 
 
-# Ideally, we would like to use an IntFlag coupled with enum.auto().
-# However, doing many bitwise operations (which happens when nesting too many
-# widgets ...) on IntFlag is orders of magnitude slower than doing the same
-# operations on IntEnum.
 class _ContainerElementSizingFlag(enum.IntEnum):
+    """Bitfield describing the sizing modes and the width/height setting a container element supports.
+
+    .. note::
+        Ideally this would be an :class:`enum.IntFlag` coupled with :func:`enum.auto`, but doing many bitwise
+        operations on an ``IntFlag`` - which happens when widgets are deeply nested - is orders of magnitude
+        slower than doing the same operations on an :class:`enum.IntEnum`.
+    """
+
     # fmt: off
     NONE      = 0b000000
     BOX       = 0b000001
@@ -125,7 +129,7 @@ class WidgetContainerMixin(WidgetContainerMixinProto[_KT_contra]):
         focus by passing in the value returned from an earlier call to
         get_focus_path().
 
-        positions -- sequence of positions
+        :param positions: sequence of positions
         """
         w: WidgetContainerMixin[typing.Any] | AbstractWidget = self
         for p in positions:

--- a/urwid/widget/edit.py
+++ b/urwid/widget/edit.py
@@ -732,8 +732,8 @@ class IntEdit(Edit):
 
     def __init__(self, caption: _TagMarkup = "", default: int | str | None = None) -> None:
         """
-        caption -- caption markup
-        default -- default edit value
+        :param caption: caption markup
+        :param default: default edit value
 
         >>> IntEdit("", 42)
         <IntEdit selectable flow widget '42' edit_pos=2>

--- a/urwid/widget/filler.py
+++ b/urwid/widget/filler.py
@@ -199,7 +199,13 @@ class Filler(WidgetDecoration[WrappedWidget]):
 
     @property
     def body(self) -> WrappedWidget:
-        """backwards compatibility, widget used to be stored as body"""
+        """
+        The wrapped widget.
+
+        .. deprecated:: 0.9.9
+            The widget used to be stored as ``body``. Use :attr:`original_widget` instead.
+            This API will be removed in version 5.0.
+        """
         warnings.warn(
             "backwards compatibility, widget used to be stored as body. API will be removed in version 5.0.",
             DeprecationWarning,
@@ -209,6 +215,13 @@ class Filler(WidgetDecoration[WrappedWidget]):
 
     @body.setter
     def body(self, new_body: WrappedWidget) -> None:
+        """
+        Replace the wrapped widget.
+
+        .. deprecated:: 0.9.9
+            The widget used to be stored as ``body``. Use :attr:`original_widget` instead.
+            This API will be removed in version 5.0.
+        """
         warnings.warn(
             "backwards compatibility, widget used to be stored as body. API will be removed in version 5.0.",
             DeprecationWarning,
@@ -393,14 +406,13 @@ def calculate_top_bottom_filler(
     Return the amount of filler (or clipping) on the top and
     bottom part of maxrow rows to satisfy the following:
 
-    valign_type -- 'top', 'middle', 'bottom', 'relative'
-    valign_amount -- a percentage when align_type=='relative'
-    height_type -- 'given', 'relative', 'clip'
-    height_amount -- a percentage when width_type=='relative'
-        otherwise equal to the height of the widget
-    min_height -- a desired minimum width for the widget or None
-    top -- a fixed number of rows to fill on the top
-    bottom -- a fixed number of rows to fill on the bottom
+    :param valign_type: 'top', 'middle', 'bottom', 'relative'
+    :param valign_amount: a percentage when align_type=='relative'
+    :param height_type: 'given', 'relative', 'clip'
+    :param height_amount: a percentage when width_type=='relative' otherwise equal to the height of the widget
+    :param min_height: a desired minimum width for the widget or None
+    :param top: a fixed number of rows to fill on the top
+    :param bottom: a fixed number of rows to fill on the bottom
 
     >>> ctbf = calculate_top_bottom_filler
     >>> ctbf(15, "top", 0, "given", 10, None, 2, 0)

--- a/urwid/widget/frame.py
+++ b/urwid/widget/frame.py
@@ -126,6 +126,13 @@ class Frame(
         self._invalidate()
 
     def get_header(self) -> HeaderWidget | None:
+        """
+        Return the header widget.
+
+        .. deprecated:: 2.2.0
+            Use the standard property :attr:`header` instead.
+            This API will be removed in version 5.0.
+        """
         warnings.warn(
             f"method `{self.__class__.__name__}.get_header` is deprecated, "
             f"standard property `{self.__class__.__name__}.header` should be used instead."
@@ -136,6 +143,15 @@ class Frame(
         return self.header
 
     def set_header(self, header: HeaderWidget | None) -> None:
+        """
+        Set the header widget.
+
+        :param header: the new header widget
+
+        .. deprecated:: 2.2.0
+            Use the standard property :attr:`header` instead.
+            This API will be removed in version 5.0.
+        """
         warnings.warn(
             f"method `{self.__class__.__name__}.set_header` is deprecated, "
             f"standard property `{self.__class__.__name__}.header` should be used instead."
@@ -156,6 +172,13 @@ class Frame(
         self._invalidate()
 
     def get_body(self) -> BodyWidget:
+        """
+        Return the body widget.
+
+        .. deprecated:: 2.2.0
+            Use the standard property :attr:`body` instead.
+            This API will be removed in version 5.0.
+        """
         warnings.warn(
             f"method `{self.__class__.__name__}.get_body` is deprecated, "
             f"standard property {self.__class__.__name__}.body should be used instead."
@@ -166,6 +189,15 @@ class Frame(
         return self.body
 
     def set_body(self, body: BodyWidget) -> None:
+        """
+        Set the body widget.
+
+        :param body: the new body widget
+
+        .. deprecated:: 2.2.0
+            Use the standard property :attr:`body` instead.
+            This API will be removed in version 5.0.
+        """
         warnings.warn(
             f"method `{self.__class__.__name__}.set_body` is deprecated, "
             f"standard property `{self.__class__.__name__}.body` should be used instead."
@@ -188,6 +220,13 @@ class Frame(
         self._invalidate()
 
     def get_footer(self) -> FooterWidget | None:
+        """
+        Return the footer widget.
+
+        .. deprecated:: 2.2.0
+            Use the standard property :attr:`footer` instead.
+            This API will be removed in version 5.0.
+        """
         warnings.warn(
             f"method `{self.__class__.__name__}.get_footer` is deprecated, "
             f"standard property `{self.__class__.__name__}.footer` should be used instead."
@@ -198,6 +237,15 @@ class Frame(
         return self.footer
 
     def set_footer(self, footer: FooterWidget | None) -> None:
+        """
+        Set the footer widget.
+
+        :param footer: the new footer widget
+
+        .. deprecated:: 2.2.0
+            Use the standard property :attr:`footer` instead.
+            This API will be removed in version 5.0.
+        """
         warnings.warn(
             f"method `{self.__class__.__name__}.set_footer` is deprecated, "
             f"standard property `{self.__class__.__name__}.footer` should be used instead."
@@ -238,11 +286,12 @@ class Frame(
         writeable property containing an indicator which part of the frame
         that is in focus: `'body', 'header'` or `'footer'`.
 
-        .. note:: included for backwards compatibility. You should rather use
-            the container property :attr:`.focus_position` to get this value.
-
         :returns: one of 'header', 'footer' or 'body'.
         :rtype: str
+
+        .. deprecated:: 1.1.0
+            Use the container property :attr:`focus_position` instead.
+            This API will be removed in version 5.0.
         """
         warnings.warn(
             "included for backwards compatibility."
@@ -254,6 +303,15 @@ class Frame(
         return self.focus_position
 
     def set_focus(self, part: Literal["header", "footer", "body"]) -> None:
+        """
+        Set the part of the frame that is in focus.
+
+        :param part: one of 'header', 'footer' or 'body'
+
+        .. deprecated:: 1.1.0
+            Use the container property :attr:`focus_position` instead.
+            This API will be removed in version 5.0.
+        """
         warnings.warn(
             "included for backwards compatibility."
             "You should rather use the container property `.focus_position` to set this value."

--- a/urwid/widget/grid_flow.py
+++ b/urwid/widget/grid_flow.py
@@ -150,11 +150,11 @@ class GridFlow(
     @property
     def cells(self) -> MonitoredList[AbstractFlowWidget]:
         """
-        A list of the widgets in this GridFlow
+        A list of the widgets in this GridFlow.
 
-        .. note:: only for backwards compatibility. You should use the new
-            standard container property :attr:`contents` to modify GridFlow
-            contents.
+        .. deprecated:: 1.1.0
+            Use the standard container property :attr:`contents` instead.
+            This API will be removed in version 5.0.
         """
         warnings.warn(
             "only for backwards compatibility."
@@ -173,6 +173,13 @@ class GridFlow(
 
     @cells.setter
     def cells(self, widgets: MonitoredList[AbstractFlowWidget]) -> None:
+        """
+        Replace the widgets in this GridFlow, giving each of them the current cell width.
+
+        .. deprecated:: 1.1.0
+            Use the standard container property :attr:`contents` instead.
+            This API will be removed in version 5.0.
+        """
         warnings.warn(
             "only for backwards compatibility."
             "You should use the new standard container property `contents` to modify GridFlow."
@@ -229,8 +236,8 @@ class GridFlow(
         """
         Return a new options tuple for use in a GridFlow's .contents list.
 
-        width_type -- 'given' is the only value accepted
-        width_amount -- None to use the default cell_width for this GridFlow
+        :param width_type: 'given' is the only value accepted
+        :param width_amount: None to use the default cell_width for this GridFlow
         """
         if width_type != WHSettings.GIVEN:
             raise GridFlowError(f"invalid width_type: {width_type!r}")
@@ -240,13 +247,14 @@ class GridFlow(
 
     def set_focus(self, cell: AbstractFlowWidget | int) -> None:
         """
-        Set the cell in focus, for backwards compatibility.
-
-        .. note:: only for backwards compatibility. You may also use the new
-            standard container property :attr:`focus_position` to get the focus.
+        Set the cell in focus.
 
         :param cell: contained element to focus
         :type cell: Widget or int
+
+        .. deprecated:: 1.1.0
+            Use the standard container property :attr:`focus_position` instead.
+            This API will be removed in version 5.0.
         """
         warnings.warn(
             "only for backwards compatibility."
@@ -281,10 +289,11 @@ class GridFlow(
 
     def get_focus(self) -> AbstractFlowWidget | None:
         """
-        Return the widget in focus, for backwards compatibility.
+        Return the widget in focus.
 
-        .. note:: only for backwards compatibility. You may also use the new
-            standard container property :attr:`focus` to get the focus.
+        .. deprecated:: 1.1.0
+            Use the standard container property :attr:`focus` instead.
+            This API will be removed in version 5.0.
         """
         warnings.warn(
             "only for backwards compatibility."
@@ -299,6 +308,14 @@ class GridFlow(
 
     @property
     def focus_cell(self) -> AbstractFlowWidget | None:
+        """
+        The cell in focus.
+
+        .. deprecated:: 1.1.0
+            Use the standard container property :attr:`focus` to read the cell in focus,
+            and :attr:`focus_position` to read or set it by index.
+            This API will be removed in version 5.0.
+        """
         warnings.warn(
             "only for backwards compatibility."
             "You may also use the new standard container property"
@@ -311,6 +328,14 @@ class GridFlow(
 
     @focus_cell.setter
     def focus_cell(self, cell: AbstractFlowWidget) -> None:
+        """
+        Set the cell in focus.
+
+        .. deprecated:: 1.1.0
+            Use the standard container property :attr:`focus` to read the cell in focus,
+            and :attr:`focus_position` to read or set it by index.
+            This API will be removed in version 5.0.
+        """
         warnings.warn(
             "only for backwards compatibility."
             "You may also use the new standard container property"
@@ -341,7 +366,7 @@ class GridFlow(
         """
         Set the widget in focus.
 
-        position -- index of child widget to be made focus
+        :param position: index of child widget to be made focus
         """
         try:
             if position < 0 or position >= len(self.contents):

--- a/urwid/widget/listbox.py
+++ b/urwid/widget/listbox.py
@@ -658,9 +658,11 @@ class ListBox(Widget, WidgetContainerMixin[_K]):
 
     def get_focus(self) -> tuple[AbstractFlowWidget, _K] | tuple[None, None]:
         """
-        Return a `(focus widget, focus position)` tuple, for backwards
-        compatibility. You may also use the new standard container
-        properties :attr:`focus` and :attr:`focus_position` to read these values.
+        Return a `(focus widget, focus position)` tuple.
+
+        .. deprecated:: 2.2.0
+            Use the standard container properties :attr:`focus` and :attr:`focus_position` instead.
+            This API will be removed in version 5.0.
         """
         warnings.warn(
             "only for backwards compatibility."
@@ -718,6 +720,13 @@ class ListBox(Widget, WidgetContainerMixin[_K]):
                 return f"<{inner_self.__class__.__name__} for {self!r} at 0x{id(inner_self):X}>"
 
             def __call__(inner_self) -> Self:
+                """
+                Return the contents object itself.
+
+                .. deprecated:: 2.4.3
+                    :attr:`ListBox.contents` is a property, not a method: use it without calling it.
+                    This API will be removed in version 5.0.
+                """
                 warnings.warn(
                     "ListBox.contents is a property, not a method. Call API will be removed in version 5.0.",
                     DeprecationWarning,

--- a/urwid/widget/monitored_list.py
+++ b/urwid/widget/monitored_list.py
@@ -228,9 +228,8 @@ class MonitoredFocusList(MonitoredList[_T], typing.Generic[_T]):
     @focus.setter
     def focus(self, index: int) -> None:
         """
-        index -- index into this list, any index out of range will
-            raise an IndexError, except when the list is empty and
-            the index passed is ignored.
+        :param index: index into this list, any index out of range will raise an IndexError, except when the list is
+            empty and the index passed is ignored.
 
         This function may call self._focus_changed when the focus
         is modified, passing the new focus position to the
@@ -267,11 +266,9 @@ class MonitoredFocusList(MonitoredList[_T], typing.Generic[_T]):
 
     def set_focus_changed_callback(self, callback: Callable[[int], typing.Any]) -> None:
         """
-        Assign a callback to be called when the focus index changes
-        for any reason.  The callback is in the form:
+        Assign a callback to be called when the focus index changes for any reason.
 
-        callback(new_focus)
-        new_focus -- new focus index
+        :param callback: a callable in the form ``callback(new_focus)``, where ``new_focus`` is the new focus index.
 
         >>> import sys
         >>> ml = MonitoredFocusList([1, 2, 3], focus=1)
@@ -313,14 +310,10 @@ class MonitoredFocusList(MonitoredList[_T], typing.Generic[_T]):
         It may also return an integer position to be the new focus after the
         list is modified, or None to use the default behaviour.
 
-        The callback is in the form:
-
-        callback(indices, new_items)
-        indices -- a (start, stop, step) tuple whose range covers the
-            items being modified
-        new_items -- an iterable of items replacing those at range(*indices),
-            empty if items are being removed, if step==1 this list may
-            contain any number of items
+        :param callback: a callable in the form ``callback(indices, new_items)``, where ``indices`` is a
+            ``(start, stop, step)`` tuple whose range covers the items being modified, and ``new_items`` is an
+            iterable of items replacing those at ``range(*indices)`` - empty if items are being removed, and, if
+            ``step == 1``, of any length.
         """
         self._validate_contents_modified_callback = callback
 

--- a/urwid/widget/overlay.py
+++ b/urwid/widget/overlay.py
@@ -149,6 +149,7 @@ class Overlay(
             (``'relative'``, *percentage* 0=left 100=right)
         :type align: Literal["left", "center", "right"] | tuple[Literal["relative"], int]
         :param width: width type, one of:
+
             ``'pack'``
               if *top_w* is a fixed widget
             *given width*
@@ -160,6 +161,7 @@ class Overlay(
             (``'relative'``, *percentage* 0=top 100=bottom)
         :type valign: Literal["top", "middle", "bottom"] | tuple[Literal["relative"], int]
         :param height: one of:
+
             ``'pack'``
               if *top_w* is a flow or fixed widget
             *given height*
@@ -628,7 +630,7 @@ class Overlay(
         """
         Set the widget in focus.  Currently only position 1 is accepted.
 
-        position -- index of child widget to be made focus
+        :param position: index of child widget to be made focus
         """
         if position != 1:
             raise IndexError(f"Overlay widget focus_position currently must always be set to 1, not {position}")

--- a/urwid/widget/padding.py
+++ b/urwid/widget/padding.py
@@ -566,13 +566,13 @@ def calculate_left_right_padding(
     Return the amount of padding (or clipping) on the left and
     right part of maxcol columns to satisfy the following:
 
-    align_type -- 'left', 'center', 'right', 'relative'
-    align_amount -- a percentage when align_type=='relative'
-    width_type -- 'fixed', 'relative', 'clip'
-    width_amount -- a percentage when width_type=='relative' otherwise equal to the width of the widget
-    min_width -- a desired minimum width for the widget or None
-    left -- a fixed number of columns to pad on the left
-    right -- a fixed number of columns to pad on the right
+    :param align_type: 'left', 'center', 'right', 'relative'
+    :param align_amount: a percentage when align_type=='relative'
+    :param width_type: 'fixed', 'relative', 'clip'
+    :param width_amount: a percentage when width_type=='relative' otherwise equal to the width of the widget
+    :param min_width: a desired minimum width for the widget or None
+    :param left: a fixed number of columns to pad on the left
+    :param right: a fixed number of columns to pad on the right
 
     >>> clrp = calculate_left_right_padding
     >>> clrp(15, "left", 0, "given", 10, None, 2, 0)

--- a/urwid/widget/pile.py
+++ b/urwid/widget/pile.py
@@ -378,10 +378,11 @@ class Pile(
     @property
     def widget_list(self) -> MonitoredList[AbstractWidget]:
         """
-        A list of the widgets in this Pile
+        A list of the widgets in this Pile.
 
-        .. note:: only for backwards compatibility. You should use the new
-            standard container property :attr:`contents`.
+        .. deprecated:: 1.1.0
+            Use the standard container property :attr:`contents` instead.
+            This API will be removed in version 5.0.
         """
         warnings.warn(
             "only for backwards compatibility. You should use the new standard container property `contents`."
@@ -422,8 +423,9 @@ class Pile(
         """
         A list of the options values for widgets in this Pile.
 
-        .. note:: only for backwards compatibility. You should use the new
-            standard container property :attr:`contents`.
+        .. deprecated:: 1.1.0
+            Use the standard container property :attr:`contents` instead.
+            This API will be removed in version 5.0.
         """
         warnings.warn(
             "only for backwards compatibility. You should use the new standard container property `contents`."
@@ -458,6 +460,13 @@ class Pile(
             | tuple[Literal[WHSettings.WEIGHT], int | float]
         ],
     ) -> None:
+        """
+        Replace the height settings of the widgets in this Pile.
+
+        .. deprecated:: 1.1.0
+            Use the standard container property :attr:`contents` instead.
+            This API will be removed in version 5.0.
+        """
         warnings.warn(
             "only for backwards compatibility. You should use the new standard container property `contents`."
             "API will be removed in version 5.0.",
@@ -599,9 +608,11 @@ class Pile(
 
     def get_focus(self) -> AbstractWidget | None:
         """
-        Return the widget in focus, for backwards compatibility.  You may
-        also use the new standard container property .focus to get the
-        child widget in focus.
+        Return the widget in focus.
+
+        .. deprecated:: 1.1.0
+            Use the standard container property :attr:`focus` instead.
+            This API will be removed in version 5.0.
         """
         warnings.warn(
             "for backwards compatibility."
@@ -615,6 +626,15 @@ class Pile(
         return self.contents[self.focus_position][0]
 
     def set_focus(self, item: AbstractWidget | int) -> None:
+        """
+        Set the child widget in focus.
+
+        :param item: widget or integer index
+
+        .. deprecated:: 1.1.0
+            Use the standard container property :attr:`focus_position` instead.
+            This API will be removed in version 5.0.
+        """
         warnings.warn(
             "for backwards compatibility."
             "You may also use the new standard container property .focus to get the child widget in focus."
@@ -647,7 +667,7 @@ class Pile(
         """
         Set the widget in focus.
 
-        position -- index of child widget to be made focus
+        :param position: index of child widget to be made focus
         """
         try:
             if position < 0 or position >= len(self.contents):

--- a/urwid/widget/progress_bar.py
+++ b/urwid/widget/progress_bar.py
@@ -75,7 +75,7 @@ class ProgressBar(Widget):
 
     def set_completion(self, current: int) -> None:
         """
-        current -- current progress
+        :param current: current progress
         """
         self._current = current
         self._invalidate()
@@ -89,7 +89,7 @@ class ProgressBar(Widget):
     @done.setter
     def done(self, done: int) -> None:
         """
-        done -- progress amount at 100%
+        :param done: progress amount at 100%
         """
         self._done = done
         self._invalidate()

--- a/urwid/widget/widget.py
+++ b/urwid/widget/widget.py
@@ -115,8 +115,11 @@ class AbstractWidget(typing.Protocol):
     In this case `isinstance` will fail to compare with :class:`Widget`,
     but if all required interfaces present - we can use it as valid widget implementation.
 
-    .. note: sizing specific arguments left `typing.Any` to prevent static type checking errors.
-    .. note: focus_position is not listed since it's raising `IndexError` on attribute access check
+    .. note::
+        Sizing specific arguments are left as `typing.Any` to prevent static type checking errors.
+
+    .. note::
+        `focus_position` is not listed, since it raises `IndexError` on an attribute access check.
     """
 
     # Base widget methods (from Widget)
@@ -537,17 +540,16 @@ class Widget(AbstractWidget, metaclass=WidgetMeta):
 
     def selectable(self) -> bool:
         """
-        :returns: ``True`` if this is a widget that is designed to take the
-                  focus, i.e. it contains something the user might want to
-                  interact with, ``False`` otherwise,
+        Return whether this widget is designed to take the focus.
 
-        This default implementation returns :attr:`._selectable`.
-        Subclasses may leave these is if the are not selectable,
-        or if they are always selectable they may
-        set the :attr:`_selectable` class variable to ``True``.
+        :returns: ``True`` if this widget contains something the user might want to interact with,
+            ``False`` otherwise.
 
-        If this method returns ``True`` then the :meth:`.keypress` method
-        must be implemented.
+        This default implementation returns :attr:`_selectable`.
+        Subclasses may leave it as is if they are not selectable, or,
+        if they are always selectable, set the :attr:`_selectable` class variable to ``True``.
+
+        If this method returns ``True`` then the :meth:`Widget.keypress` method must be implemented.
 
         Returning ``False`` does not guarantee that this widget will never be in
         focus, only that this widget will usually be skipped over when changing
@@ -878,7 +880,7 @@ class WidgetWrap(
 ):
     def __init__(self, w: WrappedWidget) -> None:
         """
-        w -- widget to wrap, stored as self._w
+        :param w: widget to wrap, stored as self._w
 
         This object will pass the functions defined in Widget interface
         definition to self._w.
@@ -927,8 +929,12 @@ class WidgetWrap(
 
     def _set_w(self, w: WrappedWidget) -> None:
         """
-        Change the wrapped widget.  This is meant to be called
-        only by subclasses.
+        Change the wrapped widget.  This is meant to be called only by subclasses.
+
+        .. deprecated:: 2.2.0
+            Assign to the :attr:`WidgetWrap._w` property directly instead.
+            This API will be removed in version 5.0.
+
         >>> from urwid import Edit, Text
         >>> size = (10,)
         >>> ww = WidgetWrap(Edit("hello? ", "hi"))

--- a/urwid/widget/widget_decoration.py
+++ b/urwid/widget/widget_decoration.py
@@ -27,22 +27,22 @@ WrappedWidget = typing.TypeVar("WrappedWidget", bound="AbstractWidget")
 
 class WidgetDecoration(Widget, typing.Generic[WrappedWidget]):  # pylint: disable=abstract-method
     """
-    original_widget -- the widget being decorated
+    Base class for decoration widgets: widgets that contain one or more widgets and only ever have a single focus.
 
-    This is a base class for decoration widgets,
-    widgets that contain one or more widgets and only ever have a single focus.
     This type of widget will affect the display or behaviour of the original_widget,
     but it is not part of determining a chain of focus.
 
-    Don't actually do this -- use a WidgetDecoration subclass instead, these are not real widgets:
+    :param original_widget: the widget being decorated
+
+    Don't actually do this - use a WidgetDecoration subclass instead, these are not real widgets:
 
     >>> from urwid import Text
     >>> WidgetDecoration(Text("hi"))
     <WidgetDecoration fixed/flow widget <Text fixed/flow widget 'hi'>>
 
-    .. Warning:
-        WidgetDecoration do not implement ``render`` method.
-        Implement it or forward to the widget in the subclass.
+    .. warning::
+        WidgetDecoration does not implement the ``render`` method.
+        Implement it, or forward to the wrapped widget, in the subclass.
     """
 
     def __init__(self, original_widget: WrappedWidget) -> None:

--- a/urwid/widget/wimp.py
+++ b/urwid/widget/wimp.py
@@ -309,8 +309,8 @@ class CheckBox(WidgetWrap[Columns]):
         """
         Change the check box label.
 
-        label -- markup for label.  See Text widget for description
-        of text markup.
+        :param label: markup for label.  See Text widget for description
+            of text markup.
 
         >>> cb = CheckBox("foo")
         >>> cb
@@ -348,8 +348,8 @@ class CheckBox(WidgetWrap[Columns]):
         """
         Set the CheckBox state.
 
-        state -- True, False or "mixed"
-        do_callback -- False to suppress signal from this change
+        :param state: True, False or "mixed"
+        :param do_callback: False to suppress signal from this change
 
         >>> from urwid import disconnect_signal
         >>> changes = []
@@ -555,9 +555,9 @@ class RadioButton(CheckBox):
         """
         Set the RadioButton state.
 
-        state -- True, False or "mixed"
+        :param state: True, False or "mixed"
 
-        do_callback -- False to suppress signal from this change
+        :param do_callback: False to suppress signal from this change
 
         If state is True all other radio buttons in the same button
         group will be set to False.
@@ -738,7 +738,7 @@ class Button(WidgetWrap[Columns]):
         """
         Change the button label.
 
-        label -- markup for button label
+        :param label: markup for button label
 
         >>> b = Button("Ok")
         >>> b.set_label("Yup yup")


### PR DESCRIPTION
* Parameters/returns/raises declarations.
* Deprecation declarations, information extracted to provide actual information.
* Notes blocks instead of simple inline.

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
