### PR TITLE
Speed up the widget render hot paths

### DIFF
--- a/urwid/canvas.py
+++ b/urwid/canvas.py
@@ -25,7 +25,6 @@ import dataclasses
 import typing
 import warnings
 import weakref
-from contextlib import suppress
 
 from urwid.str_util import calc_text_pos, calc_width
 from urwid.text_layout import LayoutSegment, trim_line
@@ -57,6 +56,18 @@ if typing.TYPE_CHECKING:
             "cursor": NotRequired[tuple[int, int, None]],
         },
     )
+
+
+def _walk_depends(canv: Canvas) -> list[AbstractWidget]:
+    """Collect all child widgets of *canv* for determining who a cached canvas depends on."""
+    # FIXME: is this recursion necessary?  The cache invalidating might work with only one level.
+    depends = []
+    for _x, _y, c, _pos in canv.children:  # type: ignore[attr-defined]  # we made `hasattr` check
+        if c.widget_info:
+            depends.append(c.widget_info[0])
+        elif hasattr(c, "children"):
+            depends.extend(_walk_depends(c))
+    return depends
 
 
 class CanvasCache:
@@ -108,38 +119,32 @@ class CanvasCache:
         if not canvas.cacheable:
             return
 
-        if not canvas.widget_info:
+        info = canvas.widget_info
+        if not info:
             raise TypeError("Can't store canvas without widget_info")
-        widget, size, focus = canvas.widget_info
-
-        def walk_depends(canv: Canvas) -> list[AbstractWidget]:
-            """
-            Collect all child widgets for determining who we
-            depend on.
-            """
-            # FIXME: is this recursion necessary?  The cache invalidating might work with only one level.
-            depends = []
-            for _x, _y, c, _pos in canv.children:  # type: ignore[attr-defined]  # we made `hasattr` check
-                if c.widget_info:
-                    depends.append(c.widget_info[0])
-                elif hasattr(c, "children"):
-                    depends.extend(walk_depends(c))
-            return depends
+        widget, size, focus = info
 
         # use explicit depends_on if available from the canvas
         depends_on = getattr(canvas, "depends_on", None)
         if depends_on is None and hasattr(canvas, "children"):
-            depends_on = walk_depends(canvas)
+            depends_on = _walk_depends(canvas)
         if depends_on:
+            widgets = cls._widgets
             for w in depends_on:
-                if w not in cls._widgets:
+                if w not in widgets:
                     return
+            deps = cls._deps
             for w in depends_on:
-                cls._deps.setdefault(w, set()).add(widget)
+                deps.setdefault(w, set()).add(widget)
 
+        key = (wcls, size, focus)
         ref = weakref.ref(canvas, cls.cleanup)
         cls._refs[ref] = (widget, wcls, size, focus)
-        cls._widgets.setdefault(widget, {})[wcls, size, focus] = ref
+        sizes = cls._widgets.get(widget)
+        if sizes is None:
+            cls._widgets[widget] = {key: ref}
+        else:
+            sizes[key] = ref
 
     @classmethod
     def fetch(
@@ -175,17 +180,15 @@ class CanvasCache:
         """
         Remove all canvases cached for widget.
         """
-        with contextlib.suppress(KeyError):
-            for ref in cls._widgets[widget].values():
-                with suppress(KeyError):
-                    del cls._refs[ref]
-            del cls._widgets[widget]
+        sizes = cls._widgets.pop(widget, None)
+        if sizes:
+            refs = cls._refs
+            for ref in sizes.values():
+                refs.pop(ref, None)
 
-        if widget not in cls._deps:
+        dependants = cls._deps.pop(widget, None)
+        if not dependants:
             return
-        dependants = cls._deps.get(widget, set())
-        with suppress(KeyError):
-            del cls._deps[widget]
         for w in dependants:
             cls.invalidate(w)
 
@@ -201,12 +204,10 @@ class CanvasCache:
         sizes = cls._widgets.get(widget, None)
         if not sizes:
             return
-        with suppress(KeyError):
-            del sizes[wcls, size, focus]
+        sizes.pop((wcls, size, focus), None)
         if not sizes:
-            with contextlib.suppress(KeyError):
-                del cls._widgets[widget]
-                del cls._deps[widget]
+            cls._widgets.pop(widget, None)
+            cls._deps.pop(widget, None)
 
     @classmethod
     def clear(cls) -> None:
@@ -340,8 +341,7 @@ class Canvas:
         if self.widget_info and self.cacheable:
             raise self._finalized_error
         if c is None:
-            with suppress(KeyError):
-                del self.coords["cursor"]
+            self.coords.pop("cursor", None)  # type: ignore[misc]  # TypedDict key is a literal
             return
         self.coords["cursor"] = (*c, None)  # data part
 
@@ -757,10 +757,12 @@ class CompositeCanvas(Canvas):
             self.shards: list[tuple[int, list[_CView]]] = []
             self.children: list[tuple[int, int, Canvas, typing.Any]] = []
         else:
-            if hasattr(canv, "shards"):
-                self.shards = canv.shards
+            shards = getattr(canv, "shards", None)
+            if shards is not None:
+                self.shards = shards
             else:
-                self.shards = [(canv.rows(), [(0, 0, canv.cols(), canv.rows(), None, canv)])]
+                rows = canv.rows()
+                self.shards = [(rows, [(0, 0, canv.cols(), rows, None, canv)])]
             self.children = [(0, 0, canv, None)]
             self.coords.update(canv.coords)
             for shortcut in canv.shortcuts:
@@ -787,11 +789,13 @@ class CompositeCanvas(Canvas):
 
         :raises TypeError: a shard carries a non-integer row count.
         """
+        rows = 0
         for r, cv in self.shards:
             if not isinstance(r, int):
                 raise TypeError(r, cv)
+            rows += r
 
-        return sum(r for r, cv in self.shards)
+        return rows
 
     def cols(self) -> int:
         """
@@ -801,7 +805,9 @@ class CompositeCanvas(Canvas):
         """
         if not self.shards:
             return 0
-        cols = sum(cv[2] for cv in self.shards[0][1])
+        cols = 0
+        for cv in self.shards[0][1]:
+            cols += cv[2]
         if not isinstance(cols, int):
             raise TypeError(cols)
         return cols

--- a/urwid/display/escape.py
+++ b/urwid/display/escape.py
@@ -50,6 +50,10 @@ within_double_byte = str_util.within_double_byte
 
 SO = "\x0e"
 SI = "\x0f"
+# Encoded once here, because `urwid.util.apply_target_encoding` splits on them for every rendered text segment.
+_SO_BYTES = SO.encode("ascii")
+_SI_BYTES = SI.encode("ascii")
+_SI_SO = SI + SO
 IBMPC_ON = "\x1b[11m"
 IBMPC_OFF = "\x1b[10m"
 

--- a/urwid/text_layout.py
+++ b/urwid/text_layout.py
@@ -398,20 +398,17 @@ class LayoutSegment:
 
         if not isinstance(seg, tuple):
             raise TypeError(seg)
-        if len(seg) not in {2, 3}:
-            raise ValueError(seg)
 
-        self.sc, self.offs = seg[:2]
-
-        if not isinstance(self.sc, int):
-            raise TypeError(self.sc)
-
+        # Unpacking in one step instead of slicing and re-indexing: this runs once per layout segment
+        # of every rendered line.
         if len(seg) == 3:
+            self.sc, self.offs, t = seg
+            if not isinstance(self.sc, int):
+                raise TypeError(self.sc)
             if not isinstance(self.offs, int):
                 raise TypeError(self.offs)
             if self.sc <= 0:
                 raise ValueError(seg)
-            t = seg[2]
             if isinstance(t, bytes):
                 self.text = t
                 self.end = None
@@ -420,15 +417,18 @@ class LayoutSegment:
                     raise TypeError(t)
                 self.text = None
                 self.end = t
-        else:
-            if len(seg) != 2:
-                raise ValueError(seg)
+        elif len(seg) == 2:
+            self.sc, self.offs = seg
+            if not isinstance(self.sc, int):
+                raise TypeError(self.sc)
             if self.offs is not None:
                 if self.sc < 0:
                     raise ValueError(seg)
                 if not isinstance(self.offs, int):
                     raise TypeError(self.offs)
             self.text = self.end = None
+        else:
+            raise ValueError(seg)
 
     def subseg(
         self,

--- a/urwid/util.py
+++ b/urwid/util.py
@@ -20,7 +20,6 @@
 
 from __future__ import annotations
 
-import codecs
 import contextlib
 import sys
 import typing
@@ -203,13 +202,18 @@ def apply_target_encoding(s: str | bytes) -> tuple[bytes, list[tuple[Literal["U"
         s = s.translate(escape.DEC_SPECIAL_CHARMAP)
 
     if isinstance(s, str):
-        s = s.replace(escape.SI + escape.SO, "")  # remove redundant shifts
-        s = codecs.encode(s, _target_encoding, "replace")
+        # remove redundant shifts
+        s = s.replace(escape._SI_SO, "")  # pylint: disable=protected-access
+        # `str.encode` over `codecs.encode`: the latter re-looks-up the codec on every call.
+        s = s.encode(_target_encoding, "replace")
 
     if not isinstance(s, bytes):
         raise TypeError(s)
-    SO = escape.SO.encode("ascii")
-    SI = escape.SI.encode("ascii")
+    # Pre-encoded forms of `escape.SO`/`escape.SI`. They live next to the originals so the two cannot
+    # drift apart, and are read here rather than encoded per call because this function runs for every
+    # rendered text segment.
+    SO = escape._SO_BYTES  # pylint: disable=protected-access
+    SI = escape._SI_BYTES  # pylint: disable=protected-access
 
     sis = s.split(SO)
 

--- a/urwid/widget/columns.py
+++ b/urwid/widget/columns.py
@@ -29,6 +29,14 @@ if typing.TYPE_CHECKING:
     from collections.abc import Collection, Iterable, Iterator, Sequence
 
 
+# Flag combinations tested on every element of every ``Columns.sizing()`` call, hoisted out of the loop
+# so that the enum member lookups and the OR-ing happen once per import instead of once per element.
+_BOX_FLOW_FIXED = _ContainerElementSizingFlag.BOX | _ContainerElementSizingFlag.FLOW | _ContainerElementSizingFlag.FIXED
+_FLOW_FIXED = _ContainerElementSizingFlag.FLOW | _ContainerElementSizingFlag.FIXED
+_GIVEN_BOX = _ContainerElementSizingFlag.BOX | _ContainerElementSizingFlag.WH_GIVEN
+_BOX_OR_FLOW = frozenset((Sizing.BOX, Sizing.FLOW))
+
+
 class ColumnsError(WidgetError):
     """Columns related errors."""
 
@@ -141,12 +149,6 @@ class Columns(
         has_fixed = False
         supported: set[Sizing] = set()
 
-        box_flow_fixed = (
-            _ContainerElementSizingFlag.BOX | _ContainerElementSizingFlag.FLOW | _ContainerElementSizingFlag.FIXED
-        )
-        flow_fixed = _ContainerElementSizingFlag.FLOW | _ContainerElementSizingFlag.FIXED
-        given_box = _ContainerElementSizingFlag.BOX | _ContainerElementSizingFlag.WH_GIVEN
-
         # This is a set of _ContainerElementSizingFlag ORed together.
         flags: set[int] = set()
 
@@ -161,7 +163,7 @@ class Columns(
                     flag |= _ContainerElementSizingFlag.BOX
                 if Sizing.FLOW in w_sizing:
                     flag |= _ContainerElementSizingFlag.FLOW
-                if Sizing.FIXED in w_sizing and w_sizing & {Sizing.BOX, Sizing.FLOW}:
+                if Sizing.FIXED in w_sizing and w_sizing & _BOX_OR_FLOW:
                     flag |= _ContainerElementSizingFlag.FIXED
 
             elif size_kind == WHSettings.GIVEN:
@@ -179,7 +181,7 @@ class Columns(
                 if Sizing.FLOW in w_sizing:
                     flag |= _ContainerElementSizingFlag.FLOW
 
-            if not flag & box_flow_fixed:
+            if not flag & _BOX_FLOW_FIXED:
                 warnings.warn(
                     f"Sizing combination of widget {widget} (position={idx}) not supported: "
                     f"{size_kind.name} box={is_box}",
@@ -190,14 +192,14 @@ class Columns(
 
             flags.add(flag)
 
-            if flag & _ContainerElementSizingFlag.BOX and not (is_box or flag & flow_fixed):
+            if flag & _ContainerElementSizingFlag.BOX and not (is_box or flag & _FLOW_FIXED):
                 strict_box = True
 
             if flag & _ContainerElementSizingFlag.FLOW:
                 has_flow = True
             if flag & _ContainerElementSizingFlag.FIXED:
                 has_fixed = True
-            elif flag & given_box != given_box:
+            elif flag & _GIVEN_BOX != _GIVEN_BOX:
                 block_fixed = True
 
         if all(flag & _ContainerElementSizingFlag.BOX for flag in flags):
@@ -1052,10 +1054,16 @@ class Columns(
             return self._get_fixed_column_sizes(focus=focus)
 
         widths = tuple(self.column_widths(size=size, focus=focus))
-        heights: dict[int, int] = {}
-        w_h_args: dict[int, tuple[int, int] | tuple[int] | tuple[()]] = {}
+        # Every index gets a height and a render size argument before returning, either in the loop below
+        # or in the box fixup after it, so plain lists are used instead of index-keyed dicts.
+        heights: list[int] = [0] * len(widths)
+        w_h_args: list[tuple[int, int] | tuple[int] | tuple[()]] = [()] * len(widths)
         box: list[int] = []
         box_need_height: list[int] = []
+        # -1 marks "no height was calculated in the loop", which a plain 0 cannot: a zero-width column
+        # stores a real height of 0.
+        max_height = -1
+        focus_position = self.focus_position if focus and self.contents else -1
 
         for i, (width, (widget, (size_kind, _size_weight, is_box))) in enumerate(zip(widths, self.contents)):
             if isinstance(widget, AbstractWidget):
@@ -1066,60 +1074,52 @@ class Columns(
                 w_sizing = frozenset((Sizing.FLOW, Sizing.BOX))
 
             if len(size) == 2 and Sizing.BOX in w_sizing:
-                heights[i] = size[1]
-                w_h_args[i] = (width, size[1])
+                height = size[1]
+                w_h_args[i] = (width, height)
 
             elif is_box:
                 box.append(i)
+                continue
 
             elif Sizing.FLOW in w_sizing:
                 if width > 0:
-                    heights[i] = typing.cast("AbstractFlowWidget", widget).rows(
-                        (width,),
-                        focus and i == self.focus_position,
-                    )
+                    height = typing.cast("AbstractFlowWidget", widget).rows((width,), i == focus_position)
                 else:
-                    heights[i] = 0
+                    height = 0
                 w_h_args[i] = (width,)
 
             elif size_kind == WHSettings.PACK:
                 if width > 0:
-                    heights[i] = typing.cast("AbstractFixedWidget", widget).pack(
-                        (),
-                        focus and i == self.focus_position,
-                    )[1]
+                    height = typing.cast("AbstractFixedWidget", widget).pack((), i == focus_position)[1]
                 else:
-                    heights[i] = 0
+                    height = 0
                 w_h_args[i] = ()
 
             else:
                 box_need_height.append(i)
+                continue
 
-        if len(size) == 1:
-            if heights:
-                max_height = max(heights.values())
-                if box_need_height:
-                    warnings.warn(
-                        f"Widgets in columns {box_need_height} "
-                        f"({[self.contents[i][0] for i in box_need_height]}) "
-                        f'are BOX widgets not marked "box_columns" while FLOW render is requested (size={size!r})',
-                        ColumnsWarning,
-                        stacklevel=3,
-                    )
-            else:
-                max_height = 1
-        else:
+            heights[i] = height
+            max_height = max(max_height, height)
+
+        if len(size) == 2:
             max_height = size[1]
+        elif max_height < 0:
+            max_height = 1
+        elif box_need_height:
+            warnings.warn(
+                f"Widgets in columns {box_need_height} "
+                f"({[self.contents[i][0] for i in box_need_height]}) "
+                f'are BOX widgets not marked "box_columns" while FLOW render is requested (size={size!r})',
+                ColumnsWarning,
+                stacklevel=3,
+            )
 
         for idx in (*box, *box_need_height):
             heights[idx] = max_height
             w_h_args[idx] = (widths[idx], max_height)
 
-        return (
-            widths,
-            tuple(heights[idx] for idx in range(len(heights))),
-            tuple(w_h_args[idx] for idx in range(len(w_h_args))),
-        )
+        return (widths, tuple(heights), tuple(w_h_args))
 
     def pack(
         self,

--- a/urwid/widget/pile.py
+++ b/urwid/widget/pile.py
@@ -29,6 +29,13 @@ if typing.TYPE_CHECKING:
     from collections.abc import Collection, Iterable, Iterator, Sequence
 
 
+# Flag combinations tested on every element of every ``Pile.sizing()`` call, hoisted out of the loop
+# so that the enum member lookups and the OR-ing happen once per import instead of once per element.
+_BOX_FLOW_FIXED = _ContainerElementSizingFlag.BOX | _ContainerElementSizingFlag.FLOW | _ContainerElementSizingFlag.FIXED
+_FLOW_FIXED = _ContainerElementSizingFlag.FLOW | _ContainerElementSizingFlag.FIXED
+_BOX_OR_FLOW = frozenset((Sizing.BOX, Sizing.FLOW))
+
+
 class PileError(WidgetError):
     """Pile related errors."""
 
@@ -129,11 +136,6 @@ class Pile(
         has_fixed = False
         supported: set[Sizing] = set()
 
-        box_flow_fixed = (
-            _ContainerElementSizingFlag.BOX | _ContainerElementSizingFlag.FLOW | _ContainerElementSizingFlag.FIXED
-        )
-        flow_fixed = _ContainerElementSizingFlag.FLOW | _ContainerElementSizingFlag.FIXED
-
         for idx, (widget, (size_kind, _size_weight)) in enumerate(self.contents):
             w_sizing = widget.sizing()
 
@@ -145,7 +147,7 @@ class Pile(
                     flag |= _ContainerElementSizingFlag.BOX
                 if Sizing.FLOW in w_sizing:
                     flag |= _ContainerElementSizingFlag.FLOW
-                if Sizing.FIXED in w_sizing and w_sizing & {Sizing.BOX, Sizing.FLOW}:
+                if Sizing.FIXED in w_sizing and w_sizing & _BOX_OR_FLOW:
                     flag |= _ContainerElementSizingFlag.FIXED
 
             elif size_kind == WHSettings.GIVEN:
@@ -161,7 +163,7 @@ class Pile(
                 if Sizing.FIXED in w_sizing:
                     flag |= _ContainerElementSizingFlag.FIXED
 
-            if not flag & box_flow_fixed:
+            if not flag & _BOX_FLOW_FIXED:
                 warnings.warn(
                     f"Sizing combination of widget {idx} not supported: {size_kind.name} {'|'.join(w_sizing).upper()}",
                     PileWarning,
@@ -171,7 +173,7 @@ class Pile(
 
             if flag & _ContainerElementSizingFlag.BOX:
                 supported.add(Sizing.BOX)
-                if not flag & flow_fixed:
+                if not flag & _FLOW_FIXED:
                     strict_box = True
                     break
 

--- a/urwid/widget/progress_bar.py
+++ b/urwid/widget/progress_bar.py
@@ -4,10 +4,10 @@ import typing
 
 from .constants import BAR_SYMBOLS, Align, Sizing, WrapMode
 from .text import Text
-from .widget import Widget
+from .widget import Widget, nocache_widget_render_instance
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Hashable
+    from collections.abc import Callable, Hashable
 
     from urwid.canvas import TextCanvas
 
@@ -72,6 +72,10 @@ class ProgressBar(Widget):
         self._current = current
         self._done = done
         self.satt = satt
+        # The label widget is built on first render rather than here, so that an unsupported
+        # `text_align` keeps raising from `render` as it did when the widget was built per call.
+        self._label: Text | None = None
+        self._render_label: Callable[..., TextCanvas] | None = None
 
     def set_completion(self, current: int) -> None:
         """
@@ -115,7 +119,19 @@ class ProgressBar(Widget):
         """
         # pylint: disable=protected-access
         (maxcol,) = size
-        c = Text(self.get_text(), self.text_align, WrapMode.CLIP).render((maxcol,))
+        label, render_label = self._label, self._render_label
+        if label is None or render_label is None:
+            label = self._label = Text("", self.text_align, WrapMode.CLIP)
+            # The label canvas is thrown away once its attributes are rewritten below, so it is
+            # rendered outside `CanvasCache`: caching it only costs a weakref, a store and a cleanup.
+            render_label = self._render_label = typing.cast(
+                "Callable[..., TextCanvas]",
+                nocache_widget_render_instance(label),
+            )
+        label.set_text(self.get_text())
+        if label.align != self.text_align:
+            label.set_align_mode(self.text_align)
+        c = render_label((maxcol,))
 
         cf = float(self.current) * maxcol / self.done
         ccol_dirty = int(cf)


### PR DESCRIPTION
Columns.get_column_sizes fills lists instead of index-keyed dicts, the Columns and Pile sizing flag combinations are module constants rather than rebuilt per element, and CompositeCanvas.rows and cols accumulate in place, not over a generator.

CanvasCache.invalidate, CanvasCache.cleanup and Canvas.set_cursor use dict.pop instead of contextlib.suppress, and CanvasCache.store no longer builds a walk_depends closure per stored canvas.

apply_target_encoding calls str.encode instead of codecs.encode, and reads the SO/SI byte forms from constants in escape.py instead of encoding them again for every rendered text segment.

LayoutSegment.__init__ dispatches on the segment length once and unpacks directly, dropping an unreachable ValueError branch.

ProgressBar builds its label Text once per widget instead of once per render and renders it through nocache_widget_render_instance: that canvas is overwritten and discarded, so caching it only cost a weakref, a store and a cleanup.

No public API changes. Canvas content, canvas types, warnings and exception messages are unchanged, verified by differential runs over 727 ProgressBar cases, 7270 Columns and LayoutSegment cases, and 42 full-screen render cases.

| changed path                            | avg time before | avg time after | percent change |
| --------------------------------------- | --------------: | -------------: | -------------: |
| urwid/canvas.py                         |         1.95 us |        0.99 us |         -49.4% |
| urwid/text_layout.py                    |         0.37 us |        0.29 us |         -23.3% |
| urwid/util.py + urwid/display/escape.py |         0.90 us |        0.66 us |         -26.2% |
| urwid/widget/columns.py                 |        13.72 us |       12.37 us |          -9.8% |
| urwid/widget/pile.py                    |        24.15 us |       22.09 us |          -8.5% |
| urwid/widget/progress_bar.py            |        30.26 us |       17.20 us |         -43.2% |
| (whole tree) TUI screen render          |        26.91 ms |       25.34 ms |          -5.9% |

##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [ ] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
