### PR TITLE
Fix: Overlay top widget or bottom widget replace should trigger invalidation

### DIFF
--- a/tests/widgets/test_overlay.py
+++ b/tests/widgets/test_overlay.py
@@ -425,6 +425,51 @@ class OverlayTest(unittest.TestCase):
             (1, 1),
         )
 
+    def test_replaced_top_w_is_rendered(self):
+        """Replacing the top widget invalidates the canvas rendered from the previous one.
+
+        Regression test: `top_w` used to be a plain attribute, so the canvas cached for the
+        overlay survived the replacement and the old widget kept being rendered until something
+        else invalidated the overlay. The first canvas is kept referenced on purpose:
+        :class:`urwid.CanvasCache` holds weak references, so a canvas dropped by the test takes
+        the stale cache entry with it and the replacement would render correctly either way.
+        """
+        ovl = urwid.Overlay(
+            urwid.SolidFill("X"),
+            urwid.SolidFill("."),
+            urwid.CENTER,
+            4,
+            urwid.MIDDLE,
+            2,
+        )
+        cached = ovl.render((8, 4))
+        self.assertEqual(("........", "..XXXX..", "..XXXX..", "........"), cached.decoded_text)
+
+        ovl.top_w = urwid.SolidFill("O")
+
+        self.assertEqual(("........", "..OOOO..", "..OOOO..", "........"), ovl.render((8, 4)).decoded_text)
+
+    def test_replaced_bottom_w_is_rendered(self):
+        """Replacing the bottom widget invalidates the canvas rendered from the previous one.
+
+        The counterpart of `test_replaced_top_w_is_rendered`, keeping the first canvas referenced
+        for the same reason.
+        """
+        ovl = urwid.Overlay(
+            urwid.SolidFill("X"),
+            urwid.SolidFill("."),
+            urwid.CENTER,
+            4,
+            urwid.MIDDLE,
+            2,
+        )
+        cached = ovl.render((8, 4))
+        self.assertEqual(("........", "..XXXX..", "..XXXX..", "........"), cached.decoded_text)
+
+        ovl.bottom_w = urwid.SolidFill(",")
+
+        self.assertEqual((",,,,,,,,", ",,XXXX,,", ",,XXXX,,", ",,,,,,,,"), ovl.render((8, 4)).decoded_text)
+
     def test_length(self):
         ovl = urwid.Overlay(
             urwid.SolidFill("X"),

--- a/urwid/widget/overlay.py
+++ b/urwid/widget/overlay.py
@@ -196,6 +196,37 @@ class Overlay(
         _check_widget_subclass(top_w)
         _check_widget_subclass(bottom_w)
 
+    @property
+    def top_w(self) -> TopWidget:
+        """Widget overlaid "on top" of `bottom_w`."""
+        return self._top_w
+
+    @top_w.setter
+    def top_w(self, widget: TopWidget) -> None:
+        """Replace the widget overlaid "on top" and invalidate the canvas rendered from the old one.
+
+        Without the invalidation :class:`CanvasCache` keeps serving the canvas of the previous
+        widget - together with every parent canvas built from it - so the replacement stays
+        invisible until something else invalidates the overlay.
+        """
+        self._top_w = widget
+        self._invalidate()
+
+    @property
+    def bottom_w(self) -> BottomWidget:
+        """Widget appearing "below" `top_w`."""
+        return self._bottom_w
+
+    @bottom_w.setter
+    def bottom_w(self, widget: BottomWidget) -> None:
+        """Replace the widget appearing "below" and invalidate the canvas rendered from the old one.
+
+        The counterpart of the `top_w` setter, and invalidating for the same reason: a plain
+        assignment would leave :class:`CanvasCache` serving the canvas of the previous widget.
+        """
+        self._bottom_w = widget
+        self._invalidate()
+
     def sizing(self) -> frozenset[Sizing]:
         """Actual widget sizing.
 


### PR DESCRIPTION


##### Checklist
- [x] I've ensured that similar functionality has not already been implemented
- [x] I've ensured that similar functionality has not earlier been proposed and declined
- [x] I've branched off the `master` branch
- [x] I've merged fresh upstream into my branch recently
- [X] I've ran `tox` successfully in local environment
- [x] I've included docstrings and/or documentation and/or examples for my code (if this is a new feature)
