### PR TITLE
docs: clarify signal order for RadioButton (change vs postchange)

### DIFF
--- a/docs/reference/widget.rst
+++ b/docs/reference/widget.rst
@@ -63,6 +63,17 @@ RadioButton
 
 .. autoclass:: RadioButton
 
+   Signal Order
+~~~~~~~~~~~~
+
+When the state of a ``RadioButton`` changes, it emits two signals in the following order:
+
+1. ``"change"``: Emitted when the state has changed. The callback receives the new state value.
+2. ``"postchange"``: Emitted immediately after the ``"change"`` signal is fully processed.
+
+Use ``"change"`` to react to the new value (e.g., updating other widgets).
+Use ``"postchange"`` if you need to perform actions after the radio button group has fully settled.  
+
 TreeWidget
 ~~~~~~~~~~
 


### PR DESCRIPTION
#### Checklist

- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)

#### Description:

This PR addresses **Issue #289**.

It clarifies the execution order of the `change` and `postchange` signals in the `RadioButton` widget documentation. 

Based on the source code logic, the `change` signal is emitted immediately when the state is updated, while the `postchange` signal is emitted subsequently. This update ensures users understand that `change` handlers run before `postchange` handlers.