### PR TITLE
docs: add terminal bell example for issue #203

### DIFF
--- a/docs/examples/bell.py
+++ b/docs/examples/bell.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+"""
+Urwid example: Terminal Bell (Beep)
+Demonstrates how to trigger a terminal bell sound using the ASCII BEL character.
+"""
+
+import urwid
+
+def exit_on_q(key):
+    """Press 'q' to exit the program."""
+    if key in ('q', 'Q'):
+        raise urwid.ExitMainLoop()
+
+def make_beep(key):
+    """
+    Trigger a terminal bell.
+    In many terminals, printing '\a' triggers the system bell or visual bell.
+    """
+    # urwid.Text widget content update is not enough to trigger sound usually,
+    # we need to write to stdout or use the terminal's capability.
+    # However, in a raw terminal mode managed by urwid, simply printing 
+    # might be intercepted. 
+    
+    # The most reliable way in a curses/raw terminal environment is often
+    # writing directly to the file descriptor or relying on the terminal 
+    # to interpret the output stream.
+    
+    # For this simple example, we will try to print to stdout. 
+    # Note: Depending on how urwid manages stdout, this might need 
+    # specific handling, but let's try the standard approach first.
+    
+    # Actually, writing to sys.stdout inside the main loop might mess up urwid's screen.
+    # A safer way for a "demo" that doesn't break the screen is using 
+    # os.write(1, b'\a') which writes directly to fd 1 (stdout).
+    import os
+    os.write(1, b'\a') 
+
+def main():
+    # Create a simple text widget
+    txt = urwid.Text(
+        "Press [B] to ring the terminal bell.\n"
+        "Press [Q] to quit.",
+        align='center'
+    )
+    
+    # Wrap it in a Pile or just use it directly with padding
+    fill = urwid.Filler(txt, 'middle')
+    
+    # Setup input handling
+    def input_handler(key):
+        if key == 'b':
+            make_beep(key)
+            txt.set_text("Bell rang! (Did you hear it?)\nPress [B] again or [Q] to quit.")
+        elif key == 'q':
+            raise urwid.ExitMainLoop()
+            
+    loop = urwid.MainLoop(fill, unhandled_input=input_handler)
+    loop.run()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
#### Checklist

- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch (or `main`)
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

#### Description:

This PR adds a new example script `docs/examples/bell.py` to demonstrate how to trigger a terminal bell (beep sound) using Urwid.

**Key changes:**
- Added `bell.py` which creates a simple interface to trigger the ASCII BEL character (`\a`).
- This addresses Issue #203 regarding the request for a minimal usage recipe for terminal hints/beeps.

**How to test:**
1. Run `python docs/examples/bell.py`
2. Press the button or key binding to trigger the beep.
3. Ensure your terminal emulator has "Audible Bell" or "Visual Bell" enabled to perceive the effect.