### PR TITLE
Partial fix for terminal keys handling

### DIFF
--- a/urwid/display/_posix_raw_display.py
+++ b/urwid/display/_posix_raw_display.py
@@ -85,6 +85,13 @@ class Screen(_raw_display_base.Screen):
             should chain to the previous handler (as this class does) rather than replacing it outright,
             and multithreaded applications must call `signal_init()` and `signal_restore()` from the main thread,
             since only the main thread can receive process signals.
+
+        .. note::
+            on Ctrl+S/Ctrl+Q: cbreak mode also leaves the tty's ``IXON``/``IXOFF`` flags set, so without
+            further action the line discipline treats Ctrl+S/Ctrl+Q as XOFF/XON flow control and consumes
+            them before urwid ever sees the bytes, which looks like Ctrl+S producing no key event and
+            freezing terminal output (urwid/urwid#140). `start()` clears ``IXON``/``IXOFF`` so both keys
+            reach the application as ordinary ``ctrl s``/``ctrl q`` key events instead.
         """
         super().__init__(input, output)
         self.gpm_mev: Popen[str] | None = None
@@ -247,6 +254,11 @@ class Screen(_raw_display_base.Screen):
         if fd is not None and os.isatty(fd):
             self._old_termios_settings = termios.tcgetattr(fd)
             tty.setcbreak(fd)
+            # setcbreak() does not clear IXON/IXOFF, so the tty driver still intercepts
+            # Ctrl+S/Ctrl+Q as XOFF/XON flow control before urwid ever sees them (urwid/urwid#140).
+            attrs = termios.tcgetattr(fd)
+            attrs[tty.IFLAG] &= ~(termios.IXON | termios.IXOFF)
+            termios.tcsetattr(fd, termios.TCSANOW, attrs)
 
         self.signal_init()
         self._alternate_buffer = alternate_buffer


### PR DESCRIPTION
setcbreak() leaves the tty's IXON/IXOFF flags set, so the line discipline still intercepts Ctrl+S/Ctrl+Q as XOFF/XON flow control before urwid ever sees the bytes. This makes Ctrl+S appear to produce no key event and freezes terminal output.

Clear IXON/IXOFF alongside the existing cbreak setup in start(), so both keys reach the application as ordinary ctrl s/ctrl q key events (urwid/urwid#140).

Partial #140

##### Checklist
- [X] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [x] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
